### PR TITLE
BlockTracker no longer takes timeout

### DIFF
--- a/services/blockstorage/test/commit_block_test.go
+++ b/services/blockstorage/test/commit_block_test.go
@@ -131,7 +131,7 @@ func TestCommitBlockWithSameTransactionTwice(t *testing.T) {
 		_, err = harness.commitBlock(ctx, block1)
 		require.NoError(t, err)
 
-		blockHeight := harness.storageAdapter.WaitForTransaction(ctx, txHash, 10*time.Millisecond)
+		blockHeight := harness.storageAdapter.WaitForTransaction(ctx, txHash)
 		require.EqualValues(t, 1, blockHeight)
 
 		harness.verifyMocks(t, 1)

--- a/services/blockstorage/test/get_block_headers_test.go
+++ b/services/blockstorage/test/get_block_headers_test.go
@@ -86,7 +86,7 @@ func TestReturnTransactionBlockHeaderFromNearFutureFailsWhenContextEnds(t *testi
 		}
 
 		err := <-timeoutError
-		require.EqualError(t, err, "timed out waiting for block at height 5", "expect a timeout as the requested block height never reached")
+		require.EqualError(t, err, "aborted while waiting for block at height 5: context canceled", "expect a timeout as the requested block height never reached")
 	})
 }
 
@@ -166,6 +166,6 @@ func TestReturnResultsBlockHeaderFromNearFutureFailsWhenContextEnds(t *testing.T
 		}
 
 		err := <-timeoutError
-		require.EqualError(t, err, "timed out waiting for block at height 5", "expect a timeout as the requested block height never reached")
+		require.EqualError(t, err, "aborted while waiting for block at height 5: context canceled", "expect a timeout as the requested block height never reached")
 	})
 }

--- a/services/blockstorage/test/harness.go
+++ b/services/blockstorage/test/harness.go
@@ -168,11 +168,6 @@ func (d *harness) setupCustomBlocksForInit() time.Time {
 	return now
 }
 
-func (d *harness) withBlockTrackerTimeout(duration time.Duration) *harness {
-	d.storageAdapter = adapter.NewInMemoryBlockPersistenceWithBlockTimeout(duration)
-	return d
-}
-
 func createConfig(nodePublicKey primitives.Ed25519PublicKey) config.BlockStorageConfig {
 	cfg := &configForBlockStorageTests{}
 	cfg.pk = nodePublicKey

--- a/services/statestorage/test/get_state_hash_test.go
+++ b/services/statestorage/test/get_state_hash_test.go
@@ -25,7 +25,7 @@ func TestGetStateHashFutureHeightWithinGrace(t *testing.T) {
 		d := newStateStorageDriverWithGrace(1, 1, 1)
 
 		output, err := d.service.GetStateHash(ctx, &services.GetStateHashInput{BlockHeight: 1})
-		require.EqualError(t, errors.Cause(err), "timed out waiting for block at height 1", "expected timeout error")
+		require.EqualError(t, errors.Cause(err), "context deadline exceeded", "expected timeout error")
 		require.Nil(t, output, "expected nil output when timing out")
 	})
 }

