### PR TITLE
Debug deadlocks on acceptance timeouts

### DIFF
--- a/test/debug.go
+++ b/test/debug.go
@@ -1,0 +1,10 @@
+package test
+
+import (
+	"os"
+	"runtime/pprof"
+)
+
+func DebugPrintGoroutineStacks() {
+	pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+}

--- a/test/harness/network.go
+++ b/test/harness/network.go
@@ -9,6 +9,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	nativeProcessorAdapter "github.com/orbs-network/orbs-network-go/services/processor/native/adapter"
+	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-network-go/test/builders"
 	"github.com/orbs-network/orbs-network-go/test/contracts"
 	"github.com/orbs-network/orbs-network-go/test/crypto/keys"
@@ -85,6 +86,7 @@ func (n *inProcessNetwork) WaitForTransactionInStateForAtMost(ctx context.Contex
 	blockHeight := n.BlockPersistence(nodeIndex).WaitForTransaction(ctx, txhash, atMost)
 	err := n.nodes[nodeIndex].statePersistence.WaitUntilCommittedBlockOfHeight(ctx, blockHeight)
 	if err != nil {
+		test.DebugPrintGoroutineStacks() // since test timed out, help find deadlocked goroutines
 		panic(fmt.Sprintf("statePersistence.WaitUntilCommittedBlockOfHeight failed: %s", err.Error()))
 	}
 }

--- a/test/harness/services/blockstorage/adapter/memory_persistence.go
+++ b/test/harness/services/blockstorage/adapter/memory_persistence.go
@@ -6,6 +6,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/crypto/digest"
 	"github.com/orbs-network/orbs-network-go/services/blockstorage/adapter"
 	"github.com/orbs-network/orbs-network-go/synchronization"
+	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/pkg/errors"
@@ -54,6 +55,7 @@ func (bp *inMemoryBlockPersistence) WaitForTransaction(ctx context.Context, txha
 	case h := <-ch:
 		return h
 	case <-time.After(atMost):
+		test.DebugPrintGoroutineStacks() // since test timed out, help find deadlocked goroutines
 		panic(fmt.Sprintf("timed out waiting for transaction with hash %s", txhash))
 	}
 }


### PR DESCRIPTION
When tests time out with panics that usually result from deadlocks, print goroutine stacks to help find what caused the deadlock