### PR TITLE
moved transport contract test to testify

### DIFF
--- a/test/eventually.go
+++ b/test/eventually.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-const iterations = 10
+const iterations = 20
 const interval = 5 * time.Millisecond
 
 func Eventually(f func() bool) bool {

--- a/test/harness/services/gossip/adapter/mock_listener.go
+++ b/test/harness/services/gossip/adapter/mock_listener.go
@@ -25,7 +25,7 @@ func (m *mockListener) expectReceive(payloads [][]byte) {
 }
 
 func (m *mockListener) expectNotReceive() {
-	m.WhenOnTransportMessageReceived(mock.Any).Return().Times(0)
+	m.Never("OnTransportMessageReceived", mock.Any)
 }
 
 func (m *mockListener) WhenOnTransportMessageReceived(arg interface{}) *mock.MockFunction {


### PR DESCRIPTION
moved transport contract test to testify. Had to increase number of iterations in eventually, as Ginko's `Eventually` is apparently implemented differently and the memberlist transport took more than 100 ms to initialize properly.