### PR TITLE
rename log package

### DIFF
--- a/bootstrap/httpserver/server.go
+++ b/bootstrap/httpserver/server.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/orbs-network/membuffers/go"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/client"
 	"github.com/orbs-network/orbs-spec/types/go/services"
 )
@@ -18,13 +18,13 @@ type HttpServer interface {
 
 type server struct {
 	httpServer *http.Server
-	reporting  instrumentation.BasicLogger
+	reporting  log.BasicLogger
 	publicApi  services.PublicApi
 }
 
-func NewHttpServer(address string, reporting instrumentation.BasicLogger, publicApi services.PublicApi) HttpServer {
+func NewHttpServer(address string, reporting log.BasicLogger, publicApi services.PublicApi) HttpServer {
 	server := &server{
-		reporting: reporting.For(instrumentation.String("subsystem", "http-server")),
+		reporting: reporting.For(log.String("subsystem", "http-server")),
 		publicApi: publicApi,
 	}
 
@@ -34,7 +34,7 @@ func NewHttpServer(address string, reporting instrumentation.BasicLogger, public
 	}
 
 	go func() {
-		reporting.Info("Starting server on address", instrumentation.String("address", address))
+		reporting.Info("Starting server on address", log.String("address", address))
 		server.httpServer.ListenAndServe() //TODO error on failed startup
 	}()
 
@@ -79,9 +79,9 @@ func (s *server) GracefulShutdown(timeout time.Duration) {
 	s.httpServer.Shutdown(context.TODO()) //TODO timeout context
 }
 
-func report(reporting instrumentation.BasicLogger, h http.Handler) http.Handler {
+func report(reporting log.BasicLogger, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		meter := reporting.Meter("request-process-time", instrumentation.String("url", r.URL.String()))
+		meter := reporting.Meter("request-process-time", log.String("url", r.URL.String()))
 		defer meter.Done()
 		h.ServeHTTP(w, r)
 	})
@@ -112,7 +112,7 @@ func (s *server) handler(handler func(bytes []byte, r *response)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bytes, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			s.reporting.Info("could not read http request body", instrumentation.Error(err))
+			s.reporting.Info("could not read http request body", log.Error(err))
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))
 			return

--- a/bootstrap/node.go
+++ b/bootstrap/node.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/orbs-network/orbs-network-go/bootstrap/httpserver"
 	"github.com/orbs-network/orbs-network-go/config"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	blockStorageAdapter "github.com/orbs-network/orbs-network-go/services/blockstorage/adapter"
 	gossipAdapter "github.com/orbs-network/orbs-network-go/services/gossip/adapter"
 	stateStorageAdapter "github.com/orbs-network/orbs-network-go/services/statestorage/adapter"
@@ -34,7 +34,7 @@ func NewNode(
 	blockSyncCommitTimeoutMillis uint32,
 	constantConsensusLeader primitives.Ed25519PublicKey,
 	activeConsensusAlgo consensus.ConsensusAlgoType,
-	logger instrumentation.BasicLogger,
+	logger log.BasicLogger,
 	benchmarkConsensusRoundRetryIntervalMillis uint32, // TODO: move all of the config from the ctor, it's a smell
 	transport gossipAdapter.Transport,
 	minimumTransactionsInBlock int,
@@ -52,7 +52,7 @@ func NewNode(
 		minimumTransactionsInBlock,
 	)
 
-	nodeLogger := logger.For(instrumentation.Node(nodePublicKey.String()))
+	nodeLogger := logger.For(log.Node(nodePublicKey.String()))
 
 	blockPersistence := blockStorageAdapter.NewLevelDbBlockPersistence()
 	stateStorageAdapter := stateStorageAdapter.NewInMemoryStatePersistence()

--- a/bootstrap/node_logic.go
+++ b/bootstrap/node_logic.go
@@ -3,7 +3,7 @@ package bootstrap
 import (
 	"context"
 	"github.com/orbs-network/orbs-network-go/config"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/blockstorage"
 	blockStorageAdapter "github.com/orbs-network/orbs-network-go/services/blockstorage/adapter"
 	"github.com/orbs-network/orbs-network-go/services/consensusalgo/benchmarkconsensus"
@@ -38,7 +38,7 @@ func NewNodeLogic(
 	gossipTransport gossipAdapter.Transport,
 	blockPersistence blockStorageAdapter.BlockPersistence,
 	statePersistence stateStorageAdapter.StatePersistence,
-	reporting instrumentation.BasicLogger,
+	reporting log.BasicLogger,
 	nodeConfig config.NodeConfig,
 ) NodeLogic {
 

--- a/instrumentation/log/basic_logger.go
+++ b/instrumentation/log/basic_logger.go
@@ -1,4 +1,4 @@
-package instrumentation
+package log
 
 import (
 	"fmt"

--- a/instrumentation/log/basic_logger_test.go
+++ b/instrumentation/log/basic_logger_test.go
@@ -1,11 +1,11 @@
-package instrumentation_test
+package log_test
 
 import (
 	"bytes"
 	"encoding/json"
 	"fmt"
 	. "github.com/onsi/gomega"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/test/builders"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
@@ -43,7 +43,7 @@ func TestSimpleLogger(t *testing.T) {
 	RegisterTestingT(t)
 
 	stdout := captureStdout(func(writer io.Writer) {
-		serviceLogger := instrumentation.GetLogger(instrumentation.Node("node1"), instrumentation.Service("public-api")).WithOutput(instrumentation.NewOutput(writer))
+		serviceLogger := log.GetLogger(log.Node("node1"), log.Service("public-api")).WithOutput(log.NewOutput(writer))
 		serviceLogger.Info("Service initialized")
 	})
 
@@ -53,7 +53,7 @@ func TestSimpleLogger(t *testing.T) {
 	Expect(jsonMap["level"]).To(Equal("info"))
 	Expect(jsonMap["node"]).To(Equal("node1"))
 	Expect(jsonMap["service"]).To(Equal("public-api"))
-	Expect(jsonMap["function"]).To(Equal("instrumentation_test.TestSimpleLogger.func1"))
+	Expect(jsonMap["function"]).To(Equal("log_test.TestSimpleLogger.func1"))
 	Expect(jsonMap["message"]).To(Equal("Service initialized"))
 	Expect(jsonMap["source"]).NotTo(BeEmpty())
 	Expect(jsonMap["timestamp"]).NotTo(BeNil())
@@ -63,10 +63,10 @@ func TestNestedLogger(t *testing.T) {
 	RegisterTestingT(t)
 
 	stdout := captureStdout(func(writer io.Writer) {
-		serviceLogger := instrumentation.GetLogger(instrumentation.Node("node1"), instrumentation.Service("public-api")).WithOutput(instrumentation.NewOutput(writer))
-		txId := instrumentation.String("txId", "1234567")
-		txFlowLogger := serviceLogger.For(instrumentation.String("flow", TransactionFlow))
-		txFlowLogger.Info(TransactionAccepted, txId, instrumentation.Bytes("payload", []byte{1, 2, 3, 99}))
+		serviceLogger := log.GetLogger(log.Node("node1"), log.Service("public-api")).WithOutput(log.NewOutput(writer))
+		txId := log.String("txId", "1234567")
+		txFlowLogger := serviceLogger.For(log.String("flow", TransactionFlow))
+		txFlowLogger.Info(TransactionAccepted, txId, log.Bytes("payload", []byte{1, 2, 3, 99}))
 	})
 
 	fmt.Println(stdout)
@@ -75,7 +75,7 @@ func TestNestedLogger(t *testing.T) {
 	Expect(jsonMap["level"]).To(Equal("info"))
 	Expect(jsonMap["node"]).To(Equal("node1"))
 	Expect(jsonMap["service"]).To(Equal("public-api"))
-	Expect(jsonMap["function"]).To(Equal("instrumentation_test.TestNestedLogger.func1"))
+	Expect(jsonMap["function"]).To(Equal("log_test.TestNestedLogger.func1"))
 	Expect(jsonMap["message"]).To(Equal(TransactionAccepted))
 	Expect(jsonMap["source"]).NotTo(BeEmpty())
 	Expect(jsonMap["timestamp"]).NotTo(BeNil())
@@ -93,8 +93,8 @@ func TestStringableSlice(t *testing.T) {
 	receipts = append(receipts, builders.TransactionReceipt().Build())
 
 	stdout := captureStdout(func(writer io.Writer) {
-		serviceLogger := instrumentation.GetLogger(instrumentation.Node("node1"), instrumentation.Service("public-api")).WithOutput(instrumentation.NewOutput(writer))
-		serviceLogger.Info("StringableSlice test", instrumentation.StringableSlice("a-collection", receipts))
+		serviceLogger := log.GetLogger(log.Node("node1"), log.Service("public-api")).WithOutput(log.NewOutput(writer))
+		serviceLogger.Info("StringableSlice test", log.StringableSlice("a-collection", receipts))
 	})
 
 	fmt.Println(stdout)
@@ -103,7 +103,7 @@ func TestStringableSlice(t *testing.T) {
 	Expect(jsonMap["level"]).To(Equal("info"))
 	Expect(jsonMap["node"]).To(Equal("node1"))
 	Expect(jsonMap["service"]).To(Equal("public-api"))
-	Expect(jsonMap["function"]).To(Equal("instrumentation_test.TestStringableSlice.func1"))
+	Expect(jsonMap["function"]).To(Equal("log_test.TestStringableSlice.func1"))
 	Expect(jsonMap["message"]).To(Equal("StringableSlice test"))
 	Expect(jsonMap["source"]).NotTo(BeEmpty())
 	Expect(jsonMap["timestamp"]).NotTo(BeNil())
@@ -126,8 +126,8 @@ func TestStringableSliceCustomFormat(t *testing.T) {
 	transactions = append(transactions, builders.TransferTransaction().Build())
 
 	stdout := captureStdout(func(writer io.Writer) {
-		serviceLogger := instrumentation.GetLogger(instrumentation.Node("node1"), instrumentation.Service("public-api")).WithOutput(instrumentation.NewOutput(writer).WithFormatter(instrumentation.NewHumanReadableFormatter()))
-		serviceLogger.Info("StringableSlice HR test", instrumentation.StringableSlice("a-collection", transactions))
+		serviceLogger := log.GetLogger(log.Node("node1"), log.Service("public-api")).WithOutput(log.NewOutput(writer).WithFormatter(log.NewHumanReadableFormatter()))
+		serviceLogger.Info("StringableSlice HR test", log.StringableSlice("a-collection", transactions))
 	})
 
 	fmt.Println(stdout)
@@ -138,9 +138,9 @@ func TestStringableSliceCustomFormat(t *testing.T) {
 	Expect(stdout).To(ContainSubstring("service=public-api"))
 	Expect(stdout).To(ContainSubstring("a-collection=["))
 	Expect(stdout).To(ContainSubstring("{Transaction:{ProtocolVersion:1,"))
-	Expect(stdout).To(ContainSubstring("function=instrumentation_test.TestStringableSliceCustomFormat.func1"))
+	Expect(stdout).To(ContainSubstring("function=log_test.TestStringableSliceCustomFormat.func1"))
 	Expect(stdout).To(ContainSubstring("source="))
-	Expect(stdout).To(ContainSubstring("instrumentation/basic_logger_test.go"))
+	Expect(stdout).To(ContainSubstring("log/basic_logger_test.go"))
 
 }
 
@@ -148,9 +148,9 @@ func TestMeter(t *testing.T) {
 	RegisterTestingT(t)
 
 	stdout := captureStdout(func(writer io.Writer) {
-		serviceLogger := instrumentation.GetLogger(instrumentation.Node("node1"), instrumentation.Service("public-api")).WithOutput(instrumentation.NewOutput(writer))
-		txId := instrumentation.String("txId", "1234567")
-		txFlowLogger := serviceLogger.For(instrumentation.String("flow", TransactionFlow))
+		serviceLogger := log.GetLogger(log.Node("node1"), log.Service("public-api")).WithOutput(log.NewOutput(writer))
+		txId := log.String("txId", "1234567")
+		txFlowLogger := serviceLogger.For(log.String("flow", TransactionFlow))
 		meter := txFlowLogger.Meter("tx-process-time", txId)
 		defer meter.Done()
 
@@ -164,7 +164,7 @@ func TestMeter(t *testing.T) {
 	Expect(jsonMap["level"]).To(Equal("metric"))
 	Expect(jsonMap["node"]).To(Equal("node1"))
 	Expect(jsonMap["service"]).To(Equal("public-api"))
-	Expect(jsonMap["function"]).To(Equal("instrumentation_test.TestMeter.func1"))
+	Expect(jsonMap["function"]).To(Equal("log_test.TestMeter.func1"))
 	Expect(jsonMap["message"]).To(Equal("Metric recorded"))
 	Expect(jsonMap["source"]).NotTo(BeEmpty())
 	Expect(jsonMap["timestamp"]).NotTo(BeNil())
@@ -178,8 +178,8 @@ func TestCustomLogFormatter(t *testing.T) {
 	RegisterTestingT(t)
 
 	stdout := captureStdout(func(writer io.Writer) {
-		serviceLogger := instrumentation.GetLogger(instrumentation.Node("node1"), instrumentation.Service("public-api")).WithOutput(instrumentation.NewOutput(writer).WithFormatter(instrumentation.NewHumanReadableFormatter()))
-		serviceLogger.Info("Service initialized", instrumentation.Int("some-int-value", 12), instrumentation.BlockHeight(primitives.BlockHeight(9999)), instrumentation.Bytes("bytes", []byte{2, 3, 99}), instrumentation.Stringable("vchainId", primitives.VirtualChainId(123)))
+		serviceLogger := log.GetLogger(log.Node("node1"), log.Service("public-api")).WithOutput(log.NewOutput(writer).WithFormatter(log.NewHumanReadableFormatter()))
+		serviceLogger.Info("Service initialized", log.Int("some-int-value", 12), log.BlockHeight(primitives.BlockHeight(9999)), log.Bytes("bytes", []byte{2, 3, 99}), log.Stringable("vchainId", primitives.VirtualChainId(123)))
 	})
 
 	fmt.Println(stdout)
@@ -192,9 +192,9 @@ func TestCustomLogFormatter(t *testing.T) {
 	Expect(stdout).To(ContainSubstring("vchainId=7b"))
 	Expect(stdout).To(ContainSubstring("bytes=gDp"))
 	Expect(stdout).To(ContainSubstring("some-int-value=12"))
-	Expect(stdout).To(ContainSubstring("function=instrumentation_test.TestCustomLogFormatter.func1"))
+	Expect(stdout).To(ContainSubstring("function=log_test.TestCustomLogFormatter.func1"))
 	Expect(stdout).To(ContainSubstring("source="))
-	Expect(stdout).To(ContainSubstring("instrumentation/basic_logger_test.go"))
+	Expect(stdout).To(ContainSubstring("log/basic_logger_test.go"))
 }
 
 func TestMultipleOutputs(t *testing.T) {
@@ -206,7 +206,7 @@ func TestMultipleOutputs(t *testing.T) {
 	fileOutput, _ := os.Create(filename)
 
 	stdout := captureStdout(func(writer io.Writer) {
-		serviceLogger := instrumentation.GetLogger(instrumentation.Node("node1"), instrumentation.Service("public-api")).WithOutput(instrumentation.NewOutput(writer), instrumentation.NewOutput(fileOutput))
+		serviceLogger := log.GetLogger(log.Node("node1"), log.Service("public-api")).WithOutput(log.NewOutput(writer), log.NewOutput(fileOutput))
 		serviceLogger.Info("Service initialized")
 	})
 
@@ -229,7 +229,7 @@ func TestMultipleOutputsForMemoryViolationByHumanReadable(t *testing.T) {
 
 	Expect(func() {
 		captureStdout(func(writer io.Writer) {
-			serviceLogger := instrumentation.GetLogger(instrumentation.Node("node1"), instrumentation.Service("public-api")).WithOutput(instrumentation.NewOutput(writer).WithFormatter(instrumentation.NewHumanReadableFormatter()), instrumentation.NewOutput(fileOutput))
+			serviceLogger := log.GetLogger(log.Node("node1"), log.Service("public-api")).WithOutput(log.NewOutput(writer).WithFormatter(log.NewHumanReadableFormatter()), log.NewOutput(fileOutput))
 			serviceLogger.Info("Service initialized")
 		})
 	}).NotTo(Panic())
@@ -241,7 +241,7 @@ func checkOutput(output string) {
 	Expect(jsonMap["level"]).To(Equal("info"))
 	Expect(jsonMap["node"]).To(Equal("node1"))
 	Expect(jsonMap["service"]).To(Equal("public-api"))
-	Expect(jsonMap["function"]).To(Equal("instrumentation_test.TestMultipleOutputs.func1"))
+	Expect(jsonMap["function"]).To(Equal("log_test.TestMultipleOutputs.func1"))
 	Expect(jsonMap["message"]).To(Equal("Service initialized"))
 	Expect(jsonMap["source"]).NotTo(BeEmpty())
 	Expect(jsonMap["timestamp"]).NotTo(BeNil())

--- a/instrumentation/log/basic_meter.go
+++ b/instrumentation/log/basic_meter.go
@@ -1,4 +1,4 @@
-package instrumentation
+package log
 
 import (
 	"fmt"

--- a/instrumentation/log/basic_output.go
+++ b/instrumentation/log/basic_output.go
@@ -1,4 +1,4 @@
-package instrumentation
+package log
 
 import "io"
 

--- a/instrumentation/log/formatters.go
+++ b/instrumentation/log/formatters.go
@@ -1,4 +1,4 @@
-package instrumentation
+package log
 
 import (
 	"encoding/json"

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"github.com/orbs-network/orbs-network-go/bootstrap"
 	"github.com/orbs-network/orbs-network-go/config"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	gossipAdapter "github.com/orbs-network/orbs-network-go/services/gossip/adapter"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
 	"os"
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-func getLogger(path string) instrumentation.BasicLogger {
+func getLogger(path string) log.BasicLogger {
 	if path == "" {
 		path = "./orbs-network.log"
 	}
@@ -22,10 +22,10 @@ func getLogger(path string) instrumentation.BasicLogger {
 		panic(err)
 	}
 
-	stdoutOutput := instrumentation.NewOutput(os.Stdout).WithFormatter(instrumentation.NewHumanReadableFormatter())
-	fileOutput := instrumentation.NewOutput(logFile)
+	stdoutOutput := log.NewOutput(os.Stdout).WithFormatter(log.NewHumanReadableFormatter())
+	fileOutput := log.NewOutput(logFile)
 
-	return instrumentation.GetLogger().WithOutput(stdoutOutput, fileOutput)
+	return log.GetLogger().WithOutput(stdoutOutput, fileOutput)
 }
 
 func main() {

--- a/services/blockstorage/service.go
+++ b/services/blockstorage/service.go
@@ -3,7 +3,7 @@ package blockstorage
 import (
 	"fmt"
 	"github.com/orbs-network/orbs-network-go/crypto/bloom"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/blockstorage/adapter"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
@@ -33,18 +33,18 @@ type service struct {
 
 	config Config
 
-	reporting               instrumentation.BasicLogger
+	reporting               log.BasicLogger
 	consensusBlocksHandlers []handlers.ConsensusBlocksHandler
 
 	lastCommittedBlock *protocol.BlockPairContainer
 	lastBlockLock      *sync.Mutex
 }
 
-func NewBlockStorage(config Config, persistence adapter.BlockPersistence, stateStorage services.StateStorage, reporting instrumentation.BasicLogger) services.BlockStorage {
+func NewBlockStorage(config Config, persistence adapter.BlockPersistence, stateStorage services.StateStorage, reporting log.BasicLogger) services.BlockStorage {
 	return &service{
 		persistence:   persistence,
 		stateStorage:  stateStorage,
-		reporting:     reporting.For(instrumentation.Service("block-storage")),
+		reporting:     reporting.For(log.Service("block-storage")),
 		config:        config,
 		lastBlockLock: &sync.Mutex{},
 	}
@@ -52,7 +52,7 @@ func NewBlockStorage(config Config, persistence adapter.BlockPersistence, stateS
 
 func (s *service) CommitBlock(input *services.CommitBlockInput) (*services.CommitBlockOutput, error) {
 	txBlockHeader := input.BlockPair.TransactionsBlock.Header
-	s.reporting.Info("Trying to commit a block", instrumentation.BlockHeight(txBlockHeader.BlockHeight()))
+	s.reporting.Info("Trying to commit a block", log.BlockHeight(txBlockHeader.BlockHeight()))
 
 	if err := s.validateProtocolVersion(input.BlockPair); err != nil {
 		return nil, err
@@ -73,11 +73,11 @@ func (s *service) CommitBlock(input *services.CommitBlockInput) (*services.Commi
 
 	s.updateLastCommittedBlock(input.BlockPair)
 
-	s.reporting.Info("Committed a block", instrumentation.BlockHeight(txBlockHeader.BlockHeight()))
+	s.reporting.Info("Committed a block", log.BlockHeight(txBlockHeader.BlockHeight()))
 
 	if err := s.syncBlockToStateStorage(input.BlockPair); err != nil {
 		// TODO: since the intra-node sync flow is self healing, we should not fail the entire commit if state storage is slow to sync
-		s.reporting.Error("intra-node sync to state storage failed", instrumentation.Error(err))
+		s.reporting.Error("intra-node sync to state storage failed", log.Error(err))
 	}
 
 	return nil, nil
@@ -270,11 +270,11 @@ func (s *service) validateBlockDoesNotExist(txBlockHeader *protocol.Transactions
 	if txBlockHeader.BlockHeight() <= currentBlockHeight {
 		if txBlockHeader.BlockHeight() == currentBlockHeight && txBlockHeader.Timestamp() != s.lastCommittedBlockTimestamp() {
 			errorMessage := "block already in storage, timestamp mismatch"
-			s.reporting.Error(errorMessage, instrumentation.BlockHeight(currentBlockHeight))
+			s.reporting.Error(errorMessage, log.BlockHeight(currentBlockHeight))
 			return false, errors.New(errorMessage)
 		}
 
-		s.reporting.Info("block already in storage, skipping", instrumentation.BlockHeight(currentBlockHeight))
+		s.reporting.Info("block already in storage, skipping", log.BlockHeight(currentBlockHeight))
 		return false, nil
 	}
 
@@ -305,13 +305,13 @@ func (s *service) validateProtocolVersion(blockPair *protocol.BlockPairContainer
 	// FIXME we may be logging twice, this should be fixed when handling the logging structured errors in logger issue
 	if txBlockHeader.ProtocolVersion() != ProtocolVersion {
 		errorMessage := "protocol version mismatch"
-		s.reporting.Error(errorMessage, instrumentation.String("expected", "1"), instrumentation.Stringable("received", txBlockHeader.ProtocolVersion()))
+		s.reporting.Error(errorMessage, log.String("expected", "1"), log.Stringable("received", txBlockHeader.ProtocolVersion()))
 		return fmt.Errorf(errorMessage)
 	}
 
 	if rsBlockHeader.ProtocolVersion() != ProtocolVersion {
 		errorMessage := "protocol version mismatch"
-		s.reporting.Error(errorMessage, instrumentation.String("expected", "1"), instrumentation.Stringable("received", txBlockHeader.ProtocolVersion()))
+		s.reporting.Error(errorMessage, log.String("expected", "1"), log.Stringable("received", txBlockHeader.ProtocolVersion()))
 		return fmt.Errorf(errorMessage)
 	}
 

--- a/services/blockstorage/test/harness.go
+++ b/services/blockstorage/test/harness.go
@@ -3,7 +3,7 @@ package test
 import (
 	"github.com/orbs-network/go-mock"
 	"github.com/orbs-network/orbs-network-go/config"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/blockstorage"
 	"github.com/orbs-network/orbs-network-go/test/harness/services/blockstorage/adapter"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
@@ -58,7 +58,7 @@ func NewDriver() *driver {
 	d := &driver{}
 	d.stateStorage = &services.MockStateStorage{}
 	d.storageAdapter = adapter.NewInMemoryBlockPersistence()
-	d.blockStorage = blockstorage.NewBlockStorage(config.NewBlockStorageConfig(70, 5, 5, 30*60), d.storageAdapter, d.stateStorage, instrumentation.GetLogger())
+	d.blockStorage = blockstorage.NewBlockStorage(config.NewBlockStorageConfig(70, 5, 5, 30*60), d.storageAdapter, d.stateStorage, log.GetLogger())
 
 	return d
 }

--- a/services/consensusalgo/benchmarkconsensus/common.go
+++ b/services/consensusalgo/benchmarkconsensus/common.go
@@ -4,7 +4,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/crypto/digest"
 	"github.com/orbs-network/orbs-network-go/crypto/logic"
 	"github.com/orbs-network/orbs-network-go/crypto/signature"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
@@ -27,7 +27,7 @@ func (s *service) saveToBlockStorage(blockPair *protocol.BlockPairContainer) err
 	if blockPair.TransactionsBlock.Header.BlockHeight() == 0 {
 		return nil
 	}
-	s.reporting.Info("saving block to storage", instrumentation.BlockHeight(blockPair.TransactionsBlock.Header.BlockHeight()))
+	s.reporting.Info("saving block to storage", log.BlockHeight(blockPair.TransactionsBlock.Header.BlockHeight()))
 	_, err := s.blockStorage.CommitBlock(&services.CommitBlockInput{
 		BlockPair: blockPair,
 	})

--- a/services/consensusalgo/benchmarkconsensus/leader.go
+++ b/services/consensusalgo/benchmarkconsensus/leader.go
@@ -5,7 +5,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/crypto/digest"
 	"github.com/orbs-network/orbs-network-go/crypto/hash"
 	"github.com/orbs-network/orbs-network-go/crypto/signature"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
@@ -27,7 +27,7 @@ func (s *service) leaderConsensusRoundRunLoop(ctx context.Context) {
 			s.reporting.Info("consensus round run loop terminating with context")
 			return
 		case s.lastSuccessfullyVotedBlock = <-s.successfullyVotedBlocks:
-			s.reporting.Info("consensus round waking up after successfully voted block", instrumentation.BlockHeight(s.lastSuccessfullyVotedBlock))
+			s.reporting.Info("consensus round waking up after successfully voted block", log.BlockHeight(s.lastSuccessfullyVotedBlock))
 			continue
 		case <-time.After(time.Duration(s.config.BenchmarkConsensusRoundRetryIntervalMillis()) * time.Millisecond):
 			s.reporting.Info("consensus round waking up after retry timeout")
@@ -84,14 +84,14 @@ func (s *service) leaderGenerateGenesisBlock() *protocol.BlockPairContainer {
 	}
 	blockPair, err := s.leaderSignBlockProposal(transactionsBlock, resultsBlock)
 	if err != nil {
-		s.reporting.Error("leader failed to sign genesis block", instrumentation.Error(err))
+		s.reporting.Error("leader failed to sign genesis block", log.Error(err))
 		return nil
 	}
 	return blockPair
 }
 
 func (s *service) leaderGenerateNewProposedBlockUnderMutex() (*protocol.BlockPairContainer, error) {
-	s.reporting.Info("generating new proposed block for height", instrumentation.BlockHeight(s.lastCommittedBlockHeight()+1))
+	s.reporting.Info("generating new proposed block for height", log.BlockHeight(s.lastCommittedBlockHeight()+1))
 
 	// get tx
 	txOutput, err := s.consensusContext.RequestNewTransactionsBlock(&services.RequestNewTransactionsBlockInput{
@@ -163,7 +163,7 @@ func (s *service) leaderHandleCommittedVote(sender *gossipmessages.SenderSignatu
 	// validate the vote
 	err := s.leaderValidateVoteUnderMutex(sender, status)
 	if err != nil {
-		s.reporting.Error("leader failed to validate vote", instrumentation.Error(err))
+		s.reporting.Error("leader failed to validate vote", log.Error(err))
 		return
 	}
 
@@ -172,7 +172,7 @@ func (s *service) leaderHandleCommittedVote(sender *gossipmessages.SenderSignatu
 
 	// count if we have enough votes to move forward
 	existingVotes := len(s.lastCommittedBlockVoters) + 1
-	s.reporting.Info("valid vote arrived", instrumentation.Int("existing-votes", existingVotes), instrumentation.Int("required-votes", s.requiredQuorumSize()))
+	s.reporting.Info("valid vote arrived", log.Int("existing-votes", existingVotes), log.Int("required-votes", s.requiredQuorumSize()))
 	if existingVotes >= s.requiredQuorumSize() {
 		successfullyVotedBlock = s.lastCommittedBlockHeight()
 	}

--- a/services/consensusalgo/benchmarkconsensus/non_leader.go
+++ b/services/consensusalgo/benchmarkconsensus/non_leader.go
@@ -3,7 +3,7 @@ package benchmarkconsensus
 import (
 	"github.com/orbs-network/orbs-network-go/crypto/hash"
 	"github.com/orbs-network/orbs-network-go/crypto/signature"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 	"github.com/orbs-network/orbs-spec/types/go/services/gossiptopics"
@@ -16,12 +16,12 @@ func (s *service) nonLeaderHandleCommit(blockPair *protocol.BlockPairContainer) 
 
 	err := s.nonLeaderValidateBlockUnderMutex(blockPair)
 	if err != nil {
-		s.reporting.Error("non leader failed to validate block", instrumentation.Error(err))
+		s.reporting.Error("non leader failed to validate block", log.Error(err))
 		return
 	}
 	err = s.nonLeaderCommitAndReplyUnderMutex(blockPair)
 	if err != nil {
-		s.reporting.Error("non leader failed to commit and reply vote", instrumentation.Error(err))
+		s.reporting.Error("non leader failed to commit and reply vote", log.Error(err))
 		return
 	}
 }
@@ -83,7 +83,7 @@ func (s *service) nonLeaderCommitAndReplyUnderMutex(blockPair *protocol.BlockPai
 
 	// send committed back to leader via gossip
 	recipient := blockPair.ResultsBlock.BlockProof.BenchmarkConsensus().Sender().SenderPublicKey()
-	s.reporting.Info("replying committed with last committed height", instrumentation.BlockHeight(s.lastCommittedBlockHeight()), instrumentation.Stringable("signed-data", signedData))
+	s.reporting.Info("replying committed with last committed height", log.BlockHeight(s.lastCommittedBlockHeight()), log.Stringable("signed-data", signedData))
 	_, err = s.gossip.SendBenchmarkConsensusCommitted(&gossiptopics.BenchmarkConsensusCommittedInput{
 		RecipientPublicKey: recipient,
 		Message:            message,

--- a/services/consensusalgo/benchmarkconsensus/service.go
+++ b/services/consensusalgo/benchmarkconsensus/service.go
@@ -3,7 +3,7 @@ package benchmarkconsensus
 import (
 	"context"
 	"github.com/orbs-network/orbs-network-go/config"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
@@ -30,7 +30,7 @@ type service struct {
 	gossip           gossiptopics.BenchmarkConsensus
 	blockStorage     services.BlockStorage
 	consensusContext services.ConsensusContext
-	reporting        instrumentation.BasicLogger
+	reporting        log.BasicLogger
 	config           Config
 
 	isLeader           bool
@@ -48,7 +48,7 @@ func NewBenchmarkConsensusAlgo(
 	gossip gossiptopics.BenchmarkConsensus,
 	blockStorage services.BlockStorage,
 	consensusContext services.ConsensusContext,
-	reporting instrumentation.BasicLogger,
+	reporting log.BasicLogger,
 	config Config,
 ) services.ConsensusAlgoBenchmark {
 
@@ -56,7 +56,7 @@ func NewBenchmarkConsensusAlgo(
 		gossip:           gossip,
 		blockStorage:     blockStorage,
 		consensusContext: consensusContext,
-		reporting:        reporting.For(instrumentation.Service("consensus-algo-benchmark")),
+		reporting:        reporting.For(log.Service("consensus-algo-benchmark")),
 		config:           config,
 
 		isLeader: config.ConstantConsensusLeader().Equal(config.NodePublicKey()),

--- a/services/consensusalgo/benchmarkconsensus/test/harness.go
+++ b/services/consensusalgo/benchmarkconsensus/test/harness.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/orbs-network/go-mock"
 	"github.com/orbs-network/orbs-network-go/config"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/consensusalgo/benchmarkconsensus"
 	"github.com/orbs-network/orbs-network-go/test/crypto/keys"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
@@ -22,7 +22,7 @@ type harness struct {
 	gossip           *gossiptopics.MockBenchmarkConsensus
 	blockStorage     *services.MockBlockStorage
 	consensusContext *services.MockConsensusContext
-	reporting        instrumentation.BasicLogger
+	reporting        log.BasicLogger
 	config           benchmarkconsensus.Config
 	service          services.ConsensusAlgoBenchmark
 }
@@ -63,7 +63,7 @@ func newHarness(
 		5,
 	)
 
-	log := instrumentation.GetLogger().WithOutput(instrumentation.NewOutput(os.Stdout).WithFormatter(instrumentation.NewHumanReadableFormatter()))
+	log := log.GetLogger().WithOutput(log.NewOutput(os.Stdout).WithFormatter(log.NewHumanReadableFormatter()))
 
 	gossip := &gossiptopics.MockBenchmarkConsensus{}
 	gossip.When("RegisterBenchmarkConsensusHandler", mock.Any).Return().Times(1)

--- a/services/consensusalgo/leanhelix/algorithm.go
+++ b/services/consensusalgo/leanhelix/algorithm.go
@@ -1,7 +1,7 @@
 package leanhelix
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
@@ -52,7 +52,7 @@ func (s *service) leaderProposeNextBlockIfNeeded() error {
 	s.blocksForRounds[nextBlockHeight] = proposedBlockPair
 	s.blocksForRoundsMutex.Unlock()
 
-	s.reporting.Info("proposed block pair", instrumentation.BlockHeight(nextBlockHeight))
+	s.reporting.Info("proposed block pair", log.BlockHeight(nextBlockHeight))
 
 	return nil
 }
@@ -81,7 +81,7 @@ func (s *service) leaderCollectVotesForBlock(blockPair *protocol.BlockPairContai
 		<-s.votesForActiveRound
 	}
 
-	s.reporting.Info("got the required votes", instrumentation.Int("votes", numOfRequiredVotes))
+	s.reporting.Info("got the required votes", log.Int("votes", numOfRequiredVotes))
 
 	return nil
 }
@@ -93,7 +93,7 @@ func (s *service) validatorVoteForNewBlockProposal(blockPair *protocol.BlockPair
 	s.blocksForRounds[blockHeight] = blockPair
 	s.blocksForRoundsMutex.Unlock()
 
-	s.reporting.Info("voting as validator for block", instrumentation.BlockHeight(blockHeight))
+	s.reporting.Info("voting as validator for block", log.BlockHeight(blockHeight))
 	_, err := s.gossip.SendLeanHelixPrepare(&gossiptopics.LeanHelixPrepareInput{})
 	return err
 }
@@ -116,7 +116,7 @@ func (s *service) commitBlockAndMoveToNextRound() primitives.BlockHeight {
 	s.blocksForRoundsMutex.RUnlock()
 
 	if !found {
-		s.reporting.Error("trying to commit a block that wasn't prepared", instrumentation.BlockHeight(blockHeight))
+		s.reporting.Error("trying to commit a block that wasn't prepared", log.BlockHeight(blockHeight))
 		return s.lastCommittedBlockHeight
 	}
 

--- a/services/consensusalgo/leanhelix/service.go
+++ b/services/consensusalgo/leanhelix/service.go
@@ -1,7 +1,7 @@
 package leanhelix
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
@@ -24,7 +24,7 @@ type service struct {
 	blockStorage     services.BlockStorage
 	transactionPool  services.TransactionPool
 	consensusContext services.ConsensusContext
-	reporting        instrumentation.BasicLogger
+	reporting        log.BasicLogger
 	config           Config
 
 	lastCommittedBlockHeight primitives.BlockHeight
@@ -38,7 +38,7 @@ func NewLeanHelixConsensusAlgo(
 	blockStorage services.BlockStorage,
 	transactionPool services.TransactionPool,
 	consensusContext services.ConsensusContext,
-	reporting instrumentation.BasicLogger,
+	reporting log.BasicLogger,
 	config Config,
 ) services.ConsensusAlgoLeanHelix {
 
@@ -47,7 +47,7 @@ func NewLeanHelixConsensusAlgo(
 		blockStorage:     blockStorage,
 		transactionPool:  transactionPool,
 		consensusContext: consensusContext,
-		reporting:        reporting.For(instrumentation.Service("consensus-algo-lean-helix")),
+		reporting:        reporting.For(log.Service("consensus-algo-lean-helix")),
 		config:           config,
 		lastCommittedBlockHeight: 0, // TODO: improve startup
 		blocksForRounds:          make(map[primitives.BlockHeight]*protocol.BlockPairContainer),
@@ -91,12 +91,12 @@ func (s *service) HandleLeanHelixNewView(input *gossiptopics.LeanHelixNewViewInp
 func (s *service) consensusRoundRunLoop() {
 
 	for {
-		s.reporting.Info("entered consensus round with last committed block height", instrumentation.BlockHeight(s.lastCommittedBlockHeight))
+		s.reporting.Info("entered consensus round with last committed block height", log.BlockHeight(s.lastCommittedBlockHeight))
 
 		// see if we need to propose a new block
 		err := s.leaderProposeNextBlockIfNeeded()
 		if err != nil {
-			s.reporting.Error("leader failed to propose next block", instrumentation.Error(err))
+			s.reporting.Error("leader failed to propose next block", log.Error(err))
 			continue
 		}
 
@@ -107,7 +107,7 @@ func (s *service) consensusRoundRunLoop() {
 		if activeBlock != nil {
 			err := s.leaderCollectVotesForBlock(activeBlock)
 			if err != nil {
-				s.reporting.Error("leader failed to collect votes for block", instrumentation.Error(err))
+				s.reporting.Error("leader failed to collect votes for block", log.Error(err))
 				time.Sleep(10 * time.Millisecond) // TODO: handle network failures with some time of exponential backoff
 				continue
 			}

--- a/services/consensuscontext/service.go
+++ b/services/consensuscontext/service.go
@@ -1,7 +1,7 @@
 package consensuscontext
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/services"
 )
 
@@ -15,7 +15,7 @@ type service struct {
 	virtualMachine  services.VirtualMachine
 	stateStorage    services.StateStorage
 	config          Config
-	reporting       instrumentation.BasicLogger
+	reporting       log.BasicLogger
 }
 
 func NewConsensusContext(
@@ -23,7 +23,7 @@ func NewConsensusContext(
 	virtualMachine services.VirtualMachine,
 	stateStorage services.StateStorage,
 	config Config,
-	reporting instrumentation.BasicLogger,
+	reporting log.BasicLogger,
 ) services.ConsensusContext {
 
 	return &service{
@@ -31,7 +31,7 @@ func NewConsensusContext(
 		virtualMachine:  virtualMachine,
 		stateStorage:    stateStorage,
 		config:          config,
-		reporting:       reporting.For(instrumentation.Service("consensus-context")),
+		reporting:       reporting.For(log.Service("consensus-context")),
 	}
 }
 
@@ -41,7 +41,7 @@ func (s *service) RequestNewTransactionsBlock(input *services.RequestNewTransact
 		return nil, err
 	}
 
-	s.reporting.Info("created Transactions block", instrumentation.Int("num-transactions", len(txBlock.SignedTransactions)), instrumentation.Stringable("transactions-block", txBlock))
+	s.reporting.Info("created Transactions block", log.Int("num-transactions", len(txBlock.SignedTransactions)), log.Stringable("transactions-block", txBlock))
 
 	return &services.RequestNewTransactionsBlockOutput{
 		TransactionsBlock: txBlock,
@@ -54,7 +54,7 @@ func (s *service) RequestNewResultsBlock(input *services.RequestNewResultsBlockI
 		return nil, err
 	}
 
-	s.reporting.Info("created Results block", instrumentation.Stringable("results-block", rxBlock))
+	s.reporting.Info("created Results block", log.Stringable("results-block", rxBlock))
 
 	return &services.RequestNewResultsBlockOutput{
 		ResultsBlock: rxBlock,

--- a/services/consensuscontext/test/harness.go
+++ b/services/consensuscontext/test/harness.go
@@ -4,7 +4,7 @@ import (
 	"github.com/orbs-network/go-mock"
 	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/crypto/hash"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/consensuscontext"
 	"github.com/orbs-network/orbs-network-go/test/builders"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
@@ -16,7 +16,7 @@ import (
 
 type harness struct {
 	transactionPool *services.MockTransactionPool
-	reporting       instrumentation.BasicLogger
+	reporting       log.BasicLogger
 	service         services.ConsensusContext
 	config          consensuscontext.Config
 }
@@ -59,7 +59,7 @@ func (h *harness) verifyTransactionsRequestedFromTransactionPool(t *testing.T) {
 }
 
 func newHarness() *harness {
-	log := instrumentation.GetLogger().WithOutput(instrumentation.NewOutput(os.Stdout).WithFormatter(instrumentation.NewHumanReadableFormatter()))
+	log := log.GetLogger().WithOutput(log.NewOutput(os.Stdout).WithFormatter(log.NewHumanReadableFormatter()))
 
 	transactionPool := &services.MockTransactionPool{}
 

--- a/services/gossip/codec.go
+++ b/services/gossip/codec.go
@@ -1,7 +1,7 @@
 package gossip
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/pkg/errors"
 )
@@ -10,7 +10,7 @@ const NUM_HARDCODED_PAYLOADS_FOR_BLOCK_PAIR = 5 // txHeader, txMetadata, rxHeade
 
 func encodeBlockPair(blockPair *protocol.BlockPairContainer) ([][]byte, error) {
 	if blockPair == nil || blockPair.TransactionsBlock == nil || blockPair.ResultsBlock == nil {
-		return nil, errors.Errorf("codec failed to encode block pair due to missing fields", instrumentation.Stringable("block-pair", blockPair))
+		return nil, errors.Errorf("codec failed to encode block pair due to missing fields", log.Stringable("block-pair", blockPair))
 	}
 
 	payloads := make([][]byte, 0, NUM_HARDCODED_PAYLOADS_FOR_BLOCK_PAIR+
@@ -24,7 +24,7 @@ func encodeBlockPair(blockPair *protocol.BlockPairContainer) ([][]byte, error) {
 		blockPair.TransactionsBlock.BlockProof == nil ||
 		blockPair.ResultsBlock.Header == nil ||
 		blockPair.ResultsBlock.BlockProof == nil {
-		return nil, errors.Errorf("codec failed to encode block pair due to missing fields", instrumentation.Stringable("block-pair", blockPair))
+		return nil, errors.Errorf("codec failed to encode block pair due to missing fields", log.Stringable("block-pair", blockPair))
 	}
 
 	payloads = append(payloads, blockPair.TransactionsBlock.Header.Raw())
@@ -49,7 +49,7 @@ func encodeBlockPair(blockPair *protocol.BlockPairContainer) ([][]byte, error) {
 
 func decodeBlockPair(payloads [][]byte) (*protocol.BlockPairContainer, error) {
 	if len(payloads) < NUM_HARDCODED_PAYLOADS_FOR_BLOCK_PAIR {
-		return nil, errors.Errorf("codec failed to decode block pair due to missing payloads", instrumentation.Int("num-payloads", len(payloads)))
+		return nil, errors.Errorf("codec failed to decode block pair due to missing payloads", log.Int("num-payloads", len(payloads)))
 	}
 
 	txBlockHeader := protocol.TransactionsBlockHeaderReader(payloads[0])
@@ -61,7 +61,7 @@ func decodeBlockPair(payloads [][]byte) (*protocol.BlockPairContainer, error) {
 
 	expectedPayloads := NUM_HARDCODED_PAYLOADS_FOR_BLOCK_PAIR + txBlockHeader.NumSignedTransactions() + rxBlockHeader.NumTransactionReceipts() + rxBlockHeader.NumContractStateDiffs()
 	if uint32(len(payloads)) < expectedPayloads {
-		return nil, errors.Errorf("codec failed to decode block pair due to missing payloads", instrumentation.Int("num-payloads", len(payloads)), instrumentation.Uint32("expected-payloads", expectedPayloads))
+		return nil, errors.Errorf("codec failed to decode block pair due to missing payloads", log.Int("num-payloads", len(payloads)), log.Uint32("expected-payloads", expectedPayloads))
 	}
 
 	txs := make([]*protocol.SignedTransaction, 0, txBlockHeader.NumSignedTransactions())

--- a/services/gossip/topic_benchmark_consensus.go
+++ b/services/gossip/topic_benchmark_consensus.go
@@ -1,7 +1,7 @@
 package gossip
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
@@ -67,7 +67,7 @@ func (s *service) SendBenchmarkConsensusCommitted(input *gossiptopics.BenchmarkC
 	}).Build()
 
 	if input.Message.Status == nil {
-		return nil, errors.Errorf("cannot encode BenchmarkConsensusCommittedMessage", instrumentation.Stringable("message", input.Message))
+		return nil, errors.Errorf("cannot encode BenchmarkConsensusCommittedMessage", log.Stringable("message", input.Message))
 	}
 	payloads := [][]byte{header.Raw(), input.Message.Status.Raw(), input.Message.Sender.Raw()}
 

--- a/services/gossip/topic_lean_helix.go
+++ b/services/gossip/topic_lean_helix.go
@@ -1,7 +1,7 @@
 package gossip
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
@@ -36,7 +36,7 @@ func (s *service) SendLeanHelixPrePrepare(input *gossiptopics.LeanHelixPrePrepar
 		return nil, err
 	}
 	if input.Message.SignedHeader == nil || input.Message.Sender == nil {
-		return nil, errors.Errorf("cannot encode LeanHelixPrePrepareMessage", instrumentation.Stringable("message", input.Message))
+		return nil, errors.Errorf("cannot encode LeanHelixPrePrepareMessage", log.Stringable("message", input.Message))
 	}
 	payloads := append([][]byte{header.Raw(), input.Message.SignedHeader.Raw(), input.Message.Sender.Raw()}, blockPairPayloads...)
 

--- a/services/processor/native/call.go
+++ b/services/processor/native/call.go
@@ -1,7 +1,7 @@
 package native
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/processor/native/repository"
 	"github.com/orbs-network/orbs-network-go/services/processor/native/types"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
@@ -67,7 +67,7 @@ func (s *service) processMethodCall(ctx types.Context, contractInfo *types.Contr
 	}
 
 	// execute the call
-	s.reporting.Info("processor executing contract", instrumentation.Stringable("contract", contractInfo.Name), instrumentation.Stringable("method", methodInfo.Name))
+	s.reporting.Info("processor executing contract", log.Stringable("contract", contractInfo.Name), log.Stringable("method", methodInfo.Name))
 	contractValue := reflect.ValueOf(s.contractRepository[contractInfo.Name])
 	contextValue := reflect.ValueOf(ctx)
 	inValues := append([]reflect.Value{contractValue, contextValue}, argValues...)

--- a/services/processor/native/service.go
+++ b/services/processor/native/service.go
@@ -1,7 +1,7 @@
 package native
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/processor/native/repository"
 	"github.com/orbs-network/orbs-network-go/services/processor/native/types"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
@@ -12,16 +12,16 @@ import (
 )
 
 type service struct {
-	reporting instrumentation.BasicLogger
+	reporting log.BasicLogger
 
 	contractRepository map[primitives.ContractName]types.Contract
 }
 
 func NewNativeProcessor(
-	reporting instrumentation.BasicLogger,
+	reporting log.BasicLogger,
 ) services.Processor {
 	return &service{
-		reporting: reporting.For(instrumentation.Service("processor-native")),
+		reporting: reporting.For(log.Service("processor-native")),
 	}
 }
 

--- a/services/processor/native/test/harness.go
+++ b/services/processor/native/test/harness.go
@@ -2,7 +2,7 @@ package test
 
 import (
 	"github.com/orbs-network/go-mock"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/processor/native"
 	"github.com/orbs-network/orbs-network-go/test/builders"
 	"github.com/orbs-network/orbs-spec/types/go/services"
@@ -18,7 +18,7 @@ type harness struct {
 }
 
 func newHarness() *harness {
-	log := instrumentation.GetLogger().WithOutput(instrumentation.NewOutput(os.Stdout).WithFormatter(instrumentation.NewHumanReadableFormatter()))
+	log := log.GetLogger().WithOutput(log.NewOutput(os.Stdout).WithFormatter(log.NewHumanReadableFormatter()))
 
 	sdkCallHandler := &handlers.MockContractSdkCallHandler{}
 

--- a/services/publicapi/service.go
+++ b/services/publicapi/service.go
@@ -2,7 +2,7 @@ package publicapi
 
 import (
 	"github.com/orbs-network/orbs-network-go/crypto/digest"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/client"
 	"github.com/orbs-network/orbs-spec/types/go/services"
@@ -12,19 +12,19 @@ import (
 type service struct {
 	transactionPool services.TransactionPool
 	virtualMachine  services.VirtualMachine
-	reporting       instrumentation.BasicLogger
+	reporting       log.BasicLogger
 }
 
 func NewPublicApi(
 	transactionPool services.TransactionPool,
 	virtualMachine services.VirtualMachine,
-	reporting instrumentation.BasicLogger,
+	reporting log.BasicLogger,
 ) services.PublicApi {
 
 	return &service{
 		transactionPool: transactionPool,
 		virtualMachine:  virtualMachine,
-		reporting:       reporting.For(instrumentation.Service("public-api")),
+		reporting:       reporting.For(log.Service("public-api")),
 	}
 }
 

--- a/services/transactionpool/add_new_transaction.go
+++ b/services/transactionpool/add_new_transaction.go
@@ -1,7 +1,7 @@
 package transactionpool
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 	"github.com/orbs-network/orbs-spec/types/go/services"
@@ -13,7 +13,7 @@ func (s *service) AddNewTransaction(input *services.AddNewTransactionInput) (*se
 
 	err := s.createValidationContext().validateTransaction(input.SignedTransaction)
 	if err != nil {
-		s.log.Info("transaction is invalid", instrumentation.Error(err), instrumentation.Stringable("transaction", input.SignedTransaction))
+		s.logger.Info("transaction is invalid", log.Error(err), log.Stringable("transaction", input.SignedTransaction))
 		return s.addTransactionOutputFor(nil, err.(*ErrTransactionRejected).TransactionStatus), err
 	}
 
@@ -22,7 +22,7 @@ func (s *service) AddNewTransaction(input *services.AddNewTransactionInput) (*se
 	}
 
 	if alreadyCommitted := s.committedPool.get(input.SignedTransaction); alreadyCommitted != nil {
-		s.log.Info("transaction already committed", instrumentation.Stringable("transaction", input.SignedTransaction))
+		s.logger.Info("transaction already committed", log.Stringable("transaction", input.SignedTransaction))
 		return s.addTransactionOutputFor(alreadyCommitted.receipt, protocol.TRANSACTION_STATUS_DUPLCIATE_TRANSACTION_ALREADY_COMMITTED), nil
 	}
 
@@ -30,9 +30,9 @@ func (s *service) AddNewTransaction(input *services.AddNewTransactionInput) (*se
 		return s.addTransactionOutputFor(nil, protocol.TRANSACTION_STATUS_REJECTED_SMART_CONTRACT_PRE_ORDER), err
 	}
 
-	s.log.Info("adding new transaction to the pool", instrumentation.Stringable("transaction", input.SignedTransaction))
+	s.logger.Info("adding new transaction to the pool", log.Stringable("transaction", input.SignedTransaction))
 	if _, err := s.pendingPool.add(input.SignedTransaction, s.config.NodePublicKey()); err != nil {
-		s.log.Error("error adding transaction to pending pool", instrumentation.Error(err), instrumentation.Stringable("transaction", input.SignedTransaction))
+		s.logger.Error("error adding transaction to pending pool", log.Error(err), log.Stringable("transaction", input.SignedTransaction))
 		return nil, err
 
 	}

--- a/services/transactionpool/commit_transaction_receipts.go
+++ b/services/transactionpool/commit_transaction_receipts.go
@@ -1,7 +1,7 @@
 package transactionpool
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
@@ -37,7 +37,7 @@ func (s *service) CommitTransactionReceipts(input *services.CommitTransactionRec
 		})
 	}
 
-	s.log.Info("committed transaction receipts for block height", instrumentation.BlockHeight(s.lastCommittedBlockHeight))
+	s.logger.Info("committed transaction receipts for block height", log.BlockHeight(s.lastCommittedBlockHeight))
 
 	return &services.CommitTransactionReceiptsOutput{
 		NextDesiredBlockHeight:   s.lastCommittedBlockHeight + 1,

--- a/services/transactionpool/get_transactions_for_ordering.go
+++ b/services/transactionpool/get_transactions_for_ordering.go
@@ -2,7 +2,7 @@ package transactionpool
 
 import (
 	"github.com/orbs-network/orbs-network-go/crypto/digest"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
 )
@@ -20,13 +20,13 @@ func (s *service) GetTransactionsForOrdering(input *services.GetTransactionsForO
 	transactionsForPreOrder := make([]*protocol.SignedTransaction, 0, input.MaxNumberOfTransactions)
 	for _, tx := range transactions {
 		if err := vctx.validateTransaction(tx); err != nil {
-			s.log.Info("dropping invalid transaction", instrumentation.Error(err), instrumentation.Stringable("transaction", tx))
+			s.logger.Info("dropping invalid transaction", log.Error(err), log.Stringable("transaction", tx))
 		} else {
 			transactionsForPreOrder = append(transactionsForPreOrder, tx)
 		}
 
 		//else if alreadyCommitted := s.committedPool.get(tx); alreadyCommitted != nil {
-		//	s.log.Info("dropping committed transaction", instrumentation.Stringable("transaction", tx))
+		//	s.logger.Info("dropping committed transaction", instrumentation.Stringable("transaction", tx))
 		//}
 
 	}

--- a/services/virtualmachine/execution.go
+++ b/services/virtualmachine/execution.go
@@ -2,7 +2,7 @@ package virtualmachine
 
 import (
 	"github.com/orbs-network/orbs-network-go/crypto/digest"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
@@ -22,7 +22,7 @@ func (s *service) runMethod(
 	// get deployment info
 	processor, contractPermission, err := s.getServiceDeployment(executionContext, transaction.ContractName())
 	if err != nil {
-		s.reporting.Info("get deployment for contract failed", instrumentation.Error(err), instrumentation.Stringable("transaction", transaction))
+		s.reporting.Info("get deployment for contract failed", log.Error(err), log.Stringable("transaction", transaction))
 		return protocol.EXECUTION_RESULT_ERROR_UNEXPECTED, nil, err
 	}
 
@@ -48,7 +48,7 @@ func (s *service) runMethod(
 		TransactionSigner: transaction.Signer(),
 	})
 	if err != nil {
-		s.reporting.Info("transaction execution failed", instrumentation.Stringable("result", output.CallResult), instrumentation.Error(err), instrumentation.Stringable("transaction", transaction))
+		s.reporting.Info("transaction execution failed", log.Stringable("result", output.CallResult), log.Error(err), log.Stringable("transaction", transaction))
 	}
 
 	if batchTransientState != nil && output.CallResult == protocol.EXECUTION_RESULT_SUCCESS {
@@ -71,7 +71,7 @@ func (s *service) processTransactionSet(
 
 	for _, signedTransaction := range signedTransactions {
 
-		s.reporting.Info("processing transaction", instrumentation.Stringable("contract", signedTransaction.Transaction().ContractName()), instrumentation.Stringable("method", signedTransaction.Transaction().MethodName()), instrumentation.BlockHeight(blockHeight))
+		s.reporting.Info("processing transaction", log.Stringable("contract", signedTransaction.Transaction().ContractName()), log.Stringable("method", signedTransaction.Transaction().MethodName()), log.BlockHeight(blockHeight))
 		callResult, outputArgs, _ := s.runMethod(blockHeight, signedTransaction.Transaction(), protocol.ACCESS_SCOPE_READ_WRITE, batchTransientState)
 
 		receipt := s.encodeTransactionReceipt(signedTransaction.Transaction(), callResult, outputArgs)

--- a/services/virtualmachine/sdk_service.go
+++ b/services/virtualmachine/sdk_service.go
@@ -1,7 +1,7 @@
 package virtualmachine
 
 import (
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
@@ -69,7 +69,7 @@ func (s *service) handleSdkServiceCallMethod(context *executionContext, args []*
 		TransactionSigner: nil,
 	})
 	if err != nil {
-		s.reporting.Info("Sdk.Service.CallMethod failed", instrumentation.Error(err), instrumentation.Stringable("caller", callingService), instrumentation.Stringable("callee", primitives.ContractName(serviceName)))
+		s.reporting.Info("Sdk.Service.CallMethod failed", log.Error(err), log.Stringable("caller", callingService), log.Stringable("callee", primitives.ContractName(serviceName)))
 	}
 
 	return err // TODO: support result

--- a/services/virtualmachine/test/harness.go
+++ b/services/virtualmachine/test/harness.go
@@ -3,7 +3,7 @@ package test
 import (
 	"fmt"
 	"github.com/orbs-network/go-mock"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/processor/native/repository/_Deployments"
 	"github.com/orbs-network/orbs-network-go/services/virtualmachine"
 	"github.com/orbs-network/orbs-network-go/test/builders"
@@ -19,12 +19,12 @@ type harness struct {
 	stateStorage         *services.MockStateStorage
 	processors           map[protocol.ProcessorType]*services.MockProcessor
 	crosschainConnectors map[protocol.CrosschainConnectorType]*services.MockCrosschainConnector
-	reporting            instrumentation.BasicLogger
+	reporting            log.BasicLogger
 	service              services.VirtualMachine
 }
 
 func newHarness() *harness {
-	log := instrumentation.GetLogger().WithOutput(instrumentation.NewOutput(os.Stdout).WithFormatter(instrumentation.NewHumanReadableFormatter()))
+	log := log.GetLogger().WithOutput(log.NewOutput(os.Stdout).WithFormatter(log.NewHumanReadableFormatter()))
 
 	blockStorage := &services.MockBlockStorage{}
 	stateStorage := &services.MockStateStorage{}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/orbs-network/membuffers/go"
 	"github.com/orbs-network/orbs-network-go/bootstrap"
 	"github.com/orbs-network/orbs-network-go/config"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/test/builders"
 	"github.com/orbs-network/orbs-network-go/test/crypto/keys"
 	gossipAdapter "github.com/orbs-network/orbs-network-go/test/harness/services/gossip/adapter"
@@ -65,7 +65,7 @@ var _ = Describe("The Orbs Network", func() {
 				federationNodes[nodeKeyPair.PublicKey().KeyForMap()] = config.NewHardCodedFederationNode(nodeKeyPair.PublicKey())
 			}
 
-			logger := instrumentation.GetLogger().WithOutput(instrumentation.NewOutput(os.Stdout).WithFormatter(instrumentation.NewHumanReadableFormatter()))
+			logger := log.GetLogger().WithOutput(log.NewOutput(os.Stdout).WithFormatter(log.NewHumanReadableFormatter()))
 
 			for i := 0; i < 3; i++ {
 				nodeKeyPair := keys.Ed25519KeyPairForTests(i)

--- a/test/harness/network.go
+++ b/test/harness/network.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/orbs-network/orbs-network-go/bootstrap"
 	"github.com/orbs-network/orbs-network-go/config"
-	"github.com/orbs-network/orbs-network-go/instrumentation"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-network-go/test/builders"
 	"github.com/orbs-network/orbs-network-go/test/crypto/keys"
@@ -65,9 +65,9 @@ type networkNode struct {
 
 func NewTestNetwork(ctx context.Context, numNodes uint32, consensusAlgo consensus.ConsensusAlgoType) AcceptanceTestNetwork {
 
-	testLogger := instrumentation.GetLogger().WithOutput(instrumentation.NewOutput(os.Stdout).WithFormatter(instrumentation.NewHumanReadableFormatter()))
+	testLogger := log.GetLogger().WithOutput(log.NewOutput(os.Stdout).WithFormatter(log.NewHumanReadableFormatter()))
 	testLogger.Info("===========================================================================")
-	testLogger.Info("creating acceptance test network", instrumentation.String("consensus", consensusAlgo.String()), instrumentation.Uint32("num-nodes", numNodes))
+	testLogger.Info("creating acceptance test network", log.String("consensus", consensusAlgo.String()), log.Uint32("num-nodes", numNodes))
 	description := fmt.Sprintf("network with %d nodes running %s", numNodes, consensusAlgo)
 
 	sharedTamperingTransport := gossipAdapter.NewTamperingTransport()
@@ -104,7 +104,7 @@ func NewTestNetwork(ctx context.Context, numNodes uint32, consensusAlgo consensu
 			sharedTamperingTransport,
 			nodes[i].blockPersistence,
 			nodes[i].statePersistence,
-			testLogger.For(instrumentation.Node(nodeName)),
+			testLogger.For(log.Node(nodeName)),
 			nodes[i].config,
 		)
 	}
@@ -201,8 +201,8 @@ func (n *acceptanceTestNetwork) CallGetBalance(nodeIndex int) chan uint64 {
 }
 
 func (n *acceptanceTestNetwork) DumpState() {
-	testLogger := instrumentation.GetLogger().WithOutput(instrumentation.NewOutput(os.Stdout).WithFormatter(instrumentation.NewHumanReadableFormatter()))
+	testLogger := log.GetLogger().WithOutput(log.NewOutput(os.Stdout).WithFormatter(log.NewHumanReadableFormatter()))
 	for i := range n.nodes {
-		testLogger.Info("state dump", instrumentation.Int("node", i), instrumentation.String("data", n.nodes[i].statePersistence.Dump()))
+		testLogger.Info("state dump", log.Int("node", i), log.String("data", n.nodes[i].statePersistence.Dump()))
 	}
 }


### PR DESCRIPTION
this touches all services
also, specifically in the harness of the transactionpool there is code the panics and used the built-in logger (log.Panicf) i refactored the code to use our logger and then panic, but it was probably just a placeholder for something that is not fully implemented (and the refactor feels a bit like that as well)

all tests are good with this rename. (and nothing was cached after the rename was done, which means this pr touched everything..)