### PR TITLE
Fail acceptance tests on unexpected errors

### DIFF
--- a/instrumentation/log/error_recording_logger.go
+++ b/instrumentation/log/error_recording_logger.go
@@ -1,0 +1,91 @@
+package log
+
+import (
+	"sync"
+)
+
+type ErrorRecordingLogger struct {
+	nested        BasicLogger
+	allowedErrors []string
+
+	errorRecorder *errorRecorder
+}
+
+type errorRecorder struct {
+	sync.Mutex
+	unexpectedErrors []string
+}
+
+func NewErrorRecordingLogger(wrapped BasicLogger, allowedErrors []string) *ErrorRecordingLogger {
+	return &ErrorRecordingLogger{nested: wrapped, allowedErrors: allowedErrors, errorRecorder: &errorRecorder{}}
+}
+
+func (l *ErrorRecordingLogger) Log(level string, message string, params ...*Field) {
+	l.nested.Log(level, message, params...)
+
+}
+
+func (l *ErrorRecordingLogger) LogFailedExpectation(message string, expected *Field, actual *Field, params ...*Field) {
+	l.nested.LogFailedExpectation(message, expected, actual, params...)
+}
+
+func (l *ErrorRecordingLogger) Info(message string, params ...*Field) {
+	l.nested.Info(message, params...)
+}
+
+func (l *ErrorRecordingLogger) Error(message string, params ...*Field) {
+	l.nested.Error(message, params...)
+
+	for _, allowedMessage := range l.allowedErrors {
+		if allowedMessage == message {
+			return
+		}
+	}
+
+	l.recordUnexpectedError(message, params)
+}
+
+func (l *ErrorRecordingLogger) Metric(params ...*Field) {
+	l.nested.Metric(params...)
+}
+
+func (l *ErrorRecordingLogger) WithTags(params ...*Field) BasicLogger {
+	return &ErrorRecordingLogger{
+		nested: l.nested.WithTags(),
+		allowedErrors: l.allowedErrors,
+		errorRecorder: l.errorRecorder,
+	}
+
+	return NewErrorRecordingLogger(l.nested.WithTags(), l.allowedErrors)
+}
+
+func (l *ErrorRecordingLogger) Tags() []*Field {
+	return l.nested.Tags()
+}
+
+func (l *ErrorRecordingLogger) WithOutput(writer ...Output) BasicLogger {
+	return l.nested.WithOutput(writer...)
+}
+
+func (l *ErrorRecordingLogger) WithFilters(filter ...Filter) BasicLogger {
+	return l.nested.WithFilters(filter...)
+}
+
+func (l *ErrorRecordingLogger) recordUnexpectedError(message string, fields []*Field) {
+	l.errorRecorder.Lock()
+	defer l.errorRecorder.Unlock()
+	l.errorRecorder.unexpectedErrors = append(l.errorRecorder.unexpectedErrors, message)
+
+}
+
+func (l *ErrorRecordingLogger) GetUnexpectedErrors() []string {
+	return l.errorRecorder.unexpectedErrors
+}
+
+func (l *ErrorRecordingLogger) HasErrors() bool {
+	l.errorRecorder.Lock()
+	defer l.errorRecorder.Unlock()
+	return len(l.errorRecorder.unexpectedErrors) > 0
+}
+
+

