### PR TITLE
return zero value when reading from a non existent contract

### DIFF
--- a/services/processor/native/repository/BenchmarkToken/contract.go
+++ b/services/processor/native/repository/BenchmarkToken/contract.go
@@ -33,7 +33,7 @@ var METHOD_INIT = types.MethodInfo{
 }
 
 func (c *contract) _init(ctx types.Context) error {
-	return c.State.WriteUint64ByKey(ctx, "total-balance", 0)
+	return nil
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/services/statestorage/adapter/memory_persistence.go
+++ b/services/statestorage/adapter/memory_persistence.go
@@ -77,11 +77,7 @@ func (sp *InMemoryStatePersistence) cloneCurrentStateDiff(height primitives.Bloc
 
 func (sp *InMemoryStatePersistence) ReadState(height primitives.BlockHeight, contract primitives.ContractName) (map[string]*protocol.StateRecord, error) {
 	if stateAtHeight, ok := sp.snapshots[height]; ok {
-		if contractStateDiff, ok := stateAtHeight[contract]; ok {
-			return contractStateDiff, nil
-		} else {
-			return nil, errors.Errorf("contract %v does not exist", contract)
-		}
+		return stateAtHeight[contract], nil
 	} else {
 		return nil, errors.Errorf("block %v does not exist in snapshot history", height)
 	}

--- a/services/statestorage/adapter/memory_persistence_test.go
+++ b/services/statestorage/adapter/memory_persistence_test.go
@@ -16,7 +16,7 @@ func TestReadStateWithNonExistingBlockHeight(t *testing.T) {
 func TestReadStateWithNonExistingContractName(t *testing.T) {
 	d := NewInMemoryStatePersistence()
 	_, err := d.ReadState(0, "foo")
-	require.EqualError(t, err, "contract foo does not exist", "did not fail with error")
+	require.NoError(t, err, "unexpected error")
 }
 
 func TestWriteStateAddAndRemoveKeyFromPersistentStorage(t *testing.T) {


### PR DESCRIPTION
return zero value when reading from a non existent contract.

removes the need to initialize contract state explicitly