### PR TITLE
Unit test: service-sync block committer triggered immediately

### DIFF
--- a/services/blockstorage/servicesync/service_sync_test.go
+++ b/services/blockstorage/servicesync/service_sync_test.go
@@ -103,14 +103,14 @@ func TestSyncTriggersImmediately(t *testing.T) {
 
 		NewServiceBlockSync(ctx, log.GetLogger(), sourceMock, &thinCommitter)
 
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond)
 		require.EqualValues(t, 1, thinCommitter, "expected source initial state to sync immediately")
 
 		// push another block
 		sourceMock.setLastBlockHeight(2)
 		sourceTracker.IncrementHeight()
 
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond)
 		require.EqualValues(t, 2, thinCommitter, "expected source modified state to sync immediately")
 	})
 }


### PR DESCRIPTION
This new test (requested by @talkol) makes sure that no one breaks the service sync mechanism so that it runs slowly

However, there are some limitations to this test and we should think if it's desired:

- Tried to use `runtime.Gosched()` and measured how many `runtime.Gosched()`s are needed - it was between 1 and 2000. so we can reliably assume that a small amount of `runtime.Gosched()` will suffice
- Used a timer of 5 Milliseconds as the test requirement to trigger a commit. This may lead to flakiness. I've seen it fail with 1 Millisecond. And mostly it passes at around 500-700Microseconds (on my dev machine)
- Sync speed may be throttled by network once deployed across machines - making this test of little significance