### PR TITLE
Feature/statestore bulk update

### DIFF
--- a/services/processor/native/repository/BenchmarkToken/contract.go
+++ b/services/processor/native/repository/BenchmarkToken/contract.go
@@ -33,7 +33,7 @@ var METHOD_INIT = types.MethodInfo{
 }
 
 func (c *contract) _init(ctx types.Context) error {
-	return nil
+	return c.State.WriteUint64ByKey(ctx, "total-balance", 0)
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/services/statestorage/adapter/memory_persistence.go
+++ b/services/statestorage/adapter/memory_persistence.go
@@ -21,11 +21,9 @@ type InMemoryStatePersistence struct {
 }
 
 func NewInMemoryStatePersistence() *InMemoryStatePersistence {
-	stateDiffsContract := map[primitives.ContractName]ContractState{primitives.ContractName("BenchmarkToken"): {}}
-
 	return &InMemoryStatePersistence{
-		// TODO remove init with a hard coded contract once deploy/provisioning of contracts exists
-		snapshots:            map[primitives.BlockHeight]StateVersion{primitives.BlockHeight(0): stateDiffsContract},
+		// TODO remove this hard coded init of genesis block state once init flow syncs state storage with block storage
+		snapshots:            map[primitives.BlockHeight]StateVersion{primitives.BlockHeight(0): map[primitives.ContractName]ContractState{}},
 		blockTrackerForTests: synchronization.NewBlockTracker(0, 64000, time.Duration(1*time.Hour)),
 	}
 }

--- a/services/statestorage/merkle/merkle_forest_test.go
+++ b/services/statestorage/merkle/merkle_forest_test.go
@@ -33,7 +33,8 @@ func updateStringEntries(f *Forest, keyValues ...string) TrieId {
 		panic("expected key value pairs")
 	}
 	for i := 0; i < len(keyValues); i = i + 2 {
-		f.updateSingleEntry(keyValues[i], hash.CalcSha256([]byte(keyValues[i+1])))
+		f.roots[f.topRoot+1] = f.updateSingleEntry(f.roots[f.topRoot], keyValues[i], hash.CalcSha256([]byte(keyValues[i+1])))
+		f.topRoot++
 	}
 	return f.topRoot
 }
@@ -122,31 +123,62 @@ func TestAddSingleEntryToEmptyTree(t *testing.T) {
 	getProofRequireHeight(t, f, rootId, "", "bar", 1)
 }
 
