### PR TITLE
Improved flakiness -count 100 test by introducing cpu jitter

### DIFF
--- a/test.acceptance.sh
+++ b/test.acceptance.sh
@@ -2,5 +2,5 @@
 
 source ./test.common.sh
 
-NO_LOG_STDOUT=true go test ./test/acceptance -count 100 -timeout 20m -failfast > test.out
+NO_LOG_STDOUT=true go test -tags cpunoise ./test/acceptance -count 100 -timeout 20m -failfast > test.out
 check_exit_code_and_report

--- a/test/acceptance/cpunoise.go
+++ b/test/acceptance/cpunoise.go
@@ -1,0 +1,9 @@
+// +build cpunoise
+
+package acceptance
+
+import "github.com/orbs-network/orbs-network-go/test"
+
+func init() {
+	test.StartCpuSchedulingJitter()
+}

--- a/test/cpunoise.go
+++ b/test/cpunoise.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"math/rand"
+	"runtime"
+	"sync"
+	"time"
+)
+
+var (
+	MIN_REST_DURATION  = 1 * time.Millisecond
+	MAX_REST_DURATION  = 5 * time.Millisecond
+	MIN_BURST_DURATION = 1 * time.Millisecond
+	MAX_BURST_DURATION = 10 * time.Millisecond
+)
+
+// creates ongoing random bursts of cpu noise (all cores together) to make goroutine scheduling erratic in -count 100 flakiness tests
+func StartCpuSchedulingJitter() {
+	go generateCpuNoiseRunLoop()
+}
+
+func generateCpuNoiseRunLoop() {
+	r := rand.New(rand.NewSource(int64(17)))
+	for {
+
+		restDuration := randDurationInRange(r, MIN_REST_DURATION, MAX_REST_DURATION)
+		burstDuration := randDurationInRange(r, MIN_BURST_DURATION, MAX_BURST_DURATION)
+
+		time.Sleep(restDuration)
+
+		cpuNoiseBurst(burstDuration, runtime.GOMAXPROCS(0))
+	}
+}
+
+func randDurationInRange(r *rand.Rand, min time.Duration, max time.Duration) time.Duration {
+	return min + time.Duration(r.Int63n(int64(max-min)))
+}
+
+func cpuNoiseBurst(burstDuration time.Duration, numCores int) {
+	var wg sync.WaitGroup
+	burstDeadline := time.Now().Add(burstDuration)
+	for i := 0; i < numCores; i++ {
+		wg.Add(1)
+		go cpuNoiseBurstPerCore(burstDeadline, &wg)
+	}
+	wg.Wait()
+}
+
+func cpuNoiseBurstPerCore(burstDeadline time.Time, wg *sync.WaitGroup) {
+	for time.Now().Before(burstDeadline) {
+		// busy wait
+	}
+	wg.Done()
+}


### PR DESCRIPTION
add optional ongoing random bursts of cpu noise to make goroutine scheduling erratic in -count 100 flakiness tests