### PR TITLE
Added runtime metrics

### DIFF
--- a/bootstrap/node_logic.go
+++ b/bootstrap/node_logic.go
@@ -28,8 +28,9 @@ type NodeLogic interface {
 }
 
 type nodeLogic struct {
-	publicApi      services.PublicApi
-	consensusAlgos []services.ConsensusAlgo
+	publicApi       services.PublicApi
+	consensusAlgos  []services.ConsensusAlgo
+	runtimeReporter interface{} // only needed so that the runtime reporter doesn't get GCed
 }
 
 func NewNodeLogic(
@@ -63,11 +64,13 @@ func NewNodeLogic(
 	//consensusAlgos = append(consensusAlgos, leanhelix.NewLeanHelixConsensusAlgo(ctx, gossipService, blockStorageService, transactionPoolService, consensusContextService, logger, nodeConfig))
 	consensusAlgos = append(consensusAlgos, benchmarkconsensus.NewBenchmarkConsensusAlgo(ctx, gossipService, blockStorageService, consensusContextService, logger, nodeConfig, metricRegistry))
 
+	runtimeReporter := metric.NewRuntimeReporter(ctx, metricRegistry)
 	metricRegistry.ReportEvery(ctx, nodeConfig.MetricsReportInterval(), logger)
 
 	return &nodeLogic{
 		publicApi:      publicApiService,
 		consensusAlgos: consensusAlgos,
+		runtimeReporter: runtimeReporter,
 	}
 }
 

--- a/instrumentation/metric/registry.go
+++ b/instrumentation/metric/registry.go
@@ -111,6 +111,8 @@ func (r *inMemoryRegistry) ReportEvery(ctx context.Context, interval time.Durati
 			r.report(logger)
 
 			// We only rotate histograms because there it is the only type of metric that we're currently rotating
+			r.mu.Lock()
+			defer r.mu.Unlock()
 			for _, m := range r.mu.metrics {
 				switch m.(type) {
 				case *Histogram:

--- a/instrumentation/metric/runtime.go
+++ b/instrumentation/metric/runtime.go
@@ -1,0 +1,54 @@
+package metric
+
+import (
+	"context"
+	"runtime"
+	"time"
+)
+
+type runtimeMetrics struct {
+	heapAlloc *Gauge
+	heapSys *Gauge
+	gcCpuPercentage *Gauge
+}
+
+type runtimeReporter struct {
+	metrics runtimeMetrics
+}
+
+func NewRuntimeReporter(ctx context.Context, metricFactory Factory) interface{} {
+	r := &runtimeReporter{
+		metrics: runtimeMetrics {
+			heapAlloc: metricFactory.NewGauge("Runtime.HeapAlloc"),
+			heapSys: metricFactory.NewGauge("Runtime.HeapSys"),
+			gcCpuPercentage: metricFactory.NewGauge("Runtime.GCCPUPercentage"),
+		},
+	}
+
+	go r.startReporting(ctx)
+
+	return r
+}
+
+func (r *runtimeReporter) startReporting(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			ticker.Stop()
+			return
+		case <-ticker.C:
+			r.reportRuntimeMetrics()
+		}
+	}
+}
+
+func (r *runtimeReporter) reportRuntimeMetrics() {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	//TODO debug.ReadGCStats()?
+
+	r.metrics.heapSys.Update(int64(mem.HeapSys))
+	r.metrics.heapAlloc.Update(int64(mem.HeapAlloc))
+	r.metrics.gcCpuPercentage.Update(int64(mem.GCCPUFraction * 100))
+}


### PR DESCRIPTION
Reporting 3 new metrics:

> Runtime.HeapAlloc
> Runtime.HeapSys
> Runtime.GCCPUPercentage

The naming reflect namings of the `runtime.MemStats` object we read from.
Currently polling every 5 seconds, hard-coded