### PR TITLE
Log acceptance tests to files

### DIFF
--- a/.circleci/archive-logs.sh
+++ b/.circleci/archive-logs.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -x
+
+find logs/ -type f -exec bzip2 {} \;

--- a/.circleci/archive-logs.sh
+++ b/.circleci/archive-logs.sh
@@ -1,3 +1,5 @@
 #!/bin/sh -x
 
-find logs/ -type f -exec bzip2 {} \;
+bzip2 logs/*.out
+
+tar jcvf logs/acceptance.tar.bz2 logs/acceptance/ && rm -rf logs/acceptance

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           command: ./docker-test.acceptance.sh
           no_output_timout: 20m
-      - run: ./.circleci/archive-logs.sh
+      - run: sudo chown -R circleci:circleci logs && ./.circleci/archive-logs.sh
       - store_artifacts:
           path: logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
       - run:
           command: ./docker-test.acceptance.sh
           no_output_timout: 20m
+      - run: ./.circleci/archive-logs.sh
       - store_artifacts:
           path: logs
 

--- a/test.acceptance.sh
+++ b/test.acceptance.sh
@@ -2,5 +2,5 @@
 
 source ./test.common.sh
 
-STANDALONE=true go test ./test/acceptance -count 100 -timeout 6m -failfast > test.out
+NO_LOG_STDOUT=true go test ./test/acceptance -count 100 -timeout 6m -failfast > test.out
 check_exit_code_and_report

--- a/test.acceptance.sh
+++ b/test.acceptance.sh
@@ -2,5 +2,5 @@
 
 source ./test.common.sh
 
-STANDALONE=true go test ./test/acceptance -count 100 -timeout 6m -failfast > test.out
+STANDALONE=true go test ./test/acceptance -count 2 -timeout 6m -failfast > test.out
 check_exit_code_and_report

--- a/test.acceptance.sh
+++ b/test.acceptance.sh
@@ -2,5 +2,5 @@
 
 source ./test.common.sh
 
-STANDALONE=true go test ./test/acceptance -count 2 -timeout 6m -failfast > test.out
+STANDALONE=true go test ./test/acceptance -count 100 -timeout 6m -failfast > test.out
 check_exit_code_and_report

--- a/test.acceptance.sh
+++ b/test.acceptance.sh
@@ -2,5 +2,5 @@
 
 source ./test.common.sh
 
-go test ./test/acceptance -count 100 -timeout 6m -failfast > test.out
+STANDALONE=true go test ./test/acceptance -count 100 -timeout 6m -failfast > test.out
 check_exit_code_and_report

--- a/test.common.sh
+++ b/test.common.sh
@@ -23,7 +23,6 @@ check_exit_code_and_report () {
     # copy full log for further investigation
     mkdir -p logs
     cp *.out logs
-    find logs/ -type f -exec bzip2 {} \;
 
     exit $EXIT_CODE
 }

--- a/test.common.sh
+++ b/test.common.sh
@@ -18,11 +18,12 @@ check_exit_code_and_report () {
             tail -500 test.out
         fi
 
-        # copy full log for further investigation
-        mkdir -p logs
-        cp *.out logs
-        bzip2 logs/*
-
-        exit $EXIT_CODE
     fi
+
+    # copy full log for further investigation
+    mkdir -p logs
+    cp *.out logs
+    find logs/ -type f -exec bzip2 {} \;
+
+    exit $EXIT_CODE
 }

--- a/test/acceptance/main_test.go
+++ b/test/acceptance/main_test.go
@@ -9,7 +9,7 @@ import (
 func TestMain(m *testing.M) {
 	logs := config.GetProjectSourceRootPath() + "/logs/acceptance/"
 	os.RemoveAll(logs)
-	os.MkdirAll(logs, 0700)
+	os.MkdirAll(logs, 0755)
 
 	os.Exit(m.Run())
 }

--- a/test/acceptance/main_test.go
+++ b/test/acceptance/main_test.go
@@ -1,0 +1,15 @@
+package acceptance
+
+import (
+	"github.com/orbs-network/orbs-network-go/config"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	logs := config.GetProjectSourceRootPath() + "/logs/acceptance/"
+	os.RemoveAll(logs)
+	os.MkdirAll(logs, 0700)
+
+	os.Exit(m.Run())
+}

--- a/test/harness/acceptance_network.go
+++ b/test/harness/acceptance_network.go
@@ -14,7 +14,12 @@ import (
 )
 
 func NewAcceptanceTestNetwork(numNodes uint32, consensusAlgo consensus.ConsensusAlgoType, testId string) *inProcessNetwork {
-	testLogger := log.GetLogger(log.String("_test-id", testId)).WithOutput(log.NewOutput(os.Stdout).WithFormatter(log.NewHumanReadableFormatter()))
+	logFile, err := os.OpenFile(config.GetProjectSourceRootPath()+"/logs/acceptance_"+testId+".log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		panic(err)
+	}
+
+	testLogger := log.GetLogger(log.String("_test-id", testId)).WithOutput(log.NewOutput(logFile).WithFormatter(log.NewHumanReadableFormatter()))
 	testLogger.Info("===========================================================================")
 	testLogger.Info("creating acceptance test network", log.String("consensus", consensusAlgo.String()), log.Uint32("num-nodes", numNodes))
 	description := fmt.Sprintf("network with %d nodes running %s", numNodes, consensusAlgo)

--- a/test/harness/acceptance_network.go
+++ b/test/harness/acceptance_network.go
@@ -10,16 +10,24 @@ import (
 	nativeProcessorAdapter "github.com/orbs-network/orbs-network-go/test/harness/services/processor/native/adapter"
 	stateStorageAdapter "github.com/orbs-network/orbs-network-go/test/harness/services/statestorage/adapter"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
+	"io"
 	"os"
 )
 
 func NewAcceptanceTestNetwork(numNodes uint32, consensusAlgo consensus.ConsensusAlgoType, testId string) *inProcessNetwork {
-	logFile, err := os.OpenFile(config.GetProjectSourceRootPath()+"/logs/acceptance_"+testId+".log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		panic(err)
+	var output io.Writer
+	output = os.Stdout
+
+	if os.Getenv("STANDALONE") == "true" {
+		logFile, err := os.OpenFile(config.GetProjectSourceRootPath()+"/logs/acceptance/"+testId+".log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			panic(err)
+		}
+
+		output = logFile
 	}
 
-	testLogger := log.GetLogger(log.String("_test-id", testId)).WithOutput(log.NewOutput(logFile).WithFormatter(log.NewHumanReadableFormatter()))
+	testLogger := log.GetLogger(log.String("_test-id", testId)).WithOutput(log.NewOutput(output).WithFormatter(log.NewHumanReadableFormatter()))
 	testLogger.Info("===========================================================================")
 	testLogger.Info("creating acceptance test network", log.String("consensus", consensusAlgo.String()), log.Uint32("num-nodes", numNodes))
 	description := fmt.Sprintf("network with %d nodes running %s", numNodes, consensusAlgo)

--- a/test/harness/acceptance_network.go
+++ b/test/harness/acceptance_network.go
@@ -18,7 +18,7 @@ func NewAcceptanceTestNetwork(numNodes uint32, consensusAlgo consensus.Consensus
 	var output io.Writer
 	output = os.Stdout
 
-	if os.Getenv("STANDALONE") == "true" {
+	if os.Getenv("NO_LOG_STDOUT") == "true" {
 		logFile, err := os.OpenFile(config.GetProjectSourceRootPath()+"/logs/acceptance/"+testId+".log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
This PR drastically decreases memory usage of the acceptance suite, something that we initially believed was caused by a memory leak.

The actual problem was `go test` process capturing stdout and holding it in memory.