### PR TITLE
Measure memory consumption in block storage

### DIFF
--- a/bootstrap/inmemory/network.go
+++ b/bootstrap/inmemory/network.go
@@ -35,14 +35,14 @@ type Network struct {
 }
 
 type Node struct {
-	index              int
-	name               string
-	config             config.NodeConfig
-	blockPersistence   blockStorageAdapter.InMemoryBlockPersistence
-	statePersistence   stateStorageAdapter.TamperingStatePersistence
-	nativeCompiler     nativeProcessorAdapter.Compiler
-	nodeLogic          bootstrap.NodeLogic
-	metricRegistry     metric.Registry
+	index            int
+	name             string
+	config           config.NodeConfig
+	blockPersistence blockStorageAdapter.InMemoryBlockPersistence
+	statePersistence stateStorageAdapter.TamperingStatePersistence
+	nativeCompiler   nativeProcessorAdapter.Compiler
+	nodeLogic        bootstrap.NodeLogic
+	metricRegistry   metric.Registry
 }
 
 func NewNetwork(logger log.BasicLogger, transport adapter.Transport, ethereumConnection ethereumAdapter.EthereumConnection) Network {
@@ -54,10 +54,10 @@ func (n *Network) AddNode(nodeKeyPair *keys.Ed25519KeyPair, cfg config.NodeConfi
 	node.index = len(n.Nodes)
 	node.name = fmt.Sprintf("%s", nodeKeyPair.PublicKey()[:3])
 	node.config = cfg
-	node.statePersistence = stateStorageAdapter.NewTamperingStatePersistence()
-	node.blockPersistence = blockStorageAdapter.NewInMemoryBlockPersistence(n.Logger)
-	node.nativeCompiler = compiler
 	node.metricRegistry = metric.NewRegistry()
+	node.statePersistence = stateStorageAdapter.NewTamperingStatePersistence()
+	node.blockPersistence = blockStorageAdapter.NewInMemoryBlockPersistence(n.Logger, node.metricRegistry)
+	node.nativeCompiler = compiler
 
 	n.Nodes = append(n.Nodes, node)
 }

--- a/bootstrap/node.go
+++ b/bootstrap/node.go
@@ -35,7 +35,7 @@ func NewNode(nodeConfig config.NodeConfig, logger log.BasicLogger, httpAddress s
 	metricRegistry := metric.NewRegistry()
 
 	transport := gossipAdapter.NewDirectTransport(ctx, nodeConfig, nodeLogger)
-	blockPersistence := blockStorageAdapter.NewInMemoryBlockPersistence(nodeLogger)
+	blockPersistence := blockStorageAdapter.NewInMemoryBlockPersistence(nodeLogger, metricRegistry)
 	statePersistence := stateStorageAdapter.NewInMemoryStatePersistence(metricRegistry)
 	ethereumConnection := ethereumAdapter.NewEthereumConnection(nodeConfig, logger)
 	nativeCompiler := nativeProcessorAdapter.NewNativeCompiler(nodeConfig, nodeLogger)

--- a/services/blockstorage/test/harness.go
+++ b/services/blockstorage/test/harness.go
@@ -82,7 +82,7 @@ func (d *harness) withSyncBroadcast(times int) *harness {
 }
 
 func (d *harness) withCommitStateDiff(times int) *harness {
-	d.stateStorage.When("CommitStateDiff", mock.Any, mock.Any).Call(func (ctx context.Context, input *services.CommitStateDiffInput) (*services.CommitStateDiffOutput, error) {
+	d.stateStorage.When("CommitStateDiff", mock.Any, mock.Any).Call(func(ctx context.Context, input *services.CommitStateDiffInput) (*services.CommitStateDiffOutput, error) {
 		return &services.CommitStateDiffOutput{
 			NextDesiredBlockHeight: input.ResultsBlockHeader.BlockHeight() + 1,
 		}, nil
@@ -215,9 +215,10 @@ func newBlockStorageHarness() *harness {
 	keyPair := keys.Ed25519KeyPairForTests(0)
 	cfg := createConfig(keyPair.PublicKey())
 
+	registry := metric.NewRegistry()
 	d := &harness{config: cfg, logger: logger}
 	d.stateStorage = &services.MockStateStorage{}
-	d.storageAdapter = adapter.NewInMemoryBlockPersistence(logger)
+	d.storageAdapter = adapter.NewInMemoryBlockPersistence(logger, registry)
 
 	d.consensus = &handlers.MockConsensusBlocksHandler{}
 
@@ -231,7 +232,7 @@ func newBlockStorageHarness() *harness {
 
 	d.txPool = &services.MockTransactionPool{}
 	// TODO: this might create issues with some tests later on, should move it to behavior or some other means of setup
-	d.txPool.When("CommitTransactionReceipts", mock.Any, mock.Any).Call(func (ctx context.Context, input *services.CommitTransactionReceiptsInput) (*services.CommitTransactionReceiptsOutput, error) {
+	d.txPool.When("CommitTransactionReceipts", mock.Any, mock.Any).Call(func(ctx context.Context, input *services.CommitTransactionReceiptsInput) (*services.CommitTransactionReceiptsOutput, error) {
 		return &services.CommitTransactionReceiptsOutput{
 			NextDesiredBlockHeight: input.ResultsBlockHeader.BlockHeight() + 1,
 		}, nil

--- a/test/harness/services/blockstorage/adapter/memory_persistence.go
+++ b/test/harness/services/blockstorage/adapter/memory_persistence.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/orbs-network/orbs-network-go/crypto/digest"
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
+	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	"github.com/orbs-network/orbs-network-go/services/blockstorage/adapter"
 	"github.com/orbs-network/orbs-network-go/synchronization"
 	"github.com/orbs-network/orbs-network-go/test"
@@ -13,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"sync"
 	"time"
+	"unsafe"
 )
 
 type InMemoryBlockPersistence interface {
@@ -22,6 +24,10 @@ type InMemoryBlockPersistence interface {
 }
 
 type blockHeightChan chan primitives.BlockHeight
+
+type metrics struct {
+	size *metric.Gauge
+}
 
 type inMemoryBlockPersistence struct {
 	blockChain struct {
@@ -37,14 +43,23 @@ type inMemoryBlockPersistence struct {
 		sync.Mutex
 		channels map[string]blockHeightChan
 	}
+
+	metrics *metrics
 }
 
-func NewInMemoryBlockPersistence(parent log.BasicLogger) InMemoryBlockPersistence {
+func newMetrics(m metric.Factory) *metrics {
+	return &metrics{
+		size: m.NewGauge("BlockStorage.InMemoryBlockPersistence.SizeInMB"),
+	}
+}
+
+func NewInMemoryBlockPersistence(parent log.BasicLogger, metricFactory metric.Factory) InMemoryBlockPersistence {
 	logger := parent.WithTags(log.String("adapter", "block-storage"))
 	p := &inMemoryBlockPersistence{
 		failNextBlocks: false,
 		logger:         logger,
 		tracker:        synchronization.NewBlockTracker(0, 5),
+		metrics:        newMetrics(metricFactory),
 	}
 
 	p.blockHeightsPerTxHash.channels = make(map[string]blockHeightChan)
@@ -98,6 +113,7 @@ func (bp *inMemoryBlockPersistence) WriteNextBlock(blockPair *protocol.BlockPair
 	}
 
 	bp.tracker.IncrementHeight()
+	bp.metrics.size.Add(sizeOfBlock(blockPair))
 
 	bp.advertiseAllTransactions(blockPair.TransactionsBlock)
 
@@ -228,4 +244,34 @@ func (bp *inMemoryBlockPersistence) GetBlocks(first primitives.BlockHeight, last
 	}
 
 	return blocks, firstReturnedBlockHeight, lastReturnedBlockHeight, nil
+}
+
+func sizeOfBlock(block *protocol.BlockPairContainer) int64 {
+	txBlock := block.TransactionsBlock
+	txBlockSize := len(txBlock.Header.Raw()) + len(txBlock.BlockProof.Raw()) + len(txBlock.Metadata.Raw())
+
+	rsBlock := block.ResultsBlock
+	rsBlockSize := len(rsBlock.Header.Raw()) + len(rsBlock.BlockProof.Raw())
+
+	txBlockPointers := unsafe.Sizeof(txBlock) + unsafe.Sizeof(txBlock.Header) + unsafe.Sizeof(txBlock.Metadata) + unsafe.Sizeof(txBlock.BlockProof) + unsafe.Sizeof(txBlock.SignedTransactions)
+	rsBlockPointers := unsafe.Sizeof(rsBlock) + unsafe.Sizeof(rsBlock.Header) + unsafe.Sizeof(rsBlock.BlockProof) + unsafe.Sizeof(rsBlock.TransactionReceipts) + unsafe.Sizeof(rsBlock.ContractStateDiffs)
+
+	for _, tx := range txBlock.SignedTransactions {
+		txBlockSize += len(tx.Raw())
+		txBlockPointers += unsafe.Sizeof(tx)
+	}
+
+	for _, diff := range rsBlock.ContractStateDiffs {
+		rsBlockSize += len(diff.Raw())
+		rsBlockPointers += unsafe.Sizeof(diff)
+	}
+
+	for _, receipt := range rsBlock.TransactionReceipts {
+		rsBlockSize += len(receipt.Raw())
+		rsBlockPointers += unsafe.Sizeof(receipt)
+	}
+
+	pointers := unsafe.Sizeof(block) + txBlockPointers + rsBlockPointers
+
+	return int64(txBlockSize) + int64(rsBlockSize) + int64(pointers)
 }

--- a/test/harness/services/blockstorage/adapter/memory_persistence_test.go
+++ b/test/harness/services/blockstorage/adapter/memory_persistence_test.go
@@ -1,0 +1,19 @@
+package adapter
+
+import (
+	"github.com/orbs-network/orbs-network-go/test/builders"
+	"testing"
+)
+
+func BenchmarkBlockSize(b *testing.B) {
+	const KILOBYTE = 1024.0
+
+	emptyBlock := builders.BlockPair().WithTransactions(0).WithReceipts(0).WithStateDiffs(0).Build()
+	b.Log("0 tx", float32(sizeOfBlock(emptyBlock))/KILOBYTE)
+
+	hundredTxBlock := builders.BlockPair().WithTransactions(100).WithReceipts(100).WithStateDiffs(100).Build()
+	b.Log("100 tx", float32(sizeOfBlock(hundredTxBlock))/KILOBYTE)
+
+	thousandTxBlock := builders.BlockPair().WithTransactions(1000).WithReceipts(1000).WithStateDiffs(1000).Build()
+	b.Log("1000 tx", float32(sizeOfBlock(thousandTxBlock))/KILOBYTE)
+}


### PR DESCRIPTION
Benchmark results for memory consumption (in kb):

```
0 tx 0.359375
100 tx 33.26953
1000 tx 329.46094
```

Looks like if we want to limit block size to 1mb, we should limit maximum amount of transactions per block to 3000.