### PR TITLE
Add ability to trace transactions

### DIFF
--- a/devtools/jsonapi/main/main.go
+++ b/devtools/jsonapi/main/main.go
@@ -57,7 +57,7 @@ func main() {
 
 		result, _ := jsonapi.SendTransaction(tx, keyPair, *apiEndpointPtr, *verbosePtr)
 
-		jsonBytes, _ := json.Marshal(result.TransactionReceipt)
+		jsonBytes, _ := json.Marshal(result)
 		fmt.Println(string(jsonBytes))
 	} else if *callMethodPtr != "" {
 		if *verbosePtr {

--- a/devtools/sambusac/test/sambusac_test.go
+++ b/devtools/sambusac/test/sambusac_test.go
@@ -15,10 +15,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type sendTransactionCliResponse struct {
+type txReceipt struct {
 	TxHash          string
 	ExecutionResult int
 	OutputArguments []string
+}
+
+type sendTransactionCliResponse struct {
+	TransactionReceipt txReceipt
+	BlockHeight        int
+	BlockTimestamp     int
 }
 
 type OutputArgumentCliResponse struct {
@@ -111,8 +117,8 @@ func TestSambusacFlow(t *testing.T) {
 	unmarshalErr := json.Unmarshal([]byte(sendCommandOutput), &response)
 
 	require.NoError(t, unmarshalErr, "error unmarshal cli response")
-	require.Equal(t, 1, response.ExecutionResult, "Transaction status to be successful = 1")
-	require.NotNil(t, response.TxHash, "got empty txhash")
+	require.Equal(t, 1, response.TransactionReceipt.ExecutionResult, "Transaction status to be successful = 1")
+	require.NotNil(t, response.TransactionReceipt.TxHash, "got empty txhash")
 
 	getCommand := append(baseCommand, "-call-method", generateGetBalanceJSON())
 

--- a/services/consensuscontext/service.go
+++ b/services/consensuscontext/service.go
@@ -1,6 +1,7 @@
 package consensuscontext
 
 import (
+	"github.com/orbs-network/orbs-network-go/crypto/digest"
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-spec/types/go/services"
 	"time"
@@ -43,6 +44,11 @@ func (s *service) RequestNewTransactionsBlock(input *services.RequestNewTransact
 	}
 
 	s.reporting.Info("created Transactions block", log.Int("num-transactions", len(txBlock.SignedTransactions)), log.Stringable("transactions-block", txBlock))
+
+	for _, tx := range txBlock.SignedTransactions {
+		txHash := digest.CalcTxHash(tx.Transaction())
+		s.reporting.Info("transaction entered transactions block", log.String("flow", "checkpoint"), log.Stringable("txHash", txHash), log.BlockHeight(txBlock.Header.BlockHeight()))
+	}
 
 	return &services.RequestNewTransactionsBlockOutput{
 		TransactionsBlock: txBlock,

--- a/services/transactionpool/add_new_transaction.go
+++ b/services/transactionpool/add_new_transaction.go
@@ -12,31 +12,34 @@ import (
 )
 
 func (s *service) AddNewTransaction(input *services.AddNewTransactionInput) (*services.AddNewTransactionOutput, error) {
+	txHash := digest.CalcTxHash(input.SignedTransaction.Transaction())
+
+	s.logger.Info("adding new transaction to the pool", log.String("flow", "checkpoint"), log.Stringable("transaction", input.SignedTransaction), log.Stringable("txHash", txHash))
 
 	if err := s.createValidationContext().validateTransaction(input.SignedTransaction); err != nil {
-		s.logger.Info("transaction is invalid", log.Error(err), log.Stringable("transaction", input.SignedTransaction))
+		s.logger.Info("transaction is invalid", log.Error(err), log.Stringable("transaction", input.SignedTransaction), log.Stringable("txHash", txHash))
 		return s.addTransactionOutputFor(nil, err.TransactionStatus), err
 	}
 
 	if alreadyCommitted := s.committedPool.get(digest.CalcTxHash(input.SignedTransaction.Transaction())); alreadyCommitted != nil {
-		s.logger.Info("transaction already committed", log.Stringable("transaction", input.SignedTransaction))
+		s.logger.Info("transaction already committed", log.Stringable("transaction", input.SignedTransaction), log.Stringable("txHash", txHash))
 		return s.addTransactionOutputFor(alreadyCommitted.receipt, protocol.TRANSACTION_STATUS_DUPLCIATE_TRANSACTION_ALREADY_COMMITTED), nil
 	}
 
 	if err := s.validateSingleTransactionForPreOrder(input.SignedTransaction); err != nil {
 		status := protocol.TRANSACTION_STATUS_REJECTED_SMART_CONTRACT_PRE_ORDER
+		s.logger.Error("error validating transaction for preorder", log.Error(err), log.Stringable("transaction", input.SignedTransaction), log.Stringable("txHash", txHash))
 		return s.addTransactionOutputFor(nil, status), err
 	}
 
-	s.logger.Info("adding new transaction to the pool", log.Stringable("transaction", input.SignedTransaction))
 	if _, err := s.pendingPool.add(input.SignedTransaction, s.config.NodePublicKey()); err != nil {
-		s.logger.Error("error adding transaction to pending pool", log.Error(err), log.Stringable("transaction", input.SignedTransaction))
+		s.logger.Error("error adding transaction to pending pool", log.Error(err), log.Stringable("transaction", input.SignedTransaction), log.Stringable("txHash", txHash))
 		return s.addTransactionOutputFor(nil, err.TransactionStatus), err
 
 	}
 	//TODO batch
 	if err := s.forwardTransaction(input.SignedTransaction); err != nil {
-		s.logger.Error("error forwarding transaction via gossip", log.Error(err), log.Stringable("transaction", input.SignedTransaction))
+		s.logger.Error("error forwarding transaction via gossip", log.Error(err), log.Stringable("transaction", input.SignedTransaction), log.Stringable("txHash", txHash))
 	}
 
 	return s.addTransactionOutputFor(nil, protocol.TRANSACTION_STATUS_PENDING), nil

--- a/services/transactionpool/commit_transaction_receipts.go
+++ b/services/transactionpool/commit_transaction_receipts.go
@@ -26,6 +26,8 @@ func (s *service) CommitTransactionReceipts(input *services.CommitTransactionRec
 		}
 
 		s.committedPool.add(receipt, timestampOrNow(removedTx))
+
+		s.logger.Info("transaction receipt committed", log.String("flow", "checkpoint"), log.Stringable("txHash", receipt.Txhash()))
 	}
 
 	s.lastCommittedBlockHeight = input.ResultsBlockHeader.BlockHeight()

--- a/trace-transaction.sh
+++ b/trace-transaction.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+LOG_FILE=$1
+TXID=$2
+
+grep flow=checkpoint $LOG_FILE | grep txHash=$TXID | sed -e 's/source=.*//g' | sed -e 's/function=.*//g'


### PR DESCRIPTION
```
./trace-transaction.sh logs/node1.log 2c7ca5db3a414cca9e37f816e16f615d3e1d0dedf7381b753b6c87df9c710d04

info 2018-09-13T11:16:37.386319Z transaction received via public api node=dfc06c5be24a67adee80b35ab4f147bb1a35c55ff85eda69f40ef827bddec173 service=public-api flow=checkpoint txHash=2c7ca5db3a414cca9e37f816e16f615d3e1d0dedf7381b753b6c87df9c710d04
info 2018-09-13T11:16:37.386625Z adding new transaction to the pool node=dfc06c5be24a67adee80b35ab4f147bb1a35c55ff85eda69f40ef827bddec173 service=transaction-pool flow=checkpoint transaction={Transaction:{ProtocolVersion:1,VirtualChainId:2a,Timestamp:1553f1786b93560a,Signer:{Scheme:(Eddsa){NetworkType:NETWORK_TYPE_TEST_NET,SignerPublicKey:a8ce8303bb21a8f802957262dc1e37c56aa89378990ef7f91cab229e86060cf2,},},ContractName:BenchmarkToken,MethodName:transfer,InputArgumentArray:1400000006000000616d6f756e7401006400000000000000,},Signature:f584c83f07a03511d93c7f0dd2714ffe297659c9e80b9f46aa5f3b4bbb391d80a0b611f94272850bd81df5f1ea97bce61c106bdba41b9e68e2ffdf2b272a5308,} txHash=2c7ca5db3a414cca9e37f816e16f615d3e1d0dedf7381b753b6c87df9c710d04
info 2018-09-13T11:16:37.935405Z transaction entered transactions block node=dfc06c5be24a67adee80b35ab4f147bb1a35c55ff85eda69f40ef827bddec173 service=consensus-context flow=checkpoint txHash=2c7ca5db3a414cca9e37f816e16f615d3e1d0dedf7381b753b6c87df9c710d04 block-height=261
info 2018-09-13T11:16:37.939953Z transaction receipt committed node=dfc06c5be24a67adee80b35ab4f147bb1a35c55ff85eda69f40ef827bddec173 service=transaction-pool flow=checkpoint txHash=2c7ca5db3a414cca9e37f816e16f615d3e1d0dedf7381b753b6c87df9c710d04
info 2018-09-13T11:16:37.940439Z transaction status returned by public api node=dfc06c5be24a67adee80b35ab4f147bb1a35c55ff85eda69f40ef827bddec173 service=public-api flow=checkpoint txHash=2c7ca5db3a414cca9e37f816e16f615d3e1d0dedf7381b753b6c87df9c710d04
```