### PR TITLE
Feature/moar supervision

### DIFF
--- a/bootstrap/node_logic.go
+++ b/bootstrap/node_logic.go
@@ -64,7 +64,7 @@ func NewNodeLogic(
 	//consensusAlgos = append(consensusAlgos, leanhelix.NewLeanHelixConsensusAlgo(ctx, gossipService, blockStorageService, transactionPoolService, consensusContextService, logger, nodeConfig))
 	consensusAlgos = append(consensusAlgos, benchmarkconsensus.NewBenchmarkConsensusAlgo(ctx, gossipService, blockStorageService, consensusContextService, logger, nodeConfig, metricRegistry))
 
-	runtimeReporter := metric.NewRuntimeReporter(ctx, metricRegistry)
+	runtimeReporter := metric.NewRuntimeReporter(ctx, metricRegistry, logger)
 	metricRegistry.ReportEvery(ctx, nodeConfig.MetricsReportInterval(), logger)
 
 	return &nodeLogic{

--- a/instrumentation/metric/histogram.go
+++ b/instrumentation/metric/histogram.go
@@ -25,7 +25,11 @@ type histogramExport struct {
 	Samples int64
 }
 
-func toMillis(nanoseconds float64) float64 {
+func toMillis(nanoseconds int64) float64 {
+	return floatToMillis(float64(nanoseconds))
+}
+
+func floatToMillis(nanoseconds float64) float64 {
 	return nanoseconds / 1e+6
 }
 
@@ -54,14 +58,14 @@ func (h *Histogram) String() string {
 	}
 
 	return fmt.Sprintf(
-		"metric %s: [min=%d, p50=%d, p95=%d, p99=%d, max=%d, avg=%f, samples=%d, error rate=%f]\n",
+		"metric %s: [min=%f, p50=%f, p95=%f, p99=%f, max=%f, avg=%f, samples=%d, error rate=%f]\n",
 		h.name,
-		histo.Min(),
-		histo.ValueAtQuantile(50),
-		histo.ValueAtQuantile(95),
-		histo.ValueAtQuantile(99),
-		histo.Max(),
-		histo.Mean(),
+		toMillis(histo.Min()),
+		toMillis(histo.ValueAtQuantile(50)),
+		toMillis(histo.ValueAtQuantile(95)),
+		toMillis(histo.ValueAtQuantile(99)),
+		toMillis(histo.Max()),
+		floatToMillis(histo.Mean()),
 		histo.TotalCount(),
 		errorRate)
 }
@@ -71,12 +75,12 @@ func (h *Histogram) Export() exportedMetric {
 
 	return &histogramExport{
 		h.name,
-		toMillis(float64(histo.Min())),
-		toMillis(float64(histo.ValueAtQuantile(50))),
-		toMillis(float64(histo.ValueAtQuantile(95))),
-		toMillis(float64(histo.ValueAtQuantile(99))),
-		toMillis(float64(histo.Max())),
-		toMillis(histo.Mean()),
+		toMillis(histo.Min()),
+		toMillis(histo.ValueAtQuantile(50)),
+		toMillis(histo.ValueAtQuantile(95)),
+		toMillis(histo.ValueAtQuantile(99)),
+		toMillis(histo.Max()),
+		floatToMillis(histo.Mean()),
 		histo.TotalCount(),
 	}
 }

--- a/instrumentation/metric/rate.go
+++ b/instrumentation/metric/rate.go
@@ -37,7 +37,7 @@ func (r *Rate) Export() exportedMetric {
 	return rateExport{
 		r.name,
 		r.movingAverage.Value(),
-		toMillis(float64(tickInterval.Nanoseconds())),
+		toMillis(tickInterval.Nanoseconds()),
 	}
 }
 

--- a/instrumentation/metric/registry.go
+++ b/instrumentation/metric/registry.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/synchronization"
-	"github.com/orbs-network/orbs-network-go/synchronization/supervized"
+	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"sync"
 	"time"
 )
@@ -109,7 +109,7 @@ func (r *inMemoryRegistry) report(logger log.BasicLogger) {
 }
 
 func (r *inMemoryRegistry) ReportEvery(ctx context.Context, interval time.Duration, logger log.BasicLogger) {
-	supervized.LongLived(ctx, logger, func() {
+	supervised.LongLived(ctx, logger, func() {
 		periodicalTrigger := synchronization.NewPeriodicalTrigger(interval, func() {
 			r.report(logger)
 

--- a/services/blockstorage/sync/block_sync.go
+++ b/services/blockstorage/sync/block_sync.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
+	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 	"github.com/orbs-network/orbs-spec/types/go/services"
@@ -60,7 +61,10 @@ func NewBlockSync(ctx context.Context, config blockSyncConfig, gossip gossiptopi
 		log.Stringable("collect-chunks-timeout", bs.config.BlockSyncCollectChunksTimeout()),
 		log.Uint32("batch-size", bs.config.BlockSyncBatchSize()))
 
-	go bs.syncLoop(ctx)
+	supervised.LongLived(ctx, logger, func() {
+		bs.syncLoop(ctx)
+	})
+
 	return bs
 }
 

--- a/services/consensusalgo/benchmarkconsensus/leader.go
+++ b/services/consensusalgo/benchmarkconsensus/leader.go
@@ -2,7 +2,6 @@ package benchmarkconsensus
 
 import (
 	"context"
-	"fmt"
 	"github.com/orbs-network/orbs-network-go/crypto/digest"
 	"github.com/orbs-network/orbs-network-go/crypto/hash"
 	"github.com/orbs-network/orbs-network-go/crypto/signature"
@@ -18,13 +17,6 @@ import (
 )
 
 func (s *service) leaderConsensusRoundRunLoop(ctx context.Context) {
-	defer func() {
-		if r := recover(); r != nil {
-			// TODO: in production we need to restart our long running goroutine (decide on supervision mechanism)
-			s.logger.Error("panic in BenchmarkConsensus.leaderConsensusRoundRunLoop long running goroutine", log.String("panic", fmt.Sprintf("%v", r)))
-		}
-	}()
-
 	s.lastCommittedBlockUnderMutex = s.leaderGenerateGenesisBlock()
 	for {
 		err := s.leaderConsensusRoundTick(ctx)

--- a/services/consensusalgo/benchmarkconsensus/service.go
+++ b/services/consensusalgo/benchmarkconsensus/service.go
@@ -5,6 +5,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
+	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
@@ -98,7 +99,9 @@ func NewBenchmarkConsensusAlgo(
 	blockStorage.RegisterConsensusBlocksHandler(s)
 
 	if config.ActiveConsensusAlgo() == consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS && s.isLeader {
-		go s.leaderConsensusRoundRunLoop(ctx)
+		supervised.LongLived(ctx, logger, func() {
+			s.leaderConsensusRoundRunLoop(ctx)
+		})
 	}
 
 	return s

--- a/services/consensusalgo/leanhelix/service.go
+++ b/services/consensusalgo/leanhelix/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/orbs-network/lean-helix-go"
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
+	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
@@ -70,7 +71,9 @@ func NewLeanHelixConsensusAlgo(
 
 	gossip.RegisterLeanHelixHandler(s)
 	if config.ActiveConsensusAlgo() == consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX && config.ConstantConsensusLeader().Equal(config.NodePublicKey()) {
-		go s.consensusRoundRunLoop(ctx)
+		supervised.LongLived(ctx, logger, func() {
+			s.consensusRoundRunLoop(ctx)
+		})
 	}
 	return s
 }

--- a/services/transactionpool/forward_transactions.go
+++ b/services/transactionpool/forward_transactions.go
@@ -6,7 +6,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/crypto/signature"
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/synchronization"
-	"github.com/orbs-network/orbs-network-go/synchronization/supervized"
+	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
@@ -80,7 +80,7 @@ func (f *transactionForwarder) submit(transaction *protocol.SignedTransaction) {
 }
 
 func (f *transactionForwarder) start(ctx context.Context) {
-	supervized.LongLived(ctx, f.logger, func() {
+	supervised.LongLived(ctx, f.logger, func() {
 		for {
 			timer := synchronization.NewTimer(f.config.TransactionPoolPropagationBatchingTimeout())
 

--- a/services/transactionpool/service.go
+++ b/services/transactionpool/service.go
@@ -8,7 +8,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	"github.com/orbs-network/orbs-network-go/synchronization"
-	"github.com/orbs-network/orbs-network-go/synchronization/supervized"
+	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
@@ -184,7 +184,7 @@ func startCleaningProcess(ctx context.Context, tickInterval func() time.Duration
 	//TODO use PeriodicalTrigger?
 	stopped := make(chan struct{})
 	ticker := time.NewTicker(tickInterval())
-	supervized.LongLived(ctx, logger, func() {
+	supervised.LongLived(ctx, logger, func() {
 		for {
 			select {
 			case <-ctx.Done():

--- a/synchronization/supervised/doc.go
+++ b/synchronization/supervised/doc.go
@@ -1,5 +1,5 @@
-// Package supervized provides basic supervision abilities for running goroutines,
+// Package supervised provides basic supervision abilities for running goroutines,
 // namely making sure that panics are not swallowed and that long-running goroutines
 // are restarted if they crash
-package supervized
+package supervised
 

--- a/synchronization/supervised/supervisor.go
+++ b/synchronization/supervised/supervisor.go
@@ -1,4 +1,4 @@
-package supervized
+package supervised
 
 import (
 	"context"

--- a/synchronization/supervised/supervisor_test.go
+++ b/synchronization/supervised/supervisor_test.go
@@ -1,4 +1,4 @@
-package supervized
+package supervised
 
 import (
 	"context"

--- a/test/harness/network.go
+++ b/test/harness/network.go
@@ -9,7 +9,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	nativeProcessorAdapter "github.com/orbs-network/orbs-network-go/services/processor/native/adapter"
-	"github.com/orbs-network/orbs-network-go/synchronization/supervized"
+	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-network-go/test/builders"
 	"github.com/orbs-network/orbs-network-go/test/contracts"
@@ -127,7 +127,7 @@ func (n *inProcessNetwork) SendTransfer(ctx context.Context, nodeIndex int, amou
 	}).Build()
 
 	ch := make(chan *client.SendTransactionResponse)
-	supervized.ShortLived(n.testLogger, func() {
+	supervised.ShortLived(n.testLogger, func() {
 		publicApi := n.nodes[nodeIndex].nodeLogic.PublicApi()
 		output, err := publicApi.SendTransaction(ctx, &services.SendTransactionInput{
 			ClientRequest: request,
@@ -149,7 +149,7 @@ func (n *inProcessNetwork) SendTransferInBackground(ctx context.Context, nodeInd
 		SignedTransaction: builders.TransferTransaction().WithEd25519Signer(signerKeyPair).WithAmountAndTargetAddress(amount, targetAddress).Builder(),
 	}).Build()
 
-	supervized.ShortLived(n.testLogger, func() {
+	supervised.ShortLived(n.testLogger, func() {
 		publicApi := n.nodes[nodeIndex].nodeLogic.PublicApi()
 		publicApi.SendTransaction(ctx, &services.SendTransactionInput{ // we ignore timeout here.
 			ClientRequest: request,
@@ -166,7 +166,7 @@ func (n *inProcessNetwork) SendInvalidTransfer(ctx context.Context, nodeIndex in
 	}).Build()
 
 	ch := make(chan *client.SendTransactionResponse)
-	supervized.ShortLived(n.testLogger, func() {
+	supervised.ShortLived(n.testLogger, func() {
 		publicApi := n.nodes[nodeIndex].nodeLogic.PublicApi()
 		output, err := publicApi.SendTransaction(ctx, &services.SendTransactionInput{
 			ClientRequest: request,
@@ -187,7 +187,7 @@ func (n *inProcessNetwork) CallGetBalance(ctx context.Context, nodeIndex int, fo
 	}).Build()
 
 	ch := make(chan uint64)
-	supervized.ShortLived(n.testLogger, func() {
+	supervised.ShortLived(n.testLogger, func() {
 		publicApi := n.nodes[nodeIndex].nodeLogic.PublicApi()
 		output, err := publicApi.CallMethod(ctx, &services.CallMethodInput{
 			ClientRequest: request,
@@ -223,7 +223,7 @@ func (n *inProcessNetwork) SendDeployCounterContract(ctx context.Context, nodeIn
 	}).Build()
 
 	ch := make(chan *client.SendTransactionResponse)
-	supervized.ShortLived(n.testLogger, func() {
+	supervised.ShortLived(n.testLogger, func() {
 		publicApi := n.nodes[nodeIndex].nodeLogic.PublicApi()
 		output, err := publicApi.SendTransaction(ctx, &services.SendTransactionInput{
 			ClientRequest: request,
@@ -247,7 +247,7 @@ func (n *inProcessNetwork) SendCounterAdd(ctx context.Context, nodeIndex int, am
 	}).Build()
 
 	ch := make(chan *client.SendTransactionResponse)
-	supervized.ShortLived(n.testLogger, func() {
+	supervised.ShortLived(n.testLogger, func() {
 		publicApi := n.nodes[nodeIndex].nodeLogic.PublicApi()
 		output, err := publicApi.SendTransaction(ctx, &services.SendTransactionInput{
 			ClientRequest: request,
@@ -269,7 +269,7 @@ func (n *inProcessNetwork) CallCounterGet(ctx context.Context, nodeIndex int) ch
 	}).Build()
 
 	ch := make(chan uint64)
-	supervized.ShortLived(n.testLogger, func() {
+	supervised.ShortLived(n.testLogger, func() {
 		publicApi := n.nodes[nodeIndex].nodeLogic.PublicApi()
 		output, err := publicApi.CallMethod(ctx, &services.CallMethodInput{
 			ClientRequest: request,

--- a/test/harness/services/gossip/adapter/tampering_transport.go
+++ b/test/harness/services/gossip/adapter/tampering_transport.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
-	"github.com/orbs-network/orbs-network-go/synchronization/supervized"
+	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 	"math/rand"
@@ -88,7 +88,7 @@ func (t *tamperingTransport) Send(ctx context.Context, data *adapter.TransportDa
 		return err
 	}
 
-	supervized.ShortLived(t.logger, func() {
+	supervised.ShortLived(t.logger, func() {
 		t.receive(ctx, data)
 	})
 
@@ -262,7 +262,7 @@ type duplicatingTamperer struct {
 
 func (o *duplicatingTamperer) maybeTamper(ctx context.Context, data *adapter.TransportData) (error, bool) {
 	if o.predicate(data) {
-		supervized.ShortLived(o.transport.logger, func() {
+		supervised.ShortLived(o.transport.logger, func() {
 			time.Sleep(10 * time.Millisecond)
 			o.transport.receive(ctx, data)
 		})
@@ -282,7 +282,7 @@ type delayingTamperer struct {
 
 func (o *delayingTamperer) maybeTamper(ctx context.Context, data *adapter.TransportData) (error, bool) {
 	if o.predicate(data) {
-		supervized.ShortLived(o.transport.logger, func() {
+		supervised.ShortLived(o.transport.logger, func() {
 			time.Sleep(o.duration())
 			o.transport.receive(ctx, data)
 		})


### PR DESCRIPTION
Migrated long-running goroutines to use `supervised.LongLived`
Migrating `DirectTransport` client-side goroutines causes them to never stop, so I'm leaving this to @talkol 