### PR TITLE
change graceful shutdown to long + change ports

### DIFF
--- a/bootstrap/httpserver/server.go
+++ b/bootstrap/httpserver/server.go
@@ -75,7 +75,10 @@ func (s *server) listen(addr string) (net.Listener, error) {
 }
 
 func (s *server) GracefulShutdown(timeout time.Duration) {
-	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	ctx := context.Background()
+	if timeout > 0 {
+		ctx, _ = context.WithTimeout(context.Background(), timeout)
+	}
 	if err := s.httpServer.Shutdown(ctx); err != nil {
 		s.logger.Error("failed to stop http server gracefully", log.Error(err))
 	}

--- a/devtools/gamma-server/test/gamma_server_and_cli_test.go
+++ b/devtools/gamma-server/test/gamma_server_and_cli_test.go
@@ -227,7 +227,7 @@ func TestGammaFlowWithActualJSONFilesUsingBenchmarkToken(t *testing.T) {
 	}
 
 	gamma := gammacli.StartGammaServer(":8080", false)
-	defer gamma.GracefulShutdown(1 * time.Second)
+	defer gamma.GracefulShutdown(0) // meaning don't have a deadline timeout so allowing enough time for shutdown to free port
 
 	time.Sleep(100 * time.Millisecond) // wait for server to start
 
@@ -245,7 +245,7 @@ func TestGammaCliDeployWithUserDefinedContract(t *testing.T) {
 	}
 
 	gamma := gammacli.StartGammaServer(":8080", false)
-	defer gamma.GracefulShutdown(1 * time.Second)
+	defer gamma.GracefulShutdown(0) // meaning don't have a deadline timeout so allowing enough time for shutdown to free port
 
 	time.Sleep(100 * time.Millisecond) // wait for server to start
 

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -30,10 +30,11 @@ type E2EConfig struct {
 }
 
 const LOCAL_NETWORK_SIZE = 3
+const START_HTTP_PORT = 8090
 
 func getConfig() E2EConfig {
 	Bootstrap := len(os.Getenv("API_ENDPOINT")) == 0
-	ApiEndpoint := "http://localhost:8082/api/v1/" // 8080 is leader, 8082 is node-3
+	ApiEndpoint := fmt.Sprintf("http://localhost:%d/api/v1/", START_HTTP_PORT + 2) // 8080 is leader, 8082 is node-3
 
 	if !Bootstrap {
 		ApiEndpoint = os.Getenv("API_ENDPOINT")
@@ -97,7 +98,7 @@ func newHarness() *harness {
 				leaderKeyPair.PublicKey(),
 				consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS)
 
-			node := bootstrap.NewNode(cfg, nodeLogger, fmt.Sprintf(":%d", 8080+i))
+			node := bootstrap.NewNode(cfg, nodeLogger, fmt.Sprintf(":%d", START_HTTP_PORT+i))
 
 			nodes = append(nodes, node)
 		}
@@ -111,7 +112,7 @@ func newHarness() *harness {
 func (h *harness) gracefulShutdown() {
 	if getConfig().Bootstrap {
 		for _, node := range h.nodes {
-			node.GracefulShutdown(1 * time.Second)
+			node.GracefulShutdown(0) // meaning don't have a deadline timeout so allowing enough time for shutdown to free port
 		}
 	}
 	_, dirToCleanup := getProcessorArtifactPath()


### PR DESCRIPTION
graceful now checks that time 0 no timeout + tests call with 0.
change ports so that there is less collision with gamma
(with Tal)
#309 