--- a/services/transactionpool/get_transactions_for_ordering.go
+++ b/services/transactionpool/get_transactions_for_ordering.go
@@ -10,7 +10,8 @@ import (
 
 func (s *service) GetTransactionsForOrdering(ctx context.Context, input *services.GetTransactionsForOrderingInput) (*services.GetTransactionsForOrderingOutput, error) {
 
-	if err := s.blockTracker.WaitForBlock(ctx, input.BlockHeight); err != nil {
+	timeoutCtx, _ := context.WithTimeout(ctx, s.config.BlockTrackerGraceTimeout())
+	if err := s.blockTracker.WaitForBlock(timeoutCtx, input.BlockHeight); err != nil {
 		return nil, err
 	}
 

--- a/services/transactionpool/service.go
+++ b/services/transactionpool/service.go
@@ -59,7 +59,7 @@ func NewTransactionPool(ctx context.Context,
 
 		pendingPool:          pendingPool,
 		committedPool:        committedPool,
-		blockTracker:         synchronization.NewBlockTracker(0, uint16(config.BlockTrackerGraceDistance()), time.Duration(config.BlockTrackerGraceTimeout())),
+		blockTracker:         synchronization.NewBlockTracker(0, uint16(config.BlockTrackerGraceDistance())),
 		transactionForwarder: txForwarder,
 	}
 
@@ -104,7 +104,8 @@ func (s *service) currentBlockHeightAndTime() (primitives.BlockHeight, primitive
 }
 
 func (s *service) ValidateTransactionsForOrdering(ctx context.Context, input *services.ValidateTransactionsForOrderingInput) (*services.ValidateTransactionsForOrderingOutput, error) {
-	if err := s.blockTracker.WaitForBlock(ctx, input.BlockHeight); err != nil {
+	timeoutCtx, _ := context.WithTimeout(ctx, s.config.BlockTrackerGraceTimeout())
+	if err := s.blockTracker.WaitForBlock(timeoutCtx, input.BlockHeight); err != nil {
 		return nil, err
 	}
 

--- a/services/transactionpool/test/get_transactions_for_ordering_test.go
+++ b/services/transactionpool/test/get_transactions_for_ordering_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/test/builders"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
@@ -170,7 +171,7 @@ func TestGetTransactionsForOrderingAsOfFutureBlockHeightTimesOutWhenNoBlockIsCom
 			MaxNumberOfTransactions: 1,
 		})
 
-		require.EqualError(t, err, "timed out waiting for block at height 2", "did not time out")
+		require.EqualError(t, errors.Cause(err), "context deadline exceeded", "did not time out")
 	})
 }
 

