### PR TITLE
Feature/statestore latch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,3 +15,4 @@ workflows:
   build:
     jobs:
       - build
+

--- a/bootstrap/node.go
+++ b/bootstrap/node.go
@@ -37,6 +37,7 @@ func NewNode(
 	benchmarkConsensusRoundRetryIntervalMillis uint32, // TODO: move all of the config from the ctor, it's a smell
 	transport gossipAdapter.Transport,
 	stateHistoryRetentionInBlockHeights uint64,
+	querySyncGraceBlockDist uint64,
 	belowMinimalBlockDelayMillis uint32,
 	minimumTransactionsInBlock int,
 ) Node {
@@ -51,6 +52,7 @@ func NewNode(
 		benchmarkConsensusRoundRetryIntervalMillis,
 		blockSyncCommitTimeoutMillis,
 		stateHistoryRetentionInBlockHeights,
+		querySyncGraceBlockDist,
 		belowMinimalBlockDelayMillis,
 		minimumTransactionsInBlock,
 	)

--- a/bootstrap/node.go
+++ b/bootstrap/node.go
@@ -38,6 +38,7 @@ func NewNode(
 	transport gossipAdapter.Transport,
 	stateHistoryRetentionInBlockHeights uint64,
 	querySyncGraceBlockDist uint64,
+	querySyncGraceTimeoutMillis uint64,
 	belowMinimalBlockDelayMillis uint32,
 	minimumTransactionsInBlock int,
 ) Node {
@@ -53,6 +54,7 @@ func NewNode(
 		blockSyncCommitTimeoutMillis,
 		stateHistoryRetentionInBlockHeights,
 		querySyncGraceBlockDist,
+		querySyncGraceTimeoutMillis,
 		belowMinimalBlockDelayMillis,
 		minimumTransactionsInBlock,
 	)

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,8 @@ type NodeConfig interface {
 
 	// state storage
 	StateHistoryRetentionInBlockHeights() uint64
+	QuerySyncGraceBlockDist() uint64
+	QuerySyncGraceTimeoutMillis() uint64
 
 	// consensus context
 	BelowMinimalBlockDelayMillis() uint32

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ type NodeConfig interface {
 	NodePrivateKey() primitives.Ed25519PrivateKey
 	NetworkSize(asOfBlock uint64) uint32
 	FederationNodes(asOfBlock uint64) map[string]FederationNode
+	QueryGraceTimeoutMillis() uint64
 
 	// consensus
 	ConstantConsensusLeader() primitives.Ed25519PublicKey
@@ -25,7 +26,6 @@ type NodeConfig interface {
 	// state storage
 	StateHistoryRetentionInBlockHeights() uint64
 	QuerySyncGraceBlockDist() uint64
-	QuerySyncGraceTimeoutMillis() uint64
 
 	// consensus context
 	BelowMinimalBlockDelayMillis() uint32

--- a/config/hardcoded_config.go
+++ b/config/hardcoded_config.go
@@ -33,7 +33,7 @@ type consensusContextConfig struct {
 type stateStorageConfig struct {
 	stateHistoryRetentionInBlockHeights uint64
 	querySyncGraceBlockDist             uint64
-	querySyncGraceTimeoutMillis		    uint64
+	querySyncGraceTimeoutMillis         uint64
 }
 
 type hardCodedFederationNode struct {
@@ -86,7 +86,7 @@ func NewHardCodedConfig(
 		stateStorageConfig: &stateStorageConfig{
 			stateHistoryRetentionInBlockHeights: stateHistoryRetentionInBlockHeights,
 			querySyncGraceBlockDist:             querySyncGraceBlockDist,
-			querySyncGraceTimeoutMillis:		 querySyncGraceTimeoutMillis,
+			querySyncGraceTimeoutMillis:         querySyncGraceTimeoutMillis,
 		},
 		consensusContextConfig: &consensusContextConfig{
 			belowMinimalBlockDelayMillis: belowMinimalBlockDelayMillis,
@@ -131,7 +131,7 @@ func NewStateStorageConfig(maxStateHistory uint64, graceBlockDist uint64, graceT
 	return &stateStorageConfig{
 		stateHistoryRetentionInBlockHeights: maxStateHistory,
 		querySyncGraceBlockDist:             graceBlockDist,
-		querySyncGraceTimeoutMillis:		 graceTimeoutMillis,
+		querySyncGraceTimeoutMillis:         graceTimeoutMillis,
 	}
 }
 
@@ -187,6 +187,6 @@ func (c *stateStorageConfig) QuerySyncGraceBlockDist() uint64 {
 	return c.querySyncGraceBlockDist
 }
 
-func (c* stateStorageConfig) QuerySyncGraceTimeoutMillis() uint64 {
+func (c *stateStorageConfig) QuerySyncGraceTimeoutMillis() uint64 {
 	return c.querySyncGraceTimeoutMillis
 }

--- a/config/hardcoded_config.go
+++ b/config/hardcoded_config.go
@@ -21,6 +21,10 @@ type consensusConfig struct {
 	benchmarkConsensusRoundRetryIntervalMillis uint32
 }
 
+type crossServiceConfig struct {
+	queryGraceTimeoutMillis             uint64
+}
+
 type blockStorageConfig struct {
 	blockSyncCommitTimeoutMillis time.Duration
 }
@@ -33,7 +37,6 @@ type consensusContextConfig struct {
 type stateStorageConfig struct {
 	stateHistoryRetentionInBlockHeights uint64
 	querySyncGraceBlockDist             uint64
-	querySyncGraceTimeoutMillis         uint64
 }
 
 type hardCodedFederationNode struct {
@@ -43,6 +46,7 @@ type hardCodedFederationNode struct {
 type hardcodedConfig struct {
 	*identity
 	*consensusConfig
+	*crossServiceConfig
 	*blockStorageConfig
 	*stateStorageConfig
 	*consensusContextConfig
@@ -64,7 +68,7 @@ func NewHardCodedConfig(
 	blockSyncCommitTimeoutMillis uint32,
 	stateHistoryRetentionInBlockHeights uint64,
 	querySyncGraceBlockDist uint64,
-	querySyncGraceTimeoutMillis uint64,
+	queryGraceTimeoutMillis uint64,
 	belowMinimalBlockDelayMillis uint32,
 	minimumTransactionsInBlock int,
 ) NodeConfig {
@@ -80,13 +84,15 @@ func NewHardCodedConfig(
 			activeConsensusAlgo:                        activeConsensusAlgo,
 			benchmarkConsensusRoundRetryIntervalMillis: benchmarkConsensusRoundRetryIntervalMillis,
 		},
+		crossServiceConfig: &crossServiceConfig{
+			queryGraceTimeoutMillis:             queryGraceTimeoutMillis,
+		},
 		blockStorageConfig: &blockStorageConfig{
 			blockSyncCommitTimeoutMillis: time.Duration(blockSyncCommitTimeoutMillis) * time.Millisecond,
 		},
 		stateStorageConfig: &stateStorageConfig{
 			stateHistoryRetentionInBlockHeights: stateHistoryRetentionInBlockHeights,
 			querySyncGraceBlockDist:             querySyncGraceBlockDist,
-			querySyncGraceTimeoutMillis:         querySyncGraceTimeoutMillis,
 		},
 		consensusContextConfig: &consensusContextConfig{
 			belowMinimalBlockDelayMillis: belowMinimalBlockDelayMillis,
@@ -127,11 +133,16 @@ func NewConsensusContextConfig(belowMinimalBlockDelayMillis uint32, minimumTrans
 	}
 }
 
-func NewStateStorageConfig(maxStateHistory uint64, graceBlockDist uint64, graceTimeoutMillis uint64) *stateStorageConfig {
+func NewStateStorageConfig(maxStateHistory uint64, graceBlockDist uint64) *stateStorageConfig {
 	return &stateStorageConfig{
 		stateHistoryRetentionInBlockHeights: maxStateHistory,
 		querySyncGraceBlockDist:             graceBlockDist,
-		querySyncGraceTimeoutMillis:         graceTimeoutMillis,
+	}
+}
+
+func NewCrossServiceConfig(graceTimeoutMillis uint64) *crossServiceConfig {
+	return &crossServiceConfig{
+		queryGraceTimeoutMillis:             graceTimeoutMillis,
 	}
 }
 
@@ -187,6 +198,6 @@ func (c *stateStorageConfig) QuerySyncGraceBlockDist() uint64 {
 	return c.querySyncGraceBlockDist
 }
 
-func (c *stateStorageConfig) QuerySyncGraceTimeoutMillis() uint64 {
-	return c.querySyncGraceTimeoutMillis
+func (c *crossServiceConfig) QueryGraceTimeoutMillis() uint64 {
+	return c.queryGraceTimeoutMillis
 }

--- a/config/hardcoded_config.go
+++ b/config/hardcoded_config.go
@@ -33,6 +33,7 @@ type consensusContextConfig struct {
 type stateStorageConfig struct {
 	stateHistoryRetentionInBlockHeights uint64
 	querySyncGraceBlockDist             uint64
+	querySyncGraceTimeoutMillis		    uint64
 }
 
 type hardCodedFederationNode struct {
@@ -63,6 +64,7 @@ func NewHardCodedConfig(
 	blockSyncCommitTimeoutMillis uint32,
 	stateHistoryRetentionInBlockHeights uint64,
 	querySyncGraceBlockDist uint64,
+	querySyncGraceTimeoutMillis uint64,
 	belowMinimalBlockDelayMillis uint32,
 	minimumTransactionsInBlock int,
 ) NodeConfig {
@@ -84,6 +86,7 @@ func NewHardCodedConfig(
 		stateStorageConfig: &stateStorageConfig{
 			stateHistoryRetentionInBlockHeights: stateHistoryRetentionInBlockHeights,
 			querySyncGraceBlockDist:             querySyncGraceBlockDist,
+			querySyncGraceTimeoutMillis:		 querySyncGraceTimeoutMillis,
 		},
 		consensusContextConfig: &consensusContextConfig{
 			belowMinimalBlockDelayMillis: belowMinimalBlockDelayMillis,
@@ -124,10 +127,11 @@ func NewConsensusContextConfig(belowMinimalBlockDelayMillis uint32, minimumTrans
 	}
 }
 
-func NewStateStorageConfig(maxStateHistory uint64, graceBlockDist uint64) *stateStorageConfig {
+func NewStateStorageConfig(maxStateHistory uint64, graceBlockDist uint64, graceTimeoutMillis uint64) *stateStorageConfig {
 	return &stateStorageConfig{
 		stateHistoryRetentionInBlockHeights: maxStateHistory,
 		querySyncGraceBlockDist:             graceBlockDist,
+		querySyncGraceTimeoutMillis:		 graceTimeoutMillis,
 	}
 }
 
@@ -181,4 +185,8 @@ func (c *stateStorageConfig) StateHistoryRetentionInBlockHeights() uint64 {
 
 func (c *stateStorageConfig) QuerySyncGraceBlockDist() uint64 {
 	return c.querySyncGraceBlockDist
+}
+
+func (c* stateStorageConfig) QuerySyncGraceTimeoutMillis() uint64 {
+	return c.querySyncGraceTimeoutMillis
 }

--- a/config/hardcoded_config.go
+++ b/config/hardcoded_config.go
@@ -32,7 +32,7 @@ type consensusContextConfig struct {
 
 type stateStorageConfig struct {
 	stateHistoryRetentionInBlockHeights uint64
-	querySyncGraceBlockDist uint64
+	querySyncGraceBlockDist             uint64
 }
 
 type hardCodedFederationNode struct {
@@ -83,7 +83,7 @@ func NewHardCodedConfig(
 		},
 		stateStorageConfig: &stateStorageConfig{
 			stateHistoryRetentionInBlockHeights: stateHistoryRetentionInBlockHeights,
-			querySyncGraceBlockDist: querySyncGraceBlockDist,
+			querySyncGraceBlockDist:             querySyncGraceBlockDist,
 		},
 		consensusContextConfig: &consensusContextConfig{
 			belowMinimalBlockDelayMillis: belowMinimalBlockDelayMillis,
@@ -127,7 +127,7 @@ func NewConsensusContextConfig(belowMinimalBlockDelayMillis uint32, minimumTrans
 func NewStateStorageConfig(maxStateHistory uint64, graceBlockDist uint64) *stateStorageConfig {
 	return &stateStorageConfig{
 		stateHistoryRetentionInBlockHeights: maxStateHistory,
-		querySyncGraceBlockDist: graceBlockDist,
+		querySyncGraceBlockDist:             graceBlockDist,
 	}
 }
 

--- a/config/hardcoded_config.go
+++ b/config/hardcoded_config.go
@@ -22,7 +22,7 @@ type consensusConfig struct {
 }
 
 type crossServiceConfig struct {
-	queryGraceTimeoutMillis             uint64
+	queryGraceTimeoutMillis uint64
 }
 
 type blockStorageConfig struct {
@@ -35,6 +35,7 @@ type consensusContextConfig struct {
 }
 
 type stateStorageConfig struct {
+	*crossServiceConfig
 	stateHistoryRetentionInBlockHeights uint64
 	querySyncGraceBlockDist             uint64
 }
@@ -85,7 +86,7 @@ func NewHardCodedConfig(
 			benchmarkConsensusRoundRetryIntervalMillis: benchmarkConsensusRoundRetryIntervalMillis,
 		},
 		crossServiceConfig: &crossServiceConfig{
-			queryGraceTimeoutMillis:             queryGraceTimeoutMillis,
+			queryGraceTimeoutMillis: queryGraceTimeoutMillis,
 		},
 		blockStorageConfig: &blockStorageConfig{
 			blockSyncCommitTimeoutMillis: time.Duration(blockSyncCommitTimeoutMillis) * time.Millisecond,
@@ -133,16 +134,13 @@ func NewConsensusContextConfig(belowMinimalBlockDelayMillis uint32, minimumTrans
 	}
 }
 
-func NewStateStorageConfig(maxStateHistory uint64, graceBlockDist uint64) *stateStorageConfig {
+func NewStateStorageConfig(maxStateHistory uint64, graceBlockDist uint64, graceTimeoutMillis uint64) *stateStorageConfig {
 	return &stateStorageConfig{
 		stateHistoryRetentionInBlockHeights: maxStateHistory,
 		querySyncGraceBlockDist:             graceBlockDist,
-	}
-}
-
-func NewCrossServiceConfig(graceTimeoutMillis uint64) *crossServiceConfig {
-	return &crossServiceConfig{
-		queryGraceTimeoutMillis:             graceTimeoutMillis,
+		crossServiceConfig: &crossServiceConfig{
+			queryGraceTimeoutMillis: graceTimeoutMillis,
+		},
 	}
 }
 

--- a/config/hardcoded_config.go
+++ b/config/hardcoded_config.go
@@ -32,6 +32,7 @@ type consensusContextConfig struct {
 
 type stateStorageConfig struct {
 	stateHistoryRetentionInBlockHeights uint64
+	querySyncGraceBlockDist uint64
 }
 
 type hardCodedFederationNode struct {
@@ -61,6 +62,7 @@ func NewHardCodedConfig(
 	benchmarkConsensusRoundRetryIntervalMillis uint32,
 	blockSyncCommitTimeoutMillis uint32,
 	stateHistoryRetentionInBlockHeights uint64,
+	querySyncGraceBlockDist uint64,
 	belowMinimalBlockDelayMillis uint32,
 	minimumTransactionsInBlock int,
 ) NodeConfig {
@@ -79,7 +81,10 @@ func NewHardCodedConfig(
 		blockStorageConfig: &blockStorageConfig{
 			blockSyncCommitTimeoutMillis: time.Duration(blockSyncCommitTimeoutMillis) * time.Millisecond,
 		},
-		stateStorageConfig: &stateStorageConfig{stateHistoryRetentionInBlockHeights: stateHistoryRetentionInBlockHeights},
+		stateStorageConfig: &stateStorageConfig{
+			stateHistoryRetentionInBlockHeights: stateHistoryRetentionInBlockHeights,
+			querySyncGraceBlockDist: querySyncGraceBlockDist,
+		},
 		consensusContextConfig: &consensusContextConfig{
 			belowMinimalBlockDelayMillis: belowMinimalBlockDelayMillis,
 			minimumTransactionsInBlock:   minimumTransactionsInBlock,
@@ -119,8 +124,11 @@ func NewConsensusContextConfig(belowMinimalBlockDelayMillis uint32, minimumTrans
 	}
 }
 
-func NewStateStorageConfig(maxStateHistory uint64) *stateStorageConfig {
-	return &stateStorageConfig{stateHistoryRetentionInBlockHeights: maxStateHistory}
+func NewStateStorageConfig(maxStateHistory uint64, graceBlockDist uint64) *stateStorageConfig {
+	return &stateStorageConfig{
+		stateHistoryRetentionInBlockHeights: maxStateHistory,
+		querySyncGraceBlockDist: graceBlockDist,
+	}
 }
 
 func (c *identity) NodePublicKey() primitives.Ed25519PublicKey {
@@ -169,4 +177,8 @@ func (c *consensusContextConfig) MinimumTransactionsInBlock() int {
 
 func (c *stateStorageConfig) StateHistoryRetentionInBlockHeights() uint64 {
 	return c.stateHistoryRetentionInBlockHeights
+}
+
+func (c *stateStorageConfig) QuerySyncGraceBlockDist() uint64 {
+	return c.querySyncGraceBlockDist
 }

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 		2*1000,
 		gossipTransport,
 		5,
+		3,
 		300,
 		2,
 	).WaitUntilShutdown()

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 		5,
 		3,
 		300,
+		300,
 		2,
 	).WaitUntilShutdown()
 }

--- a/services/statestorage/block_tracker.go
+++ b/services/statestorage/block_tracker.go
@@ -1,0 +1,56 @@
+package statestorage
+
+import (
+	"github.com/orbs-network/orbs-spec/types/go/primitives"
+	"github.com/pkg/errors"
+	"sync/atomic"
+	"time"
+)
+
+type BlockTracker struct {
+	currentHeight uint64
+	graceDistance uint64
+	timeout       time.Duration
+
+	latch chan struct{}
+}
+
+func NewBlockTracker(startingHeight uint64, graceDist uint16, timeout time.Duration) *BlockTracker {
+	return &BlockTracker{
+		currentHeight: startingHeight,
+		graceDistance: uint64(graceDist),
+		timeout:       timeout,
+		latch:         make(chan struct{}),
+	}
+}
+
+func (t *BlockTracker) IncrementHeight() {
+	atomic.AddUint64(&t.currentHeight, 1) // increment atomically in case two goroutines commit concurrently
+	prevLatch := t.latch
+	t.latch = make(chan struct{})
+	close(prevLatch)
+}
+
+func (t *BlockTracker) WaitForBlock(requestedHeight primitives.BlockHeight) error {
+
+	rh := uint64(requestedHeight)
+	if t.currentHeight >= rh { // requested block already committed
+		return nil
+	}
+
+	if t.currentHeight < rh-t.graceDistance { // requested block too far ahead, no grace
+		return errors.Errorf("requested future block outside of grace range")
+	}
+
+	timer := time.NewTimer(t.timeout)
+	defer timer.Stop()
+
+	for t.currentHeight < rh { // sit on latch until desired height or t.o.
+		select {
+		case <-timer.C:
+			return errors.Errorf("timed out waiting for block at height %v", requestedHeight)
+		case <-t.latch:
+		}
+	}
+	return nil
+}

--- a/services/statestorage/service.go
+++ b/services/statestorage/service.go
@@ -108,18 +108,18 @@ func (s *service) checkBlockHeightWithGrace(requestedHeight primitives.BlockHeig
 	}
 
 	graceDist := primitives.BlockHeight(s.config.QuerySyncGraceBlockDist())
-	if currentHeight < requestedHeight - graceDist { // requested block too far ahead, no grace
+	if currentHeight < requestedHeight-graceDist { // requested block too far ahead, no grace
 		return false
 	}
 
 	timeout := time.NewTimer(time.Duration(s.config.QuerySyncGraceTimeoutMillis()) * time.Millisecond)
 	defer timeout.Stop()
 
-	for ; s.lastCommittedBlockHeader.BlockHeight() < requestedHeight; { // sit on latch until desired height or t.o.
+	for s.lastCommittedBlockHeader.BlockHeight() < requestedHeight { // sit on latch until desired height or t.o.
 		select {
-			case <-timeout.C:
-				return false
-			case <-s.nextBlockLatch:
+		case <-timeout.C:
+			return false
+		case <-s.nextBlockLatch:
 		}
 	}
 	return true

--- a/services/statestorage/service.go
+++ b/services/statestorage/service.go
@@ -12,6 +12,7 @@ import (
 
 type Config interface {
 	StateHistoryRetentionInBlockHeights() uint64
+	//QuerySyncGraceBlockDist() uint64
 }
 
 type service struct {

--- a/services/statestorage/test/commit_diffs.go
+++ b/services/statestorage/test/commit_diffs.go
@@ -60,10 +60,10 @@ var _ = Describe("Commit a State Diff", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result.NextDesiredBlockHeight).To(BeEquivalentTo(3))
 
-				output, err := d.readSingleKeyFromHistory(2, "contract1", "key1")
+				output, err := d.readSingleKeyFromRevision(2, "contract1", "key1")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output).To(BeEquivalentTo(v2))
-				output2, err := d.readSingleKeyFromHistory(2, "contract1", "key3")
+				output2, err := d.readSingleKeyFromRevision(2, "contract1", "key3")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output2).To(BeEquivalentTo([]byte{}))
 			})

--- a/services/statestorage/test/drivers.go
+++ b/services/statestorage/test/drivers.go
@@ -21,16 +21,17 @@ type keyValue struct {
 }
 
 func newStateStorageDriver(history int) *driver {
-	return newStateStorageDriverWithGrace(history, 0)
+	return newStateStorageDriverWithGrace(history, 0, 0)
 }
 
-func newStateStorageDriverWithGrace(history int, graceBlockDiff int) *driver {
+func newStateStorageDriverWithGrace(history int, graceBlockDiff int, graceTimeoutMillis int) *driver {
 	if history <= 0 {
 		history = 1
 	}
 	historySize := driverConfig{
 		history,
 		graceBlockDiff,
+		graceTimeoutMillis,
 	}
 
 	p := adapter.NewInMemoryStatePersistence()
@@ -113,6 +114,7 @@ func (d *driver) commitValuePairsAtHeight(h int, contract string, keyValues ...s
 type driverConfig struct {
 	historySize             int
 	querySyncGraceBlockDist int
+	querySyncGraceTimeoutMillis int
 }
 
 func (d *driverConfig) StateHistoryRetentionInBlockHeights() uint64 {
@@ -121,4 +123,8 @@ func (d *driverConfig) StateHistoryRetentionInBlockHeights() uint64 {
 
 func (d *driverConfig) QuerySyncGraceBlockDist() uint64 {
 	return uint64(d.querySyncGraceBlockDist)
+}
+
+func (d *driverConfig) QuerySyncGraceTimeoutMillis() uint64 {
+	return uint64(d.querySyncGraceTimeoutMillis)
 }

--- a/services/statestorage/test/drivers.go
+++ b/services/statestorage/test/drivers.go
@@ -112,8 +112,8 @@ func (d *driver) commitValuePairsAtHeight(h int, contract string, keyValues ...s
 }
 
 type driverConfig struct {
-	historySize             int
-	querySyncGraceBlockDist int
+	historySize                 int
+	querySyncGraceBlockDist     int
 	querySyncGraceTimeoutMillis int
 }
 

--- a/services/statestorage/test/drivers.go
+++ b/services/statestorage/test/drivers.go
@@ -21,10 +21,17 @@ type keyValue struct {
 }
 
 func newStateStorageDriver(history int) *driver {
+	return newStateStorageDriverWithGrace(history, 0)
+}
+
+func newStateStorageDriverWithGrace(history int, graceBlockDiff int) *driver {
 	if history <= 0 {
 		history = 1
 	}
-	historySize := driverConfig{history}
+	historySize := driverConfig{
+		history,
+		graceBlockDiff,
+	}
 
 	p := adapter.NewInMemoryStatePersistence()
 
@@ -105,8 +112,13 @@ func (d *driver) commitValuePairsAtHeight(h int, contract string, keyValues ...s
 
 type driverConfig struct {
 	historySize int
+	querySyncGraceBlockDist int
 }
 
 func (d *driverConfig) StateHistoryRetentionInBlockHeights() uint64 {
 	return uint64(d.historySize)
+}
+
+func (d *driverConfig) QuerySyncGraceBlockDist() uint64 {
+	return uint64(d.querySyncGraceBlockDist)
 }

--- a/services/statestorage/test/drivers.go
+++ b/services/statestorage/test/drivers.go
@@ -125,6 +125,6 @@ func (d *driverConfig) QuerySyncGraceBlockDist() uint64 {
 	return uint64(d.querySyncGraceBlockDist)
 }
 
-func (d *driverConfig) QuerySyncGraceTimeoutMillis() uint64 {
+func (d *driverConfig) QueryGraceTimeoutMillis() uint64 {
 	return uint64(d.querySyncGraceTimeoutMillis)
 }

--- a/services/statestorage/test/drivers.go
+++ b/services/statestorage/test/drivers.go
@@ -111,7 +111,7 @@ func (d *driver) commitValuePairsAtHeight(h int, contract string, keyValues ...s
 }
 
 type driverConfig struct {
-	historySize int
+	historySize             int
 	querySyncGraceBlockDist int
 }
 

--- a/services/statestorage/test/read_keys.go
+++ b/services/statestorage/test/read_keys.go
@@ -1,9 +1,9 @@
 package test
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"fmt"
 	"time"
 )
 
@@ -167,12 +167,12 @@ var _ bool = Describe("Reading a Key", func() {
 					//TODO - replace this with an intrusive test to see our goroutine is blocking on the latch
 					time.Sleep(50 * time.Millisecond)
 					for ; currentHeight < futureHeightWithinGrace; currentHeight++ {
-						d.commitValuePairsAtHeight(currentHeight + 1, "contract", "foo", fmt.Sprintf("%v",currentHeight + 1))
+						d.commitValuePairsAtHeight(currentHeight+1, "contract", "foo", fmt.Sprintf("%v", currentHeight+1))
 					}
 
-					data := <- result
+					data := <-result
 
-					Expect(data).To(BeEquivalentTo(fmt.Sprintf("%v",futureHeightWithinGrace)))
+					Expect(data).To(BeEquivalentTo(fmt.Sprintf("%v", futureHeightWithinGrace)))
 
 					close(done)
 				}, 5)

--- a/services/statestorage/test/read_keys.go
+++ b/services/statestorage/test/read_keys.go
@@ -3,6 +3,8 @@ package test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"fmt"
+	"time"
 )
 
 var _ bool = Describe("Reading a Key", func() {
@@ -112,12 +114,68 @@ var _ bool = Describe("Reading a Key", func() {
 		When("Reading in the far future", func() {
 			It("fails", func() {
 				key := "foo"
-
-				d := newStateStorageDriver(1)
-				d.commitValuePairsAtHeight(1, "contract", key, "bar")
+				graceDistance := 10
+				d := newStateStorageDriverWithGrace(1, graceDistance, 10)
+				d.commitValuePairsAtHeight(11, "contract", key, "bar")
 
 				_, err := d.readSingleKeyFromHistory(100, "contract", key)
 				Expect(err).To(HaveOccurred())
+			})
+		})
+		When("Reading from future block height within grace distance", func() {
+			When("Block not committed before timeout", func() {
+				It("returns an error after timeout", func(done Done) {
+					graceDistance := 10
+					timeoutMillis := 250
+					d := newStateStorageDriverWithGrace(1, graceDistance, timeoutMillis)
+
+					d.commitValuePairs("contract", "foo", "bar")
+					futureHeightWithinGrace := 1 + graceDistance
+
+					ts := time.Now()
+					data, err := d.readKeysFromHistory(futureHeightWithinGrace, "contract", "foo")
+
+					//TODO - replace this with an intrusive test to check that a timeout has occurred and reduce timeoutMillis
+					timeouts := ((time.Now().UnixNano() - ts.UnixNano()) / 1000000) / int64(timeoutMillis)
+
+					Expect(timeouts).To(BeEquivalentTo(1))
+					Expect(err).To(HaveOccurred())
+					Expect(data).To(BeNil())
+
+					close(done)
+				}, 5)
+			})
+			When("Block committed with state diff before timeout", func() {
+				It("blocks and returns the state per new block", func(done Done) {
+					graceDistance := 10
+					d := newStateStorageDriverWithGrace(1, graceDistance, 1000)
+
+					currentHeight := 0
+					futureHeightWithinGrace := currentHeight + graceDistance
+
+					result := make(chan []byte)
+
+					go func() {
+						defer GinkgoRecover()
+
+						data, err := d.readSingleKeyFromHistory(futureHeightWithinGrace, "contract", "foo")
+
+						Expect(err).ToNot(HaveOccurred())
+						result <- data
+					}()
+
+					//TODO - replace this with an intrusive test to see our goroutine is blocking on the latch
+					time.Sleep(50 * time.Millisecond)
+					for ; currentHeight < futureHeightWithinGrace; currentHeight++ {
+						d.commitValuePairsAtHeight(currentHeight + 1, "contract", "foo", fmt.Sprintf("%v",currentHeight + 1))
+					}
+
+					data := <- result
+
+					Expect(data).To(BeEquivalentTo(fmt.Sprintf("%v",futureHeightWithinGrace)))
+
+					close(done)
+				}, 5)
 			})
 		})
 	})

--- a/services/statestorage/wait_for_block_test.go
+++ b/services/statestorage/wait_for_block_test.go
@@ -1,0 +1,53 @@
+package statestorage
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestWaitForBlockOutsideOfGraceFailsImmediately(t *testing.T) {
+	tracker := NewBlockTracker(1, 1, 10*time.Millisecond)
+
+	err := tracker.WaitForBlock(3)
+	require.EqualError(t, err, "requested future block outside of grace range", "did not fail immediately")
+}
+
+func TestWaitForBlockWithinGraceFailsAfterTimeout(t *testing.T) {
+
+	tracker := NewBlockTracker(1, 1, 1*time.Millisecond)
+	err := tracker.WaitForBlock(2)
+	require.EqualError(t, err, "timed out waiting for block at height 2", "did not timeout as expected")
+}
+
+func TestWaitForBlockWithinGraceReturnsWhenRequestedBlockHeightAdvancesBeforeTimeout(t *testing.T) {
+	tracker := NewBlockTracker(1, 2, 1*time.Second)
+
+	doneWait := make(chan error)
+	go func() {
+		doneWait <- tracker.WaitForBlock(3)
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+	tracker.IncrementHeight()
+	tracker.IncrementHeight()
+
+	require.NoError(t, <-doneWait, "did not return as expected")
+}
+
+func TestWaitForBlockWithinGraceSupportsTwoConcurrentWaiters(t *testing.T) {
+	tracker := NewBlockTracker(1, 1, 1*time.Second)
+
+	doneWait := make(chan error)
+	waiter := func() {
+		doneWait <- tracker.WaitForBlock(2)
+	}
+	go waiter()
+	go waiter()
+
+	time.Sleep(5 * time.Millisecond)
+	tracker.IncrementHeight()
+
+	require.NoError(t, <-doneWait, "first waiter did not return as expected")
+	require.NoError(t, <-doneWait, "second waiter did not return as expected")
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -69,6 +69,7 @@ var _ = Describe("The Orbs Network", func() {
 				5,
 				3,
 				300,
+				300,
 				0,
 			)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -67,6 +67,7 @@ var _ = Describe("The Orbs Network", func() {
 				2*1000,
 				gossipTransport,
 				5,
+				3,
 				300,
 				0,
 			)

--- a/test/harness/network.go
+++ b/test/harness/network.go
@@ -81,6 +81,7 @@ func NewTestNetwork(ctx context.Context, numNodes uint32, consensusAlgo consensu
 			1,
 			70,
 			5,
+			3,
 			300, 0,
 		)
 

--- a/test/harness/network.go
+++ b/test/harness/network.go
@@ -82,7 +82,9 @@ func NewTestNetwork(ctx context.Context, numNodes uint32, consensusAlgo consensu
 			70,
 			5,
 			3,
-			300, 0,
+			300,
+			300,
+			0,
 		)
 
 		nodes[i].statePersistence = stateStorageAdapter.NewInMemoryStatePersistence()

--- a/test/harness/services/gossip/adapter/transport_contract_test.go
+++ b/test/harness/services/gossip/adapter/transport_contract_test.go
@@ -5,8 +5,8 @@ import (
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
-	"testing"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestContract_SendBroadcast(t *testing.T) {


### PR DESCRIPTION
Add sync grace to ReadKeys. 

Using generic BlockTracker ready for reuse in other sync grace flows.

Add crossServiceConfig to config objects with queryGraceTimeoutMillis 