### PR TITLE
Introduced MessagePredicates to decouple message format from tampering transport

### DIFF
--- a/test/acceptance/simple_transfer.go
+++ b/test/acceptance/simple_transfer.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/orbs-network/orbs-network-go/test/harness"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
+	"github.com/orbs-network/orbs-network-go/test/harness/services/gossip/adapter"
 )
 
 var _ = Describe("a leader node", func() {
@@ -33,13 +34,13 @@ var _ = Describe("a non-leader (validator) node", func() {
 		// leader is nodeIndex 0, validator is nodeIndex 1
 		network := harness.NewTestNetwork(2)
 
-		network.GossipTransport().Pause(gossipmessages.HEADER_TOPIC_TRANSACTION_RELAY, uint16(gossipmessages.TRANSACTION_RELAY_FORWARDED_TRANSACTIONS))
+		pausedTxForwards := network.GossipTransport().Pause(adapter.TransactionRelayMessage(gossipmessages.TRANSACTION_RELAY_FORWARDED_TRANSACTIONS))
 		network.SendTransfer(1, 17)
 
 		Expect(<-network.CallGetBalance(0)).To(BeEquivalentTo(0))
 		Expect(<-network.CallGetBalance(1)).To(BeEquivalentTo(0))
 
-		network.GossipTransport().Resume(gossipmessages.HEADER_TOPIC_TRANSACTION_RELAY, uint16(gossipmessages.TRANSACTION_RELAY_FORWARDED_TRANSACTIONS))
+		pausedTxForwards.Release()
 		network.BlockPersistence(0).WaitForBlocks(1)
 		Expect(<-network.CallGetBalance(0)).To(BeEquivalentTo(17))
 		network.BlockPersistence(1).WaitForBlocks(1)

--- a/test/harness/services/gossip/adapter/tampering_predicates.go
+++ b/test/harness/services/gossip/adapter/tampering_predicates.go
@@ -1,0 +1,35 @@
+package adapter
+
+import (
+	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
+	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
+)
+
+func ConsensusMessage(messageType gossipmessages.LeanHelixMessageType) MessagePredicate {
+	return func(data *adapter.TransportData) bool {
+		header, ok := parseHeader(data)
+
+		return ok && header.IsTopicLeanHelix() && header.LeanHelix() == messageType
+	}
+}
+
+func TransactionRelayMessage(messageType gossipmessages.TransactionsRelayMessageType) MessagePredicate {
+	return func(data *adapter.TransportData) bool {
+		header, ok := parseHeader(data)
+
+		return ok && header.IsTopicTransactionRelay() && header.TransactionRelay() == messageType
+	}
+}
+
+func parseHeader(data *adapter.TransportData) (*gossipmessages.Header, bool) {
+	if data == nil || len(data.Payloads) == 0 {
+		return nil, false
+	}
+
+	header := gossipmessages.HeaderReader(data.Payloads[0])
+	if !header.IsValid() {
+		return nil, false
+	}
+
+	return header, true
+}


### PR DESCRIPTION
tampering transport now uses message predicates, removing its intimare knowledge of message format