### PR TITLE
Simplified supervision

### DIFF
--- a/services/blockstorage/sync/block_sync.go
+++ b/services/blockstorage/sync/block_sync.go
@@ -61,7 +61,7 @@ func NewBlockSync(ctx context.Context, config blockSyncConfig, gossip gossiptopi
 		log.Stringable("collect-chunks-timeout", bs.config.BlockSyncCollectChunksTimeout()),
 		log.Uint32("batch-size", bs.config.BlockSyncBatchSize()))
 
-	supervised.LongLived(ctx, logger, func() {
+	supervised.GoForever(ctx, logger, func() {
 		bs.syncLoop(ctx)
 	})
 

--- a/services/consensusalgo/benchmarkconsensus/service.go
+++ b/services/consensusalgo/benchmarkconsensus/service.go
@@ -99,7 +99,7 @@ func NewBenchmarkConsensusAlgo(
 	blockStorage.RegisterConsensusBlocksHandler(s)
 
 	if config.ActiveConsensusAlgo() == consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS && s.isLeader {
-		supervised.LongLived(ctx, logger, func() {
+		supervised.GoForever(ctx, logger, func() {
 			s.leaderConsensusRoundRunLoop(ctx)
 		})
 	}

--- a/services/consensusalgo/leanhelix/service.go
+++ b/services/consensusalgo/leanhelix/service.go
@@ -71,7 +71,7 @@ func NewLeanHelixConsensusAlgo(
 
 	gossip.RegisterLeanHelixHandler(s)
 	if config.ActiveConsensusAlgo() == consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX && config.ConstantConsensusLeader().Equal(config.NodePublicKey()) {
-		supervised.LongLived(ctx, logger, func() {
+		supervised.GoForever(ctx, logger, func() {
 			s.consensusRoundRunLoop(ctx)
 		})
 	}

--- a/services/gossip/adapter/direct_transport.go
+++ b/services/gossip/adapter/direct_transport.go
@@ -140,6 +140,10 @@ func (t *directTransport) serverMainLoop(ctx context.Context, listenPort uint16)
 	t.logger.Info("gossip transport server listening", log.Uint32("port", uint32(t.serverPort)))
 
 	for {
+		if ctx.Err() != nil {
+			t.logger.Info("ending server main loop (system shutting down)")
+		}
+
 		conn, err := listener.Accept()
 		if err != nil {
 			if !t.isServerListening() {

--- a/services/gossip/adapter/direct_transport.go
+++ b/services/gossip/adapter/direct_transport.go
@@ -50,7 +50,7 @@ func NewDirectTransport(ctx context.Context, config config.GossipTransportConfig
 	}
 
 	// server goroutine
-	supervised.LongLived(ctx, logger, func() {
+	supervised.GoForever(ctx, logger, func() {
 		t.serverMainLoop(ctx, t.config.GossipListenPort())
 	})
 

--- a/services/transactionpool/forward_transactions.go
+++ b/services/transactionpool/forward_transactions.go
@@ -80,7 +80,7 @@ func (f *transactionForwarder) submit(transaction *protocol.SignedTransaction) {
 }
 
 func (f *transactionForwarder) start(ctx context.Context) {
-	supervised.LongLived(ctx, f.logger, func() {
+	supervised.GoForever(ctx, f.logger, func() {
 		for {
 			timer := synchronization.NewTimer(f.config.TransactionPoolPropagationBatchingTimeout())
 

--- a/synchronization/supervised/supervisor.go
+++ b/synchronization/supervised/supervisor.go
@@ -47,7 +47,7 @@ func LongLived(ctx context.Context, logger Errorer, f func()) {
 		f()
 	}
 
-	go func() {
+	supervise := func() {
 		for {
 			select {
 			case <-ctx.Done():
@@ -62,8 +62,9 @@ func LongLived(ctx context.Context, logger Errorer, f func()) {
 
 			}
 		}
-	}()
+	}
 
+	go supervise()
 	go run()
 }
 

--- a/synchronization/supervised/supervisor.go
+++ b/synchronization/supervised/supervisor.go
@@ -14,58 +14,38 @@ type Errorer interface {
 	Error(message string, fields ...*log.Field)
 }
 
-type failure struct {
-	stackTrace string
-	e          error
-}
-
 // Runs f() in a goroutine; if it panics, logs the error and stack trace to the specified Errorer
-func ShortLived(logger Errorer, f func()) {
+func GoOnce(errorer Errorer, f func()) {
 	go func() {
-		defer func() {
-			if p := recover(); p != nil {
-				e := errors.Errorf("goroutine panicked at [%s]: %v", identifyPanic(), p)
-				logger.Error("recovered panic", log.Error(e), log.String("stack-trace", string(debug.Stack())))
-			}
-		}()
-		f()
+		tryOnce(errorer, f)
 	}()
 }
 
 // Runs f() in a goroutine; if it panics, logs the error and stack trace to the specified Errorer; if the provided Context isn't closed, re-runs f()
-func LongLived(ctx context.Context, logger Errorer, f func()) {
-	failed := make(chan *failure)
-
-	run := func() {
-		defer func() {
-			if p := recover(); p != nil {
-				e := errors.Errorf("goroutine panicked at [%s]: %v", identifyPanic(), p)
-				failed <- &failure{e: e, stackTrace: string(debug.Stack())}
-			}
-		}()
-
-		f()
-	}
-
-	supervise := func() {
+func GoForever(ctx context.Context, logger Errorer, f func()) {
+	go func() {
 		for {
-			select {
-			case <-ctx.Done():
+			tryOnce(logger, f)
+			//TODO count restarts, fail if too many restarts, etc
+			if ctx.Err() != nil { // this returns non-nil when context has been closed via cancellation or timeout or whatever
 				return
-			case failure := <-failed:
-				//TODO count restarts, fail if too many restarts, etc
-
-				if ctx.Err() == nil {
-					logger.Error("recovered panic", log.Error(failure.e), log.String("stack-trace", failure.stackTrace))
-					go run()
-				}
-
 			}
 		}
-	}
+	}()
+}
 
-	go supervise()
-	go run()
+// this function is needed so that we don't return out of the goroutine when it panics
+func tryOnce(errorer Errorer, f func()) {
+	defer recoverPanics(errorer)
+	f()
+
+}
+
+func recoverPanics(logger Errorer) {
+	if p := recover(); p != nil {
+		e := errors.Errorf("goroutine panicked at [%s]: %v", identifyPanic(), p)
+		logger.Error("recovered panic", log.Error(e), log.String("stack-trace", string(debug.Stack())))
+	}
 }
 
 func identifyPanic() string {

--- a/synchronization/supervised/supervisor_test.go
+++ b/synchronization/supervised/supervisor_test.go
@@ -30,12 +30,12 @@ func localFunctionThatPanics() {
 	panic("foo")
 }
 
-func TestShortLived_ReportsOnPanic(t *testing.T) {
+func TestGoOnce_ReportsOnPanic(t *testing.T) {
 	logger := mockLogger()
 
 	require.NotPanicsf(t, func() {
-		ShortLived(logger, localFunctionThatPanics)
-	}, "ShortLived panicked unexpectedly")
+		GoOnce(logger, localFunctionThatPanics)
+	}, "GoOnce panicked unexpectedly")
 
 	report := <-logger.errors
 	require.Equal(t, report.message, "recovered panic")
@@ -49,7 +49,7 @@ func TestShortLived_ReportsOnPanic(t *testing.T) {
 	require.Contains(t, stackTraceField.Value(), "localFunctionThatPanics")
 }
 
-func TestLongLived_ReportsOnPanicAndRestarts(t *testing.T) {
+func TestGoForever_ReportsOnPanicAndRestarts(t *testing.T) {
 	numOfIterations := 10
 
 	logger := mockLogger()
@@ -58,14 +58,15 @@ func TestLongLived_ReportsOnPanicAndRestarts(t *testing.T) {
 	count := 0
 
 	require.NotPanicsf(t, func() {
-		LongLived(ctx, logger, func() {
-			count++
+		GoForever(ctx, logger, func() {
 			if count > numOfIterations {
 				cancel()
+			} else {
+				count++
 			}
 			panic("foo")
 		})
-	}, "LongLived panicked unexpectedly")
+	}, "GoForever panicked unexpectedly")
 
 	for i := 0; i < numOfIterations; i++ {
 		select {
@@ -75,5 +76,11 @@ func TestLongLived_ReportsOnPanicAndRestarts(t *testing.T) {
 			require.Fail(t, "long living goroutine didn't restart")
 		}
 	}
+}
+
+func TestGoForever_TerminatesWhenContextIsClosed(t *testing.T) {
 
 }
+
+
+

--- a/synchronization/trigger.go
+++ b/synchronization/trigger.go
@@ -52,7 +52,7 @@ func (t *periodicalTrigger) TimesTriggered() uint64 {
 func (t *periodicalTrigger) run(ctx context.Context) {
 	t.ticker = time.NewTicker(t.d)
 	go func() {
-		supervised.LongLived(ctx, t.logger, func() {
+		supervised.GoForever(ctx, t.logger, func() {
 			t.wgSync.Add(1)
 			defer t.wgSync.Done()
 			for {

--- a/test/harness/contracts/api.go
+++ b/test/harness/contracts/api.go
@@ -33,7 +33,7 @@ func NewContractClient(apis []APIProvider, logger log.BasicLogger) *contractClie
 
 func (c *contractClient) sendTransaction(ctx context.Context, tx *protocol.SignedTransactionBuilder, nodeIndex int) chan *client.SendTransactionResponse {
 	ch := make(chan *client.SendTransactionResponse)
-	supervised.ShortLived(c.logger, func() {
+	supervised.GoOnce(c.logger, func() {
 		publicApi := c.apis[nodeIndex].GetPublicApi()
 		output, err := publicApi.SendTransaction(ctx, &services.SendTransactionInput{
 			ClientRequest: (&client.SendTransactionRequestBuilder{SignedTransaction: tx}).Build(),
@@ -49,7 +49,7 @@ func (c *contractClient) sendTransaction(ctx context.Context, tx *protocol.Signe
 func (c *contractClient) callMethod(ctx context.Context, tx *protocol.TransactionBuilder, nodeIndex int) chan uint64 {
 
 	ch := make(chan uint64)
-	supervised.ShortLived(c.logger, func() {
+	supervised.GoOnce(c.logger, func() {
 		publicApi := c.apis[nodeIndex].GetPublicApi()
 		output, err := publicApi.CallMethod(ctx, &services.CallMethodInput{
 			ClientRequest: (&client.CallMethodRequestBuilder{Transaction: tx}).Build(),

--- a/test/harness/contracts/benchmark_token.go
+++ b/test/harness/contracts/benchmark_token.go
@@ -48,7 +48,7 @@ func (c *contractClient) SendTransferInBackground(ctx context.Context, nodeIndex
 			Builder(),
 	}).Build()
 
-	supervised.ShortLived(c.logger, func() {
+	supervised.GoOnce(c.logger, func() {
 		publicApi := c.apis[nodeIndex].GetPublicApi()
 		publicApi.SendTransaction(ctx, &services.SendTransactionInput{ // we ignore timeout here.
 			ClientRequest: request,

--- a/test/harness/services/gossip/adapter/tampering_transport.go
+++ b/test/harness/services/gossip/adapter/tampering_transport.go
@@ -88,7 +88,7 @@ func (t *tamperingTransport) Send(ctx context.Context, data *adapter.TransportDa
 		return err
 	}
 
-	supervised.ShortLived(t.logger, func() {
+	supervised.GoOnce(t.logger, func() {
 		t.receive(ctx, data)
 	})
 
@@ -262,7 +262,7 @@ type duplicatingTamperer struct {
 
 func (o *duplicatingTamperer) maybeTamper(ctx context.Context, data *adapter.TransportData) (error, bool) {
 	if o.predicate(data) {
-		supervised.ShortLived(o.transport.logger, func() {
+		supervised.GoOnce(o.transport.logger, func() {
 			time.Sleep(10 * time.Millisecond)
 			o.transport.receive(ctx, data)
 		})
@@ -282,7 +282,7 @@ type delayingTamperer struct {
 
 func (o *delayingTamperer) maybeTamper(ctx context.Context, data *adapter.TransportData) (error, bool) {
 	if o.predicate(data) {
-		supervised.ShortLived(o.transport.logger, func() {
+		supervised.GoOnce(o.transport.logger, func() {
 			time.Sleep(o.duration())
 			o.transport.receive(ctx, data)
 		})


### PR DESCRIPTION
- renamed `ShortLived` to `GoOnce` and `LongLived` to `GoForever`
- added test asserting that `GoForever` ends
- fixed `DirectTransport` to shut down when context ends