### PR TITLE
Replaced Loop Control with latch on gossip message types

### DIFF
--- a/bootstrap/node.go
+++ b/bootstrap/node.go
@@ -35,8 +35,7 @@ func NewNode(
 	blockPersistence := blockStorageAdapter.NewLevelDbBlockPersistence(nodeConfig)
 	stateStorageAdapter := stateStorageAdapter.NewLevelDbStatePersistence(nodeConfig)
 	logger := instrumentation.NewStdoutLog()
-	loopControl := instrumentation.NewSimpleLoop(logger)
-	nodeLogic := NewNodeLogic(transport, blockPersistence, stateStorageAdapter, logger, loopControl, nodeConfig, isLeader)
+	nodeLogic := NewNodeLogic(transport, blockPersistence, stateStorageAdapter, logger, nodeConfig, isLeader)
 	httpServer := httpserver.NewHttpServer(address, logger, nodeLogic.PublicApi())
 
 	return &node{

--- a/bootstrap/node_logic.go
+++ b/bootstrap/node_logic.go
@@ -35,7 +35,6 @@ func NewNodeLogic(
 	blockPersistence blockStorageAdapter.BlockPersistence,
 	statePersistence stateStorageAdapter.StatePersistence,
 	reporting instrumentation.Reporting,
-	loopControl instrumentation.LoopControl,
 	nodeConfig config.NodeConfig,
 	isLeader bool,
 ) NodeLogic {
@@ -43,13 +42,13 @@ func NewNodeLogic(
 	gossip := gossip.NewGossip(gossipTransport, nodeConfig, reporting)
 	transactionPool := transactionpool.NewTransactionPool(gossip, reporting)
 	stateStorage := statestorage.NewStateStorage(statePersistence)
-	blockStorage := blockstorage.NewBlockStorage(blockPersistence, stateStorage)
+	blockStorage := blockstorage.NewBlockStorage(blockPersistence, stateStorage, reporting)
 	nativeProcessor := native.NewNativeProcessor()
 	ethereumCrosschainConnector := ethereum.NewEthereumCrosschainConnector()
 	virtualMachine := virtualmachine.NewVirtualMachine(blockStorage, stateStorage, nativeProcessor, ethereumCrosschainConnector)
 	publicApi := publicapi.NewPublicApi(transactionPool, virtualMachine, reporting, isLeader)
 	consensusContext := consensuscontext.NewConsensusContext(transactionPool, virtualMachine, nil)
-	leanHelixConsensusAlgo := leanhelix.NewLeanHelixConsensusAlgo(gossip, blockStorage, transactionPool, consensusContext, reporting, loopControl, nodeConfig, isLeader)
+	leanHelixConsensusAlgo := leanhelix.NewLeanHelixConsensusAlgo(gossip, blockStorage, transactionPool, consensusContext, reporting, nodeConfig, isLeader)
 	return &nodeLogic{
 		publicApi: publicApi,
 		leanHelix: leanHelixConsensusAlgo,

--- a/instrumentation/reporting.go
+++ b/instrumentation/reporting.go
@@ -10,9 +10,6 @@ type Reporting interface {
 	Error(err error)
 }
 
-const FinishedConsensusRound = "finished_consensus_round"
-const ConsensusError = "consensus_error"
-
 type StdoutLog interface {
 	Reporting
 }
@@ -33,7 +30,7 @@ func (e *stdoutLog) Infof(message string, params ...interface{}) {
 }
 
 func (e *stdoutLog) Error(err error) {
-	log.Fatal(err)
+	log.Printf("Error: %s", err)
 }
 
 type compositeReporting struct {

--- a/services/blockstorage/service.go
+++ b/services/blockstorage/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"fmt"
+	"github.com/orbs-network/orbs-network-go/instrumentation"
 )
 
 const (
@@ -20,19 +21,22 @@ type service struct {
 	persistence  adapter.BlockPersistence
 	stateStorage services.StateStorage
 
-	lastCommittedBlockHeight primitives.BlockHeight
+	lastCommittedBlockHeight    primitives.BlockHeight
 	lastCommittedBlockTimestamp primitives.Timestamp
+	reporting                   instrumentation.Reporting
 }
 
-func NewBlockStorage(persistence adapter.BlockPersistence, stateStorage services.StateStorage) services.BlockStorage {
+func NewBlockStorage(persistence adapter.BlockPersistence, stateStorage services.StateStorage, reporting instrumentation.Reporting) services.BlockStorage {
 	return &service{
 		persistence:  persistence,
 		stateStorage: stateStorage,
+		reporting: reporting,
 	}
 }
 
 func (s *service) CommitBlock(input *services.CommitBlockInput) (*services.CommitBlockOutput, error) {
 	txBlockHeader := input.BlockPair.TransactionsBlock.Header
+	s.reporting.Infof("Trying to commit block of height %d", txBlockHeader.BlockHeight())
 
 	if err := s.validateProtocolVersion(txBlockHeader); err != nil {
 		return nil, err
@@ -60,6 +64,8 @@ func (s *service) CommitBlock(input *services.CommitBlockInput) (*services.Commi
 
 	// TODO: why are we updating the state? nothing about this in the spec
 	s.updateStateStorage(input.BlockPair.TransactionsBlock)
+
+	s.reporting.Infof("Committed block of height %d", txBlockHeader.BlockHeight())
 
 	return nil, nil
 }
@@ -109,10 +115,12 @@ func (s *service) validateBlockDoesNotExist(txBlockHeader *protocol.Transactions
 	if txBlockHeader.BlockHeight() <= s.lastCommittedBlockHeight {
 		if txBlockHeader.BlockHeight() == s.lastCommittedBlockHeight && txBlockHeader.Timestamp() != s.lastCommittedBlockTimestamp {
 			// TODO should this really panic
-			message := fmt.Sprintf("block with height %d already in storage, timestamp mismatch", s.lastCommittedBlockHeight)
-			println(message)
-			panic(message)
+			err := fmt.Errorf("block with height %d already in storage, timestamp mismatch", s.lastCommittedBlockHeight)
+			s.reporting.Error(err)
+			panic(err.Error())
 		}
+
+		s.reporting.Infof("block with height %d already in storage, skipping", s.lastCommittedBlockHeight)
 		return false
 	}
 
@@ -121,7 +129,9 @@ func (s *service) validateBlockDoesNotExist(txBlockHeader *protocol.Transactions
 
 func (s *service) validateProtocolVersion(txBlockHeader *protocol.TransactionsBlockHeader) error {
 	if txBlockHeader.ProtocolVersion() != ProtocolVersion {
-		return fmt.Errorf("protocol version mismatch: expected 1 got %d", txBlockHeader.ProtocolVersion())
+		err := fmt.Errorf("protocol version mismatch: expected 1 got %d", txBlockHeader.ProtocolVersion())
+		s.reporting.Error(err)
+		return err
 	}
 
 	return nil
@@ -131,9 +141,10 @@ func (s *service) validateMonotonicIncreasingBlockHeight(txBlockHeader *protocol
 	expectedNextBlockHeight := s.lastCommittedBlockHeight + 1
 	if txBlockHeader.BlockHeight() != expectedNextBlockHeight {
 		// TODO should this really panic
-		message := fmt.Sprintf("expected block of height %d but got %d", expectedNextBlockHeight, txBlockHeader.BlockHeight())
-		println(message)
-		panic(message)
+		err := fmt.Errorf("expected block of height %d but got %d", expectedNextBlockHeight, txBlockHeader.BlockHeight())
+		s.reporting.Error(err)
+		panic(err.Error())
+
 	}
 }
 

--- a/services/blockstorage/test/commit_block.go
+++ b/services/blockstorage/test/commit_block.go
@@ -12,6 +12,7 @@ import (
 	adapter2 "github.com/orbs-network/orbs-network-go/services/blockstorage/adapter"
 	"github.com/orbs-network/orbs-network-go/test"
 	"time"
+	"github.com/orbs-network/orbs-network-go/instrumentation"
 )
 
 type adapterConfig struct {
@@ -59,7 +60,7 @@ func NewDriver() *driver {
 	d := &driver{}
 	d.stateStorage = &services.MockStateStorage{}
 	d.storageAdapter = adapter.NewInMemoryBlockPersistence(&adapterConfig{})
-	d.blockStorage = blockstorage.NewBlockStorage(d.storageAdapter, d.stateStorage)
+	d.blockStorage = blockstorage.NewBlockStorage(d.storageAdapter, d.stateStorage, instrumentation.NewStdoutLog())
 
 	return d
 }

--- a/services/consensusalgo/leanhelix/service.go
+++ b/services/consensusalgo/leanhelix/service.go
@@ -7,7 +7,8 @@ import (
 	"github.com/orbs-network/orbs-spec/types/go/services"
 	"github.com/orbs-network/orbs-spec/types/go/services/gossiptopics"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
-		)
+	"time"
+)
 
 type Config interface {
 	NetworkSize(asOfBlock uint64) uint32
@@ -98,15 +99,16 @@ func (s *service) buildBlocksEventLoop() {
 		err := s.leaderProposeNextBlockIfNeeded()
 		if err != nil {
 			s.reporting.Error(err)
-			return
+			continue
 		}
 
 		// validate the current proposed block
-		if s.blocksForRounds[s.lastCommittedBlockHeight+1] != nil {
-			err := s.leaderCollectVotesForBlock(s.blocksForRounds[s.lastCommittedBlockHeight+1])
+		if s.blocksForRounds[s.lastCommittedBlockHeight + 1] != nil {
+			err := s.leaderCollectVotesForBlock(s.blocksForRounds[s.lastCommittedBlockHeight + 1])
 			if err != nil {
 				s.reporting.Error(err)
-				return
+				time.Sleep(10 * time.Millisecond) // TODO: handle network failures with some time of exponential backoff
+				continue
 			}
 
 			// commit the block since it's validated

--- a/test/harness/services/gossip/adapter/message_predicate_test.go
+++ b/test/harness/services/gossip/adapter/message_predicate_test.go
@@ -1,0 +1,83 @@
+package adapter
+
+import (
+	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
+	"github.com/orbs-network/orbs-spec/types/go/primitives"
+	"fmt"
+	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
+)
+
+func aMessageFrom(sender string) MessagePredicate {
+	return func(data *adapter.TransportData) bool {
+		return string(data.SenderPublicKey) == sender
+	}
+}
+
+func aMessageWithPayloadOver(maxSizeInBytes int) MessagePredicate {
+	return func(data *adapter.TransportData) bool {
+		size := 0
+		for _, payload := range data.Payloads {
+			size += len(payload)
+		}
+
+		return size < maxSizeInBytes
+	}
+}
+
+func ExampleMessagePredicate_Sender() {
+	pred := aMessageFrom("sender1")
+
+	printSender := func(sender string) {
+		if pred(&adapter.TransportData{SenderPublicKey: primitives.Ed25519Pkey(sender)}) {
+			fmt.Printf("got message from %s\n", sender)
+		} else {
+			fmt.Println("got message from other sender")
+		}
+	}
+
+	printSender("sender1")
+	printSender("sender3")
+	// Output: got message from sender1
+	// got message from other sender
+}
+
+func ExampleMessagePredicate_PayloadSize() {
+	pred := aMessageWithPayloadOver(100)
+
+	printMessage := func(payloads [][]byte) {
+		if pred(&adapter.TransportData{Payloads: payloads}) {
+			fmt.Println("got message smaller than 100 bytes")
+		} else {
+			fmt.Println("got message larger than 100 bytes")
+		}
+	}
+
+	printMessage([][]byte{make([]byte, 10)})
+	printMessage([][]byte{make([]byte, 1000)})
+	// Output: got message smaller than 100 bytes
+	// got message larger than 100 bytes
+}
+
+func ExampleConsensusMessage() {
+	pred := ConsensusMessage(gossipmessages.LEAN_HELIX_COMMIT)
+
+	printMessage := func(msgType gossipmessages.LeanHelixMessageType) {
+
+		header := gossipmessages.HeaderBuilder{
+			Topic: gossipmessages.HEADER_TOPIC_LEAN_HELIX,
+			LeanHelix: msgType,
+		}
+
+		if pred(&adapter.TransportData{Payloads: [][]byte{header.Build().Raw()}}) {
+			fmt.Println("got commit message")
+		} else {
+			fmt.Println("got message of unexpected type")
+		}
+	}
+
+	printMessage(gossipmessages.LEAN_HELIX_COMMIT)
+	printMessage(gossipmessages.LEAN_HELIX_PRE_PREPARE)
+	// Output: got commit message
+	// got message of unexpected type
+}
+

--- a/test/harness/services/gossip/adapter/mock_listener.go
+++ b/test/harness/services/gossip/adapter/mock_listener.go
@@ -1,0 +1,33 @@
+package adapter
+
+import (
+	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
+	"github.com/orbs-network/orbs-spec/types/go/primitives"
+	"github.com/orbs-network/go-mock"
+)
+
+type mockListener struct {
+	mock.Mock
+}
+
+func (m *mockListener) OnTransportMessageReceived(payloads [][]byte) {
+	m.Called(payloads)
+}
+
+func listenTo(transport adapter.Transport, publicKey primitives.Ed25519Pkey) *mockListener {
+	l := &mockListener{}
+	transport.RegisterListener(l, publicKey)
+	return l
+}
+
+func (m *mockListener) expectReceive(payloads [][]byte) {
+	m.WhenOnTransportMessageReceived(payloads).Return().Times(1)
+}
+
+func (m *mockListener) expectNotReceive() {
+	m.WhenOnTransportMessageReceived(mock.Any).Return().Times(0)
+}
+
+func (m *mockListener) WhenOnTransportMessageReceived(arg interface{}) *mock.MockFunction {
+	return m.When("OnTransportMessageReceived", arg)
+}

--- a/test/harness/services/gossip/adapter/tampering_transport_test.go
+++ b/test/harness/services/gossip/adapter/tampering_transport_test.go
@@ -1,0 +1,138 @@
+package adapter
+
+import (
+	"testing"
+	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
+	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
+	"github.com/orbs-network/orbs-spec/types/go/primitives"
+	"github.com/orbs-network/go-mock"
+		"sync"
+	)
+
+type context struct {
+	senderKey string
+	transport TamperingTransport
+	listener  *mockListener
+}
+
+func newContext() *context {
+	senderKey := "sender"
+	listenerKey := "listener"
+	listener := &mockListener{}
+	transport := NewTamperingTransport()
+	transport.RegisterListener(listener, primitives.Ed25519Pkey(listenerKey))
+
+	return &context{
+		senderKey: senderKey,
+		transport: transport,
+		listener: listener,
+	}
+}
+
+func (c *context) send(payloads [][]byte) {
+	c.broadcast(c.senderKey, payloads)
+}
+
+func (c *context) broadcast(sender string, payloads [][]byte) error {
+	return c.transport.Send(&adapter.TransportData{
+		RecipientMode:   gossipmessages.RECIPIENT_LIST_MODE_BROADCAST,
+		SenderPublicKey: primitives.Ed25519Pkey(sender),
+		Payloads:        payloads,
+	})
+}
+
+
+func TestFailingTamperer(t *testing.T) {
+	c := newContext()
+
+	c.transport.Fail(anyMessage())
+
+	c.send(nil)
+
+	c.listener.expectNotReceive()
+
+	c.listener.Verify()
+}
+
+func TestPausingTamperer(t *testing.T) {
+	c := newContext()
+
+	digits := make(chan byte, 10)
+
+	odds := c.transport.Pause(oddNumbers())
+
+	c.listener.WhenOnTransportMessageReceived(mock.Any).Call(func(payloads [][]byte) {
+		digits <- payloads[0][0]
+	}).Times(10)
+
+	for b := 0; b < 10; b++ {
+		c.send([][]byte{{byte(b)}})
+	}
+
+	for b := 0; b < 5; b++ {
+		if <-digits % 2 != 0 {
+			t.Errorf("got odd number while odds should be paused")
+		}
+	}
+
+	odds.Release()
+
+	for b := 0; b < 5; b++ {
+		if <-digits % 2 != 1 {
+			t.Errorf("got even number while odds should be released")
+		}
+	}
+}
+
+func TestLatchingTamperer(t *testing.T) {
+	c := newContext()
+
+	called := make(chan bool)
+
+	latch := c.transport.LatchOn(anyMessage())
+
+	c.listener.WhenOnTransportMessageReceived(mock.Any)
+
+	afterMessageArrived := sync.WaitGroup{}
+	afterMessageArrived.Add(1)
+
+	afterLatched := sync.WaitGroup{}
+	afterLatched.Add(1)
+
+	go func() {
+		afterLatched.Done()
+
+		defer func() {
+			latch.Wait()
+			afterMessageArrived.Wait()
+			called <- true
+		}()
+
+	}()
+
+	afterLatched.Wait()
+	c.send(nil)
+
+	select {
+	case <- called:
+		t.Error("called too early")
+	default:
+	}
+
+	afterMessageArrived.Done()
+
+	<- called
+}
+
+func oddNumbers() MessagePredicate {
+	return func(data *adapter.TransportData) bool {
+		return data.Payloads[0][0] % 2 == 1
+	}
+}
+
+func anyMessage() MessagePredicate {
+	return func(data *adapter.TransportData) bool {
+		return true
+	}
+}
+

--- a/test/harness/services/gossip/adapter/transport_contract_test.go
+++ b/test/harness/services/gossip/adapter/transport_contract_test.go
@@ -3,7 +3,6 @@ package adapter
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/orbs-network/go-mock"
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
 	. "github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
@@ -65,29 +64,6 @@ func assertContractOf(makeContext func() *transportContractContext) {
 		})
 	})
 }
-
-type mockListener struct {
-	mock.Mock
-}
-
-func (m *mockListener) OnTransportMessageReceived(payloads [][]byte) {
-	m.Called(payloads)
-}
-
-func listenTo(transport adapter.Transport, publicKey primitives.Ed25519Pkey) *mockListener {
-	l := &mockListener{}
-	transport.RegisterListener(l, publicKey)
-	return l
-}
-
-func (m *mockListener) expectReceive(payloads [][]byte) {
-	m.When("OnTransportMessageReceived", payloads).Return().Times(1)
-}
-
-func (m *mockListener) expectNotReceive() {
-	m.When("OnTransportMessageReceived", mock.Any).Return().Times(0)
-}
-
 type transportContractContext struct {
 	publicKeys []primitives.Ed25519Pkey
 	transports []adapter.Transport


### PR DESCRIPTION
I was never happy with LoopControl (even though it's cool! :-) ) as it's not really in par with the concepts of black-box testing. Today I figured out we can achieve the same behavior with a latch on transport messages, waiting until at least one PRE_PREPARE message was sent, in the case of our consensus acceptance test.

Along the way, I also added some missing reporting messages in Block Storage