--- a/services/transactionpool/commit_transaction_receipts.go
+++ b/services/transactionpool/commit_transaction_receipts.go
@@ -62,7 +62,7 @@ func (s *service) updateBlockHeightAndTimestamp(header *protocol.ResultsBlockHea
 
 	if header.Timestamp() == 0 {
 		s.mu.lastCommittedBlockTimestamp = primitives.TimestampNano(time.Now().UnixNano()) //TODO remove this code when consensus-context actually sets block timestamp
-		s.logger.Error("got 0 timestamp from results block header")
+		s.logger.Info("got 0 timestamp from results block header")
 	} else {
 		s.mu.lastCommittedBlockTimestamp = header.Timestamp()
 	}

--- a/test/acceptance/block_sync_test.go
+++ b/test/acceptance/block_sync_test.go
@@ -10,15 +10,23 @@ import (
 )
 
 func TestBlockSync(t *testing.T) {
-	harness.Network(t).WithSetup(func(ctx context.Context, network harness.InProcessNetwork) {
+	harness.Network(t).
+		AllowingErrors(
+			"consensus round tick failed",
+			"intra-node sync to consensus algo failed",
+			"all consensus 0 algos refused to validate the block",
+			"all consensus 1 algos refused to validate the block",
+		).
+		WithSetup(func(ctx context.Context, network harness.InProcessTestNetwork) {
 		for i := 1; i <= 10; i++ {
 			blockPair := builders.BenchmarkConsensusBlockPair().
 				WithHeight(primitives.BlockHeight(i)).
 				WithTransactions(2).
 				Build()
 			network.BlockPersistence(0).WriteBlock(blockPair)
+
 		}
-	}).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+	}).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 		require.Zero(t, len(network.BlockPersistence(1).ReadAllBlocks()))
 
 		if err := network.BlockPersistence(0).GetBlockTracker().WaitForBlock(ctx, 10); err != nil {

--- a/test/acceptance/block_sync_test.go
+++ b/test/acceptance/block_sync_test.go
@@ -12,10 +12,10 @@ import (
 func TestBlockSync(t *testing.T) {
 	harness.Network(t).
 		AllowingErrors(
-			"consensus round tick failed",
-			"intra-node sync to consensus algo failed",
-			"all consensus 0 algos refused to validate the block",
-			"all consensus 1 algos refused to validate the block",
+			"consensus round tick failed", // (block already in storage, skipping) TODO investigate and explain, or fix and remove expected error
+			"intra-node sync to consensus algo failed", //TODO investigate and explain, or fix and remove expected error
+			"all consensus 0 algos refused to validate the block", //TODO investigate and explain, or fix and remove expected error
+			"all consensus 1 algos refused to validate the block", //TODO investigate and explain, or fix and remove expected error
 		).
 		WithSetup(func(ctx context.Context, network harness.InProcessTestNetwork) {
 		for i := 1; i <= 10; i++ {

--- a/test/acceptance/consensus_test.go
+++ b/test/acceptance/consensus_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestLeanHelixLeaderGetsValidationsBeforeCommit(t *testing.T) {
 	t.Skip("putting lean helix on hold until external library is integrated")
-	harness.Network(t).WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+	harness.Network(t).WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 
 		network.DeployBenchmarkToken(ctx, 5)
 
@@ -41,7 +41,7 @@ func TestLeanHelixLeaderGetsValidationsBeforeCommit(t *testing.T) {
 }
 
 func TestBenchmarkConsensusLeaderGetsVotesBeforeNextBlock(t *testing.T) {
-	harness.Network(t).WithMaxTxPerBlock(1).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+	harness.Network(t).WithMaxTxPerBlock(1).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 
 		network.DeployBenchmarkToken(ctx, 5)
 

--- a/test/acceptance/deploy_native_test.go
+++ b/test/acceptance/deploy_native_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNonLeaderDeploysNativeContract(t *testing.T) {
-	harness.Network(t).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+	harness.Network(t).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 
 		t.Log("testing", network.Description()) // leader is nodeIndex 0, validator is nodeIndex 1
 

--- a/test/acceptance/network_benchmark_test.go
+++ b/test/acceptance/network_benchmark_test.go
@@ -18,7 +18,7 @@ func BenchmarkInMemoryNetwork(b *testing.B) {
 
 	harness.Network(b).
 		WithLogFilters(log.DiscardAll()).
-		WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+		WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 
 		network.DeployBenchmarkToken(ctx, 5)
 

--- a/test/acceptance/simple_transfer_test.go
+++ b/test/acceptance/simple_transfer_test.go
@@ -11,7 +11,10 @@ import (
 )
 
 func TestLeaderCommitsTransactionsAndSkipsInvalidOnes(t *testing.T) {
-	harness.Network(t).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
+	harness.Network(t).
+		AllowingErrors(
+			"consensus round tick failed", // (aborting shared state update due to inconsistency) //TODO investigate and explain, or fix and remove expected error
+		).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 
 		network.DeployBenchmarkToken(ctx, 5)
 

--- a/test/acceptance/simple_transfer_test.go
+++ b/test/acceptance/simple_transfer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLeaderCommitsTransactionsAndSkipsInvalidOnes(t *testing.T) {
-	harness.Network(t).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+	harness.Network(t).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 
 		network.DeployBenchmarkToken(ctx, 5)
 
@@ -39,7 +39,7 @@ func TestLeaderCommitsTransactionsAndSkipsInvalidOnes(t *testing.T) {
 }
 
 func TestNonLeaderPropagatesTransactionsToLeader(t *testing.T) {
-	harness.Network(t).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+	harness.Network(t).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 
 		network.DeployBenchmarkToken(ctx, 5)
 

--- a/test/acceptance/stress_test.go
+++ b/test/acceptance/stress_test.go
@@ -15,8 +15,13 @@ import (
 
 func TestCreateGazillionTransactionsWhileTransportIsDuplicatingRandomMessages(t *testing.T) {
 	harness.Network(t).
+		AllowingErrors(
+			"consensus round tick failed",
+			"error adding forwarded transaction to pending pool",
+			"FORK!! block already in storage, transaction block header mismatch",
+		).
 		WithLogFilters(log.IgnoreMessagesMatching("leader failed to validate vote"), log.IgnoreErrorsMatching("transaction rejected: TRANSACTION_STATUS_DUPLICATE_TRANSACTION_ALREADY_PENDING")).
-		WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+		WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 		network.GossipTransport().Duplicate(AnyNthMessage(7))
 
 		sendTransfersAndAssertTotalBalance(ctx, network, t, 100)
@@ -25,8 +30,9 @@ func TestCreateGazillionTransactionsWhileTransportIsDuplicatingRandomMessages(t 
 
 func TestCreateGazillionTransactionsWhileTransportIsDroppingRandomMessages(t *testing.T) {
 	harness.Network(t).
+		AllowingErrors("consensus round tick failed").
 		WithLogFilters(log.IgnoreMessagesMatching("leader failed to validate vote"), log.IgnoreErrorsMatching("transport failed to send")).
-		WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+		WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 		network.GossipTransport().Fail(HasHeader(ABenchmarkConsensusMessage).And(AnyNthMessage(7)))
 
 		sendTransfersAndAssertTotalBalance(ctx, network, t, 100)
@@ -36,7 +42,7 @@ func TestCreateGazillionTransactionsWhileTransportIsDroppingRandomMessages(t *te
 func TestCreateGazillionTransactionsWhileTransportIsDelayingRandomMessages(t *testing.T) {
 	harness.Network(t).
 		WithLogFilters(log.IgnoreMessagesMatching("leader failed to validate vote")).
-		WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+		WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 
 		network.GossipTransport().Delay(func() time.Duration {
 			return (time.Duration(rand.Intn(1000)) + 1000) * time.Microsecond // delay each message between 1000 and 2000 millis
@@ -48,7 +54,7 @@ func TestCreateGazillionTransactionsWhileTransportIsDelayingRandomMessages(t *te
 
 func TestCreateGazillionTransactionsWhileTransportIsCorruptingRandomMessages(t *testing.T) {
 	t.Skip("this test causes the system to hang, seems like consensus algo stops")
-	harness.Network(t).WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessNetwork) {
+	harness.Network(t).WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 		network.GossipTransport().Corrupt(Not(HasHeader(ATransactionRelayMessage)).And(AnyNthMessage(7)))
 
 		sendTransfersAndAssertTotalBalance(ctx, network, t, 100)
@@ -74,7 +80,7 @@ func AnyNthMessage(n int) MessagePredicate {
 	}
 }
 
-func sendTransfersAndAssertTotalBalance(ctx context.Context, network harness.InProcessNetwork, t *testing.T, numTransactions int) {
+func sendTransfersAndAssertTotalBalance(ctx context.Context, network harness.InProcessTestNetwork, t *testing.T, numTransactions int) {
 	fromAddress := 5
 	toAddress := 6
 

--- a/test/acceptance/stress_test.go
+++ b/test/acceptance/stress_test.go
@@ -17,6 +17,7 @@ func TestCreateGazillionTransactionsWhileTransportIsDuplicatingRandomMessages(t 
 	harness.Network(t).
 		AllowingErrors(
 			"error adding forwarded transaction to pending pool", // because we duplicate, among other messages, the transaction propagation message
+			"consensus round tick failed", // (aborting shared state update due to inconsistency) //TODO investigate and explain, or fix and remove expected error
 			"FORK!! block already in storage, transaction block header mismatch", //TODO investigate and explain, or fix and remove expected error
 		).
 		WithLogFilters(log.IgnoreMessagesMatching("leader failed to validate vote"), log.IgnoreErrorsMatching("transaction rejected: TRANSACTION_STATUS_DUPLICATE_TRANSACTION_ALREADY_PENDING")).

--- a/test/acceptance/stress_test.go
+++ b/test/acceptance/stress_test.go
@@ -43,6 +43,9 @@ func TestCreateGazillionTransactionsWhileTransportIsDroppingRandomMessages(t *te
 
 func TestCreateGazillionTransactionsWhileTransportIsDelayingRandomMessages(t *testing.T) {
 	harness.Network(t).
+		AllowingErrors(
+			"consensus round tick failed", // (aborting shared state update due to inconsistency) //TODO investigate and explain, or fix and remove expected error
+		).
 		WithLogFilters(log.IgnoreMessagesMatching("leader failed to validate vote")).
 		WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
 

--- a/test/harness/acceptance_network.go
+++ b/test/harness/acceptance_network.go
@@ -11,32 +11,10 @@ import (
 	nativeProcessorAdapter "github.com/orbs-network/orbs-network-go/test/harness/services/processor/native/adapter"
 	stateStorageAdapter "github.com/orbs-network/orbs-network-go/test/harness/services/statestorage/adapter"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
-	"io"
-	"os"
 )
 
-func NewAcceptanceTestNetwork(numNodes uint32, logFilters []log.Filter, consensusAlgo consensus.ConsensusAlgoType, testId string, maxTxPerBlock uint32) *inProcessNetwork {
-	var output io.Writer
-	output = os.Stdout
+func NewAcceptanceTestNetwork(numNodes uint32, testLogger log.BasicLogger, consensusAlgo consensus.ConsensusAlgoType, maxTxPerBlock uint32) *inProcessNetwork {
 
-	if os.Getenv("NO_LOG_STDOUT") == "true" {
-		logFile, err := os.OpenFile(config.GetProjectSourceRootPath()+"/logs/acceptance/"+testId+".log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-
-		output = logFile
-	}
-
-	testLogger := log.GetLogger(
-		log.String("_test", "acceptance"),
-		log.String("_branch", os.Getenv("GIT_BRANCH")),
-		log.String("_commit", os.Getenv("GIT_COMMIT")),
-		log.String("_test-id", testId),
-	).
-		WithOutput(log.NewOutput(output).WithFormatter(log.NewJsonFormatter())).
-		WithFilters(logFilters...).
-		WithFilters(log.Or(log.OnlyErrors(), log.OnlyCheckpoints(), log.OnlyMetrics()))
 
 	testLogger.Info("===========================================================================")
 	testLogger.Info("creating acceptance test network", log.String("consensus", consensusAlgo.String()), log.Uint32("num-nodes", numNodes))

--- a/test/harness/network.go
+++ b/test/harness/network.go
@@ -27,6 +27,10 @@ import (
 
 type InProcessNetwork interface {
 	PublicApi(nodeIndex int) services.PublicApi
+
+	SendDeployCounterContract(ctx context.Context, nodeIndex int) chan *client.SendTransactionResponse
+	SendCounterAdd(ctx context.Context, nodeIndex int, amount uint64) chan *client.SendTransactionResponse
+	CallCounterGet(ctx context.Context, nodeIndex int) chan uint64
 }
 
 type InProcessTestNetwork interface {
@@ -39,9 +43,6 @@ type InProcessTestNetwork interface {
 	SendTransferInBackground(ctx context.Context, nodeIndex int, amount uint64, fromAddressIndex int, toAddressIndex int) primitives.Sha256
 	SendInvalidTransfer(ctx context.Context, nodeIndex int, fromAddressIndex int, toAddressIndex int) chan *client.SendTransactionResponse
 	CallGetBalance(ctx context.Context, nodeIndex int, forAddressIndex int) chan uint64
-	SendDeployCounterContract(ctx context.Context, nodeIndex int) chan *client.SendTransactionResponse
-	SendCounterAdd(ctx context.Context, nodeIndex int, amount uint64) chan *client.SendTransactionResponse
-	CallCounterGet(ctx context.Context, nodeIndex int) chan uint64
 	DumpState()
 	WaitForTransactionInState(ctx context.Context, nodeIndex int, txhash primitives.Sha256)
 	WaitForTransactionInStateForAtMost(ctx context.Context, nodeIndex int, txhash primitives.Sha256, atMost time.Duration)

--- a/test/harness/network.go
+++ b/test/harness/network.go
@@ -26,10 +26,14 @@ import (
 )
 
 type InProcessNetwork interface {
+	PublicApi(nodeIndex int) services.PublicApi
+}
+
+type InProcessTestNetwork interface {
+	InProcessNetwork
+	GossipTransport() gossipAdapter.TamperingTransport
 	Description() string
 	DeployBenchmarkToken(ctx context.Context, ownerAddressIndex int)
-	GossipTransport() gossipAdapter.TamperingTransport
-	PublicApi(nodeIndex int) services.PublicApi
 	BlockPersistence(nodeIndex int) blockStorageAdapter.InMemoryBlockPersistence
 	SendTransfer(ctx context.Context, nodeIndex int, amount uint64, fromAddressIndex int, toAddressIndex int) chan *client.SendTransactionResponse
 	SendTransferInBackground(ctx context.Context, nodeIndex int, amount uint64, fromAddressIndex int, toAddressIndex int) primitives.Sha256

--- a/test/harness/network_builder.go
+++ b/test/harness/network_builder.go
@@ -87,12 +87,7 @@ func (b *acceptanceTestNetworkBuilder) Start(f func(ctx context.Context, network
 
 			defer printTestIdOnFailure(b.f, testId)
 			defer dumpStateOnFailure(b.f, network)
-			defer func() {
-				if logger.HasErrors() {
-					b.f.Fatal("Encountered unexpected errors:\n\t", strings.Join(logger.GetUnexpectedErrors(), "\n\t"))
-
-				}
-			}()
+			defer test.RequireNoUnexpectedErrors(b.f, logger)
 
 			if b.setupFunc != nil {
 				b.setupFunc(ctx, network)

--- a/test/harness/network_builder.go
+++ b/test/harness/network_builder.go
@@ -3,9 +3,12 @@ package harness
 import (
 	"context"
 	"fmt"
+	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
+	"io"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -14,6 +17,7 @@ import (
 
 type canFail interface {
 	Failed() bool
+	Fatal(args ...interface{})
 }
 
 type acceptanceTestNetworkBuilder struct {
@@ -21,9 +25,10 @@ type acceptanceTestNetworkBuilder struct {
 	numNodes       uint32
 	consensusAlgos []consensus.ConsensusAlgoType
 	testId         string
-	setupFunc      func(ctx context.Context, network InProcessNetwork)
+	setupFunc      func(ctx context.Context, network InProcessTestNetwork)
 	logFilters     []log.Filter
 	maxTxPerBlock  uint32
+	allowedErrors  []string
 }
 
 func Network(f canFail) *acceptanceTestNetworkBuilder {
@@ -56,7 +61,7 @@ func (b *acceptanceTestNetworkBuilder) WithConsensusAlgos(algos ...consensus.Con
 }
 
 // setup runs when all adapters have been created but before the nodes are started
-func (b *acceptanceTestNetworkBuilder) WithSetup(f func(ctx context.Context, network InProcessNetwork)) *acceptanceTestNetworkBuilder {
+func (b *acceptanceTestNetworkBuilder) WithSetup(f func(ctx context.Context, network InProcessTestNetwork)) *acceptanceTestNetworkBuilder {
 	b.setupFunc = f
 	return b
 }
@@ -66,16 +71,28 @@ func (b *acceptanceTestNetworkBuilder) WithMaxTxPerBlock(maxTxPerBlock uint32) *
 	return b
 }
 
-func (b *acceptanceTestNetworkBuilder) Start(f func(ctx context.Context, network InProcessNetwork)) {
+func (b *acceptanceTestNetworkBuilder) AllowingErrors(allowedErrors ...string) *acceptanceTestNetworkBuilder {
+	b.allowedErrors = append(b.allowedErrors, allowedErrors...)
+	return b
+}
+
+func (b *acceptanceTestNetworkBuilder) Start(f func(ctx context.Context, network InProcessTestNetwork)) {
 	for _, consensusAlgo := range b.consensusAlgos {
 
 		// start test
 		test.WithContext(func(ctx context.Context) {
 			testId := b.testId + "-" + consensusAlgo.String()
-			network := NewAcceptanceTestNetwork(b.numNodes, b.logFilters, consensusAlgo, testId, b.maxTxPerBlock)
+			logger := b.makeLogger(testId)
+			network := NewAcceptanceTestNetwork(b.numNodes, logger, consensusAlgo, b.maxTxPerBlock)
 
 			defer printTestIdOnFailure(b.f, testId)
 			defer dumpStateOnFailure(b.f, network)
+			defer func() {
+				if logger.HasErrors() {
+					b.f.Fatal("Encountered unexpected errors:\n\t", strings.Join(logger.GetUnexpectedErrors(), "\n\t"))
+
+				}
+			}()
 
 			if b.setupFunc != nil {
 				b.setupFunc(ctx, network)
@@ -91,13 +108,39 @@ func (b *acceptanceTestNetworkBuilder) Start(f func(ctx context.Context, network
 	}
 }
 
+func (b *acceptanceTestNetworkBuilder) makeLogger(testId string) *log.ErrorRecordingLogger {
+	var output io.Writer
+	output = os.Stdout
+
+	if os.Getenv("NO_LOG_STDOUT") == "true" {
+		logFile, err := os.OpenFile(config.GetProjectSourceRootPath()+"/logs/acceptance/"+testId+".log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			panic(err)
+		}
+
+		output = logFile
+	}
+
+	logger := log.GetLogger(
+		log.String("_test", "acceptance"),
+		log.String("_branch", os.Getenv("GIT_BRANCH")),
+		log.String("_commit", os.Getenv("GIT_COMMIT")),
+		log.String("_test-id", testId),
+	).
+		WithOutput(log.NewOutput(output).WithFormatter(log.NewJsonFormatter())).
+		WithFilters(b.logFilters...).
+		WithFilters(log.Or(log.OnlyErrors(), log.OnlyCheckpoints(), log.OnlyMetrics()))
+
+	return log.NewErrorRecordingLogger(logger, b.allowedErrors)
+}
+
 func printTestIdOnFailure(f canFail, testId string) {
 	if f.Failed() {
 		fmt.Println("FAIL search snippet: grep _test-id="+testId, "test.out")
 	}
 }
 
-func dumpStateOnFailure(f canFail, network InProcessNetwork) {
+func dumpStateOnFailure(f canFail, network InProcessTestNetwork) {
 	if f.Failed() {
 		network.DumpState()
 	}

--- a/test/testify_extensions.go
+++ b/test/testify_extensions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -22,4 +23,19 @@ func RequireCmpEqual(t *testing.T, expected interface{}, actual interface{}, msg
 		return
 	}
 	t.FailNow()
+}
+
+type Fataler interface {
+	Fatal(args ...interface{})
+}
+
+type ErrorTracker interface {
+	HasErrors() bool
+	GetUnexpectedErrors() []string
+}
+
+func RequireNoUnexpectedErrors(f Fataler, errorTracker ErrorTracker) {
+	if errorTracker.HasErrors() {
+		f.Fatal("Encountered unexpected errors:\n\t", strings.Join(errorTracker.GetUnexpectedErrors(), "\n\t"))
+	}
 }


### PR DESCRIPTION
Acceptance Suite will no longer allow errors not specifically marked as allowed. Any such error logged will fail the suite.

@jlevison I added some weird errors in block sync and storage as expected since they occur, but I can't explain them properly