+func TestUpdateComplexStateDiffIncrementsTrieIdOnce(t *testing.T) {
+	f := NewForest()
+	originalRoot := f.topRoot
+	contract1Diff := builders.ContractStateDiff().WithContractName("foo1").
+		WithStringRecord("bar1", "baz1").
+		WithStringRecord("bar2", "baz2").
+		Build()
+
+	contract2Diff := builders.ContractStateDiff().WithContractName("foo2").
+		WithStringRecord("bar1", "qux1").
+		WithStringRecord("bar2", "qux1").
+		Build()
+
+	newRoot := f.Update([]*protocol.ContractStateDiff{contract1Diff, contract2Diff})
+
+	require.Equal(t, originalRoot+1, newRoot, "update did not increment TrieId by 1")
+}
+
 func TestProofValidationAfterBatchStateUpdate(t *testing.T) {
 	f := NewForest()
-	diffContract := builders.ContractStateDiff().WithContractName("foo")
-	r1 := diffContract.WithStringRecord("bar1", "baz").Build()
-	k1 := r1.StateDiffsIterator().NextStateDiffs().StringKey()
-	v1 := r1.StateDiffsIterator().NextStateDiffs().StringValue()
-	f.Update([]*protocol.ContractStateDiff{r1})
 
-	diffContract = builders.ContractStateDiff().WithContractName("foo")
-	r2 := diffContract.WithStringRecord("bar2", "qux").Build()
-	k2 := r2.StateDiffsIterator().NextStateDiffs().StringKey()
-	v2 := r2.StateDiffsIterator().NextStateDiffs().StringValue()
+	r1 := builders.ContractStateDiff().WithContractName("foo").
+		WithStringRecord("bar1", "baz").WithStringRecord("shared", "quux1").Build()
+	iterator1 := r1.StateDiffsIterator()
+	bar1 := iterator1.NextStateDiffs()
+	shared1 := iterator1.NextStateDiffs()
+
+	r2 := builders.ContractStateDiff().WithContractName("foo").
+		WithStringRecord("bar2", "qux").WithStringRecord("shared", "quux2").Build()
+	iterator2 := r2.StateDiffsIterator()
+	bar2 := iterator2.NextStateDiffs()
+	shared2 := iterator2.NextStateDiffs()
+
+	f.Update([]*protocol.ContractStateDiff{r1})
 	f.Update([]*protocol.ContractStateDiff{r2})
 
-	proof := getProofRequireHeight(t, f, 1, "foo", k1, 1)
-	verifyProof(t, f, 1, proof, "foo", k1, v1, true)
+	proof := getProofRequireHeight(t, f, 1, "foo", bar1.StringKey(), 2)
+	verifyProof(t, f, 1, proof, "foo", bar1.StringKey(), bar1.StringValue(), true)
 
-	proof = getProofRequireHeight(t, f, 1, "foo", k2, 1)
-	verifyProof(t, f, 1, proof, "foo", k2, v2, false)
+	proof = getProofRequireHeight(t, f, 1, "foo", bar2.StringKey(), 2)
+	verifyProof(t, f, 1, proof, "foo", bar2.StringKey(), bar2.StringValue(), false)
 
-	proof = getProofRequireHeight(t, f, 2, "foo", k2, 2)
-	verifyProof(t, f, 2, proof, "foo", k2, v2, true)
+	proof = getProofRequireHeight(t, f, 2, "foo", bar2.StringKey(), 3)
+	verifyProof(t, f, 2, proof, "foo", bar2.StringKey(), bar2.StringValue(), true)
 
-	proof = getProofRequireHeight(t, f, 2, "foo", k1, 2)
-	verifyProof(t, f, 2, proof, "foo", k1, v1, true)
+	proof = getProofRequireHeight(t, f, 2, "foo", bar1.StringKey(), 3)
+	verifyProof(t, f, 2, proof, "foo", bar1.StringKey(), bar1.StringValue(), true)
+
+	proof = getProofRequireHeight(t, f, 1, "foo", shared1.StringKey(), 2)
+	verifyProof(t, f, 1, proof, "foo", shared1.StringKey(), shared1.StringValue(), true)
+	verifyProof(t, f, 1, proof, "foo", shared1.StringKey(), shared2.StringValue(), false)
+
+	proof = getProofRequireHeight(t, f, 2, "foo", shared2.StringKey(), 2)
+	verifyProof(t, f, 2, proof, "foo", shared2.StringKey(), shared2.StringValue(), true)
+	verifyProof(t, f, 2, proof, "foo", shared2.StringKey(), shared1.StringValue(), false)
+
 }
 
 func TestProofValidationForTwoRevisionsOfSameKey(t *testing.T) {

--- a/services/statestorage/merkle/merkle_forest_test.go
+++ b/services/statestorage/merkle/merkle_forest_test.go
@@ -11,6 +11,23 @@ import (
 	"testing"
 )
 
+//TODO - updateStringEntries should advance TrieId only by one
+
+//TODO - updateStringEntries - the bulk update version (optimize node access)
+//TODO - Work with persistent state adapter + cache where appropriate
+
+//TODO - serialization based on spec (oded)
+//TODO - Radix 16 +/- parity
+//TODO - split branch and node leafs (this can be limited to serialization only)
+//TODO - avoid hashing values of less than 32 bytes ?? Other optimizations (see ethereum)?
+//TODO - what hash functions should be used for values and what functions for node addresses?
+//TODO - should we include full values or just hashes (compare Ethereum)
+//TODO - use hashes of contract names
+
+//TODO - garbage collection
+//TODO - in case uniform key length is enforced - accept a key length in the forest constructor
+//TODO - getProof in bulk ???
+
 func updateStringEntries(f *Forest, keyValues ...string) TrieId {
 	if len(keyValues)%2 != 0 {
 		panic("expected key value pairs")
@@ -346,26 +363,6 @@ func TestRemoveValue_MissingKey(t *testing.T) {
 	require.EqualValues(t, baseHash, hash4, "tree changed after removing missing key")
 }
 
-//TODO - updateStringEntries should advance TrieId only by one
-//TODO - updateStringEntries - the bulk update version (optimize node access)
-//TODO - Radix 16
-//TODO - parity
-//TODO - use hashes of contract names
-//TODO - GetProof - accept an in memory list of cached nodes (to support bulk proof fetch).
-//TODO - serialization based on spec
-//TODO - split branch and node leafs (this can be limited to serializeation only)
-//TODO - accept Node DB object
-//TODO - garbage collection
-//TODO - avoid hashing values of less than 32 bytes
-//TODO - what hash functions should be used for values and what functions for node addresses?
-//TODO - in case save key length is enforced - accept a key length in the forest constructor
-//TODO - Prepare for GC (set values of older nodes to know when they were last valid)
-
-//TODO - change verify and update types to []byte from strings
-
-// Debug helpers
-// TODO - we don't use any of these. but they are useful for debugging
-
 func TestOrderOfAdditionsDoesNotMatter(t *testing.T) {
 	keyValue := []string{"bar", "baz", "bar123", "qux", "bar1234", "quux", "bad", "foo", "bank", "hello"}
 	var1 := []int{2, 6, 0, 8, 4}
@@ -400,6 +397,10 @@ func TestOrderOfAdditionsDoesNotMatter(t *testing.T) {
 	require.Equal(t, len(proof2), len(proof3), "unexpected different tree depth / proof lengths")
 	require.Equal(t, proof2[3].hash(), proof3[3].hash(), "unexpected different leaf node hash")
 }
+
+// =================
+// Debug helpers
+// =================
 
 func (f *Forest) dump() {
 	fmt.Println("---------------- TRIE BEGIN ------------------")


### PR DESCRIPTION
* support merkle tree modifications for blocks with more than one state diff - keeping treeId in sync with block 

* Moved state initialization for BenchmarkToken to contract _init function