### PR TITLE
added regexp support to ErrorRecordingOutput

### DIFF
--- a/instrumentation/log/error_recording_output.go
+++ b/instrumentation/log/error_recording_output.go
@@ -2,13 +2,14 @@ package log
 
 import (
 	"fmt"
+	"regexp"
 	"sync"
 )
 
 type ErrorRecordingOutput struct {
-	allowedErrors []string
-
-	errorRecorder *errorRecorder
+	allowedErrors       []string
+	allowedErrorsRegExp []string
+	errorRecorder       *errorRecorder
 }
 
 type errorRecorder struct {
@@ -25,14 +26,19 @@ func (e *unexpectedError) String() string {
 	return fmt.Sprintf("%s (passed Error object: %v)", e.message, e.err)
 }
 
-func NewErrorRecordingOutput(allowedErrors []string) *ErrorRecordingOutput {
-	return &ErrorRecordingOutput{allowedErrors: allowedErrors, errorRecorder: &errorRecorder{}}
+func NewErrorRecordingOutput(allowedErrors []string, allowedErrorsRegExp []string) *ErrorRecordingOutput {
+	return &ErrorRecordingOutput{allowedErrors: allowedErrors, allowedErrorsRegExp: allowedErrorsRegExp, errorRecorder: &errorRecorder{}}
 }
 
 func (o *ErrorRecordingOutput) Append(level string, message string, params ...*Field) {
 	if level == "error" {
 		for _, allowedMessage := range o.allowedErrors {
 			if allowedMessage == message {
+				return
+			}
+		}
+		for _, allowedMessageRegExp := range o.allowedErrorsRegExp {
+			if matched, _ := regexp.MatchString(allowedMessageRegExp, message); matched {
 				return
 			}
 		}

--- a/instrumentation/log/error_recording_output_test.go
+++ b/instrumentation/log/error_recording_output_test.go
@@ -7,25 +7,25 @@ import (
 )
 
 func TestErrorRecordingOutput_IgnoresNonError(t *testing.T) {
-	o := NewErrorRecordingOutput([]string{})
+	o := NewErrorRecordingOutput([]string{}, []string{})
 	o.Append("info", "foo")
 
 	require.False(t, o.HasErrors(), "info was recorded")
 }
 
 func TestErrorRecordingOutput_IgnoresAllowedError(t *testing.T) {
-	o := NewErrorRecordingOutput([]string{"foo"})
+	o := NewErrorRecordingOutput([]string{"foo"}, []string{"bar.*baz"})
 	o.Append("error", "foo")
+	o.Append("error", "bar-- free as a bird --baz")
 
 	require.False(t, o.HasErrors(), "allowed error was recorded")
 }
 
 func TestErrorRecordingOutput_RecordsDisallowedError(t *testing.T) {
-	o := NewErrorRecordingOutput([]string{"foo"})
+	o := NewErrorRecordingOutput([]string{"foo"}, []string{"bar.*baz"})
 	e := errors.Errorf("foo error")
 	o.Append("error", "bar", Error(e))
 
 	require.True(t, o.HasErrors(), "disallowed error was not recorded")
 	require.Contains(t, o.GetUnexpectedErrors(), "bar (passed Error object: foo error)")
 }
-

--- a/test/harness/network_builder.go
+++ b/test/harness/network_builder.go
@@ -33,6 +33,7 @@ type acceptanceTestNetworkBuilder struct {
 	logFilters               []log.Filter
 	maxTxPerBlock            uint32
 	allowedErrors            []string
+	allowedErrorsRegExp		 []string
 	numOfNodesToStart        int
 	requiredQuorumPercentage uint32
 }
@@ -82,6 +83,11 @@ func (b *acceptanceTestNetworkBuilder) AllowingErrors(allowedErrors ...string) *
 	return b
 }
 
+func (b *acceptanceTestNetworkBuilder) AllowingErrorsRegExp(allowedErrorsRegExp ...string) *acceptanceTestNetworkBuilder {
+	b.allowedErrorsRegExp = append(b.allowedErrorsRegExp, allowedErrorsRegExp...)
+	return b
+}
+
 func (b *acceptanceTestNetworkBuilder) Start(f func(ctx context.Context, network TestNetworkDriver)) {
 	if b.numOfNodesToStart == 0 {
 		b.numOfNodesToStart = b.numNodes
@@ -114,7 +120,7 @@ func (b *acceptanceTestNetworkBuilder) Start(f func(ctx context.Context, network
 }
 
 func (b *acceptanceTestNetworkBuilder) makeLogger(testId string) (log.BasicLogger, test.ErrorTracker) {
-	errorRecorder := log.NewErrorRecordingOutput(b.allowedErrors)
+	errorRecorder := log.NewErrorRecordingOutput(b.allowedErrors, b.allowedErrorsRegExp)
 	logger := log.GetLogger(
 		log.String("_test", "acceptance"),
 		log.String("_branch", os.Getenv("GIT_BRANCH")),


### PR DESCRIPTION
added `AllowingErrorsRegExp()` to harness network and support for regular expression filtering to `ErrorRecordingOutput`