--- a/synchronization/block_tracker.go
+++ b/synchronization/block_tracker.go
@@ -2,6 +2,7 @@ package synchronization
 
 import (
 	"context"
+	"fmt"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/pkg/errors"
 	"sync"
@@ -63,7 +64,7 @@ func (t *BlockTracker) WaitForBlock(ctx context.Context, requestedHeight primiti
 		}
 		select {
 		case <-ctx.Done():
-			return errors.Errorf("timed out waiting for block at height %v", requestedHeight)
+			return errors.Wrap(ctx.Err(), fmt.Sprintf("aborted while waiting for block at height %v", requestedHeight))
 		case <-currentLatch:
 			currentHeight, currentLatch = t.readAtomicHeightAndLatch()
 		}

--- a/synchronization/block_tracker.go
+++ b/synchronization/block_tracker.go
@@ -5,12 +5,10 @@ import (
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/pkg/errors"
 	"sync"
-	"time"
 )
 
 type BlockTracker struct {
 	graceDistance uint16 // this is not primitives.BlockHeight on purpose, to indicate that grace distance should be small
-	timeout       time.Duration
 
 	mutex         sync.RWMutex
 	currentHeight uint64 // this is not primitives.BlockHeight so as to avoid unnecessary casts
@@ -19,11 +17,10 @@ type BlockTracker struct {
 	fireOnWait func() // used by unit test
 }
 
-func NewBlockTracker(startingHeight uint64, graceDist uint16, timeout time.Duration) *BlockTracker {
+func NewBlockTracker(startingHeight uint64, graceDist uint16) *BlockTracker {
 	return &BlockTracker{
 		currentHeight: startingHeight,
 		graceDistance: graceDist,
-		timeout:       timeout,
 		latch:         make(chan struct{}),
 	}
 }
@@ -45,6 +42,8 @@ func (t *BlockTracker) readAtomicHeightAndLatch() (uint64, chan struct{}) {
 	return t.currentHeight, t.latch
 }
 
+// waits until we reach a block at the specified height, or until the context is closed
+// to wait until some timeout, pass a child context with a deadline
 func (t *BlockTracker) WaitForBlock(ctx context.Context, requestedHeight primitives.BlockHeight) error {
 
 	requestedHeightUint := uint64(requestedHeight)
@@ -57,9 +56,6 @@ func (t *BlockTracker) WaitForBlock(ctx context.Context, requestedHeight primiti
 	if currentHeight+uint64(t.graceDistance) < requestedHeightUint { // requested block too far ahead, no grace
 		return errors.Errorf("requested future block outside of grace range")
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, t.timeout)
-	defer cancel()
 
 	for currentHeight < requestedHeightUint {
 		if t.fireOnWait != nil {

--- a/synchronization/block_tracker_test.go
+++ b/synchronization/block_tracker_test.go
@@ -6,37 +6,40 @@ import (
 	"github.com/stretchr/testify/require"
 	"sync/atomic"
 	"testing"
-	"time"
 )
 
 func TestWaitForBlockOutsideOfGraceFailsImmediately(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		tracker := NewBlockTracker(1, 1, 10*time.Millisecond)
+		tracker := NewBlockTracker(1, 1)
 
 		err := tracker.WaitForBlock(ctx, 3)
 		require.EqualError(t, err, "requested future block outside of grace range", "did not fail immediately")
 	})
 }
 
-func TestWaitForBlockWithinGraceFailsAfterTimeout(t *testing.T) {
-	test.WithContext(func(ctx context.Context) {
-		tracker := NewBlockTracker(1, 1, 1*time.Millisecond)
+func TestWaitForBlockWithinGraceFailsWhenContextEnds(t *testing.T) {
+	test.WithContext(func(parentCtx context.Context) {
+		ctx, cancel := context.WithCancel(parentCtx)
+		tracker := NewBlockTracker(1, 1)
+		cancel()
 		err := tracker.WaitForBlock(ctx, 2)
 		require.EqualError(t, err, "timed out waiting for block at height 2", "did not timeout as expected")
 	})
 }
 
 func TestWaitForBlockWithinGraceDealsWithIntegerUnderflow(t *testing.T) {
-	test.WithContext(func(ctx context.Context) {
-		tracker := NewBlockTracker(0, 5, 1*time.Millisecond)
+	test.WithContext(func(parentCtx context.Context) {
+		ctx, cancel := context.WithCancel(parentCtx)
+		tracker := NewBlockTracker(0, 5)
+		cancel()
 		err := tracker.WaitForBlock(ctx, 2)
 		require.EqualError(t, err, "timed out waiting for block at height 2", "did not timeout as expected")
 	})
 }
 
-func TestWaitForBlockWithinGraceReturnsWhenBlockHeightReachedBeforeTimeoutAfterWaiting(t *testing.T) {
+func TestWaitForBlockWithinGraceReturnsWhenBlockHeightReachedBeforeContextEnds(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		tracker := NewBlockTracker(1, 2, 1*time.Second)
+		tracker := NewBlockTracker(1, 2)
 
 		var waitCount int32
 		internalWaitChan := make(chan int32)
@@ -60,7 +63,7 @@ func TestWaitForBlockWithinGraceReturnsWhenBlockHeightReachedBeforeTimeoutAfterW
 
 func TestWaitForBlockWithinGraceSupportsTwoConcurrentWaiters(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		tracker := NewBlockTracker(1, 1, 1*time.Second)
+		tracker := NewBlockTracker(1, 1)
 
 		var waitCount int32
 		internalWaitChan := make(chan int32)

--- a/synchronization/block_tracker_test.go
+++ b/synchronization/block_tracker_test.go
@@ -23,7 +23,7 @@ func TestWaitForBlockWithinGraceFailsWhenContextEnds(t *testing.T) {
 		tracker := NewBlockTracker(1, 1)
 		cancel()
 		err := tracker.WaitForBlock(ctx, 2)
-		require.EqualError(t, err, "timed out waiting for block at height 2", "did not timeout as expected")
+		require.EqualError(t, err, "aborted while waiting for block at height 2: context canceled", "did not fail as expected")
 	})
 }
 
@@ -33,7 +33,7 @@ func TestWaitForBlockWithinGraceDealsWithIntegerUnderflow(t *testing.T) {
 		tracker := NewBlockTracker(0, 5)
 		cancel()
 		err := tracker.WaitForBlock(ctx, 2)
-		require.EqualError(t, err, "timed out waiting for block at height 2", "did not timeout as expected")
+		require.EqualError(t, err, "aborted while waiting for block at height 2: context canceled", "did not fail as expected")
 	})
 }
 

--- a/test/acceptance/consensus_test.go
+++ b/test/acceptance/consensus_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 func TestLeanHelixLeaderGetsValidationsBeforeCommit(t *testing.T) {
@@ -46,35 +47,36 @@ func TestBenchmarkConsensusLeaderGetsVotesBeforeNextBlock(t *testing.T) {
 		AllowingErrors(
 			"consensus round tick failed", // (aborting shared state update due to inconsistency) //TODO investigate and explain, or fix and remove expected error
 		).WithMaxTxPerBlock(1).
-		Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
+		Start(func(parent context.Context, network harness.InProcessTestNetwork) {
+			ctx, _ := context.WithTimeout(parent, 1*time.Second)
 
-		  contract := network.GetBenchmarkTokenContract()
-		  contract.DeployBenchmarkToken(ctx, 5)
+			contract := network.GetBenchmarkTokenContract()
+			contract.DeployBenchmarkToken(ctx, 5)
 
 			committedTamper := network.GossipTransport().Fail(adapter.BenchmarkConsensusMessage(consensus.BENCHMARK_CONSENSUS_COMMITTED))
 			blockSyncTamper := network.GossipTransport().Fail(adapter.BlockSyncMessage(gossipmessages.BLOCK_SYNC_AVAILABILITY_REQUEST)) // block sync discovery message so it does not add the blocks in a 'back door'
 			committedLatch := network.GossipTransport().LatchOn(adapter.BenchmarkConsensusMessage(consensus.BENCHMARK_CONSENSUS_COMMITTED))
 
-		  contract.SendTransferInBackground(ctx, 0, 0, 5, 6) // send a transaction so that network advances to block 1. the tamper prevents COMMITTED messages from reaching leader, so it doesn't move to block 2
-		  committedLatch.Wait()                             // wait for validator to try acknowledge that it reached block 1 (and fail)
-		  committedLatch.Wait()                             // wait for another consensus round (to make sure transaction(0) does not arrive after transaction(17) due to scheduling flakiness
+			contract.SendTransferInBackground(ctx, 0, 0, 5, 6) // send a transaction so that network advances to block 1. the tamper prevents COMMITTED messages from reaching leader, so it doesn't move to block 2
+			committedLatch.Wait()                              // wait for validator to try acknowledge that it reached block 1 (and fail)
+			committedLatch.Wait()                              // wait for another consensus round (to make sure transaction(0) does not arrive after transaction(17) due to scheduling flakiness
 
-		  txHash := contract.SendTransferInBackground(ctx, 0, 17, 5, 6) // this should be included in block 2 which will not be closed until leader knows network is at block 2
+			txHash := contract.SendTransferInBackground(ctx, 0, 17, 5, 6) // this should be included in block 2 which will not be closed until leader knows network is at block 2
 
 			committedLatch.Wait()
 
-		  require.EqualValues(t, 0, <-contract.CallGetBalance(ctx, 0, 6), "initial getBalance result on leader")
-		  require.EqualValues(t, 0, <-contract.CallGetBalance(ctx, 1, 6), "initial getBalance result on non leader")
+			require.EqualValues(t, 0, <-contract.CallGetBalance(ctx, 0, 6), "initial getBalance result on leader")
+			require.EqualValues(t, 0, <-contract.CallGetBalance(ctx, 1, 6), "initial getBalance result on non leader")
 
 			committedLatch.Remove()
 			committedTamper.Release(ctx) // this will allow COMMITTED messages to reach leader so that it can progress
 
-	  	network.WaitForTransactionInState(ctx, 0, txHash)
-	  	require.EqualValues(t, 17, <-contract.CallGetBalance(ctx, 0, 6), "eventual getBalance result on leader")
+			network.WaitForTransactionInState(ctx, 0, txHash)
+			require.EqualValues(t, 17, <-contract.CallGetBalance(ctx, 0, 6), "eventual getBalance result on leader")
 
-	  	network.WaitForTransactionInState(ctx, 1, txHash)
-	  	require.EqualValues(t, 17, <-contract.CallGetBalance(ctx, 1, 6), "eventual getBalance result on non leader")
+			network.WaitForTransactionInState(ctx, 1, txHash)
+			require.EqualValues(t, 17, <-contract.CallGetBalance(ctx, 1, 6), "eventual getBalance result on non leader")
 
 			blockSyncTamper.Release(ctx)
-		})
+	})
 }

--- a/test/acceptance/simple_transfer_test.go
+++ b/test/acceptance/simple_transfer_test.go
@@ -8,15 +8,17 @@ import (
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 func TestLeaderCommitsTransactionsAndSkipsInvalidOnes(t *testing.T) {
 	harness.Network(t).
 		AllowingErrors(
 			"consensus round tick failed", // (aborting shared state update due to inconsistency) //TODO investigate and explain, or fix and remove expected error
-		).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
-		contract := network.GetBenchmarkTokenContract()
+		).Start(func(parent context.Context, network harness.InProcessTestNetwork) {
+		ctx, _ := context.WithTimeout(parent, 1 * time.Second)
 
+		contract := network.GetBenchmarkTokenContract()
 		contract.DeployBenchmarkToken(ctx, 5)
 
 		t.Log("testing", network.Description()) // leader is nodeIndex 0, validator is nodeIndex 1
@@ -46,9 +48,10 @@ func TestNonLeaderPropagatesTransactionsToLeader(t *testing.T) {
 	harness.Network(t).
 		AllowingErrors(
 			"consensus round tick failed", // (aborting shared state update due to inconsistency) //TODO investigate and explain, or fix and remove expected error
-		).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
-		contract := network.GetBenchmarkTokenContract()
+		).Start(func(parent context.Context, network harness.InProcessTestNetwork) {
+		ctx, _ := context.WithTimeout(parent, 1 * time.Second)
 
+		contract := network.GetBenchmarkTokenContract()
 		contract.DeployBenchmarkToken(ctx, 5)
 
 		t.Log("testing", network.Description()) // leader is nodeIndex 0, validator is nodeIndex 1

--- a/test/acceptance/stress_test.go
+++ b/test/acceptance/stress_test.go
@@ -59,7 +59,9 @@ func TestCreateGazillionTransactionsWhileTransportIsDelayingRandomMessages(t *te
 
 func TestCreateGazillionTransactionsWhileTransportIsCorruptingRandomMessages(t *testing.T) {
 	t.Skip("this test causes the system to hang, seems like consensus algo stops")
-	harness.Network(t).WithNumNodes(3).Start(func(ctx context.Context, network harness.InProcessTestNetwork) {
+	harness.Network(t).WithNumNodes(3).Start(func(parent context.Context, network harness.InProcessTestNetwork) {
+		ctx, _ := context.WithTimeout(parent, 2 * time.Second)
+
 		network.GossipTransport().Corrupt(Not(HasHeader(ATransactionRelayMessage)).And(AnyNthMessage(7)))
 
 		sendTransfersAndAssertTotalBalance(ctx, network, t, 100)

--- a/test/harness/contracts/api.go
+++ b/test/harness/contracts/api.go
@@ -19,7 +19,7 @@ import (
 type APIProvider interface {
 	GetPublicApi() services.PublicApi
 	GetCompiler() adapter.Compiler
-	WaitForTransactionInStateForAtMost(ctx context.Context, txhash primitives.Sha256, atMost time.Duration)
+	WaitForTransactionInStateForAtMost(ctx context.Context, txhash primitives.Sha256, atMost time.Duration) // TODO remove atMost and use context with timeout
 }
 
 type contractClient struct {

--- a/test/harness/contracts/api.go
+++ b/test/harness/contracts/api.go
@@ -11,7 +11,6 @@ import (
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/client"
 	"github.com/orbs-network/orbs-spec/types/go/services"
-	"time"
 )
 
 //TODO abstract public API's methods
@@ -19,7 +18,7 @@ import (
 type APIProvider interface {
 	GetPublicApi() services.PublicApi
 	GetCompiler() adapter.Compiler
-	WaitForTransactionInStateForAtMost(ctx context.Context, txhash primitives.Sha256, atMost time.Duration) // TODO remove atMost and use context with timeout
+	WaitForTransactionInState(ctx context.Context, txhash primitives.Sha256)
 }
 
 type contractClient struct {

--- a/test/harness/contracts/benchmark_token.go
+++ b/test/harness/contracts/benchmark_token.go
@@ -24,7 +24,8 @@ type BenchmarkTokenClient interface {
 func (c *contractClient) DeployBenchmarkToken(ctx context.Context, ownerAddressIndex int) {
 	tx := <-c.SendTransfer(ctx, 0, 0, ownerAddressIndex, ownerAddressIndex) // deploy BenchmarkToken by running an empty transaction
 	for _, api := range c.apis {
-		api.WaitForTransactionInStateForAtMost(ctx, tx.TransactionReceipt().Txhash(), 1 * time.Second)
+		timeoutCtx, _ := context.WithTimeout(ctx, 1 * time.Second)
+		api.WaitForTransactionInState(timeoutCtx, tx.TransactionReceipt().Txhash())
 	}
 }
 

--- a/test/harness/network.go
+++ b/test/harness/network.go
@@ -78,8 +78,10 @@ func (n *networkNode) GetCompiler() nativeProcessorAdapter.Compiler {
 }
 
 func (n *networkNode) WaitForTransactionInStateForAtMost(ctx context.Context, txhash primitives.Sha256, atMost time.Duration) {
-	blockHeight := n.blockPersistence.WaitForTransaction(ctx, txhash, atMost)
-	err := n.statePersistence.WaitUntilCommittedBlockOfHeight(ctx, blockHeight)
+	timeoutCtx, _ := context.WithTimeout(ctx, atMost)
+
+	blockHeight := n.blockPersistence.WaitForTransaction(timeoutCtx, txhash, atMost)
+	err := n.statePersistence.WaitUntilCommittedBlockOfHeight(timeoutCtx, blockHeight)
 	if err != nil {
 		test.DebugPrintGoroutineStacks() // since test timed out, help find deadlocked goroutines
 		panic(fmt.Sprintf("statePersistence.WaitUntilCommittedBlockOfHeight failed: %s", err.Error()))

--- a/test/harness/network.go
+++ b/test/harness/network.go
@@ -15,7 +15,6 @@ import (
 	stateStorageAdapter "github.com/orbs-network/orbs-network-go/test/harness/services/statestorage/adapter"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/services"
-	"time"
 )
 
 type InProcessNetwork interface {
@@ -77,11 +76,9 @@ func (n *networkNode) GetCompiler() nativeProcessorAdapter.Compiler {
 	return n.nativeCompiler
 }
 
-func (n *networkNode) WaitForTransactionInStateForAtMost(ctx context.Context, txhash primitives.Sha256, atMost time.Duration) {
-	timeoutCtx, _ := context.WithTimeout(ctx, atMost)
-
-	blockHeight := n.blockPersistence.WaitForTransaction(timeoutCtx, txhash, atMost)
-	err := n.statePersistence.WaitUntilCommittedBlockOfHeight(timeoutCtx, blockHeight)
+func (n *networkNode) WaitForTransactionInState(ctx context.Context, txhash primitives.Sha256) {
+	blockHeight := n.blockPersistence.WaitForTransaction(ctx, txhash)
+	err := n.statePersistence.WaitUntilCommittedBlockOfHeight(ctx, blockHeight)
 	if err != nil {
 		test.DebugPrintGoroutineStacks() // since test timed out, help find deadlocked goroutines
 		panic(fmt.Sprintf("statePersistence.WaitUntilCommittedBlockOfHeight failed: %s", err.Error()))
@@ -89,7 +86,7 @@ func (n *networkNode) WaitForTransactionInStateForAtMost(ctx context.Context, tx
 }
 
 func (n *inProcessNetwork) WaitForTransactionInState(ctx context.Context, nodeIndex int, txhash primitives.Sha256) {
-	n.nodes[nodeIndex].WaitForTransactionInStateForAtMost(ctx, txhash, 1*time.Second)
+	n.nodes[nodeIndex].WaitForTransactionInState(ctx, txhash)
 }
 
 func (n *inProcessNetwork) MetricsString(i int) string {

--- a/test/harness/services/blockstorage/adapter/memory_persistence.go
+++ b/test/harness/services/blockstorage/adapter/memory_persistence.go
@@ -39,13 +39,9 @@ type inMemoryBlockPersistence struct {
 }
 
 func NewInMemoryBlockPersistence() InMemoryBlockPersistence {
-	return NewInMemoryBlockPersistenceWithBlockTimeout(1000 * time.Millisecond)
-}
-
-func NewInMemoryBlockPersistenceWithBlockTimeout(duration time.Duration) InMemoryBlockPersistence {
 	p := &inMemoryBlockPersistence{
 		failNextBlocks: false,
-		tracker:        synchronization.NewBlockTracker(0, 5, duration),
+		tracker:        synchronization.NewBlockTracker(0, 5),
 	}
 
 	p.blockHeightsPerTxHash.channels = make(map[string]blockHeightChan)

--- a/test/harness/services/blockstorage/adapter/memory_persistence.go
+++ b/test/harness/services/blockstorage/adapter/memory_persistence.go
@@ -17,8 +17,7 @@ import (
 type InMemoryBlockPersistence interface {
 	adapter.BlockPersistence
 	FailNextBlocks()
-	// TODO: atMost time.Duration can probably be combined into ctx and removed (context refactor)
-	WaitForTransaction(ctx context.Context, txhash primitives.Sha256, atMost time.Duration) primitives.BlockHeight
+	WaitForTransaction(ctx context.Context, txhash primitives.Sha256) primitives.BlockHeight
 }
 
 type blockHeightChan chan primitives.BlockHeight
@@ -53,13 +52,13 @@ func (bp *inMemoryBlockPersistence) GetBlockTracker() *synchronization.BlockTrac
 	return bp.tracker
 }
 
-func (bp *inMemoryBlockPersistence) WaitForTransaction(ctx context.Context, txhash primitives.Sha256, atMost time.Duration) primitives.BlockHeight {
+func (bp *inMemoryBlockPersistence) WaitForTransaction(ctx context.Context, txhash primitives.Sha256) primitives.BlockHeight {
 	ch := bp.getChanFor(txhash)
 
 	select {
 	case h := <-ch:
 		return h
-	case <-time.After(atMost):
+	case <-ctx.Done():
 		test.DebugPrintGoroutineStacks() // since test timed out, help find deadlocked goroutines
 		panic(fmt.Sprintf("timed out waiting for transaction with hash %s", txhash))
 	}

--- a/test/harness/services/statestorage/adapter/memory_persistence.go
+++ b/test/harness/services/statestorage/adapter/memory_persistence.go
@@ -5,7 +5,6 @@ import (
 	"github.com/orbs-network/orbs-network-go/services/statestorage/adapter"
 	"github.com/orbs-network/orbs-network-go/synchronization"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
-	"time"
 )
 
 type TamperingStatePersistence interface {
@@ -22,7 +21,7 @@ type TestStatePersistence struct {
 func NewTamperingStatePersistence() TamperingStatePersistence {
 	return &TestStatePersistence{
 		InMemoryStatePersistence: adapter.NewInMemoryStatePersistence(),
-		blockTrackerForTests:     synchronization.NewBlockTracker(0, 64000, time.Duration(10*time.Second)),
+		blockTrackerForTests:     synchronization.NewBlockTracker(0, 64000),
 	}
 }
 


### PR DESCRIPTION
Changed block tracker's API to rely on context cancellation for timing out
This transfers responsibility for setting timeout for the caller, but it makes it more flexible and ensures that timeouts can be global for a specific use case or test.

It also enables sending timeouts from the client .