### PR TITLE
out of memory when reading corrupt blocks file

### DIFF
--- a/services/blockstorage/adapter/filesystem/codec.go
+++ b/services/blockstorage/adapter/filesystem/codec.go
@@ -284,6 +284,7 @@ func (c *codec) writeDynamicBlockSectionWithChecksum(w io.Writer, messages []mem
 	return nil
 }
 
+// TODO V1 see https://tree.taiga.io/project/orbs-network/us/681
 func (c *codec) decode(r io.Reader) (*protocol.BlockPairContainer, int, error) {
 	checkSum := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 	tr := io.TeeReader(r, checkSum)
@@ -444,6 +445,10 @@ func (c *codec) readTransactionsSection(tr io.Reader, budget *readingBudget, cou
 }
 
 func (c *codec) readDynamicBlockSection(tr io.Reader, budget *readingBudget, count uint32) ([][]byte, uint32, error) {
+	if uint32(budget.limit) < count {
+		return nil, 0, fmt.Errorf("section element count is invalid. attempting to read %d elements in block section while size budget is only %d", count, budget.limit)
+	}
+
 	chunks := make([][]byte, 0, count)
 	for i := 0; i < cap(chunks); i++ {
 		chunk, err := readChunk(tr, budget)
@@ -480,6 +485,7 @@ func (cw *checksumWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
+// TODO V1 will be deleted when: https://tree.taiga.io/project/orbs-network/us/681
 type readingBudget struct {
 	limit     int
 	bytesRead int


### PR DESCRIPTION
when reading number of elements in a dynamic-size block section prevent allocating the array if element count exceeds block size budget

- protect against out of memory panic. fixes #780 
- lenient fix. ignoring slice size and mem-buffer size overheads. may not detect any corruption in the counter uint, and may lead to memory allocation above the allowed budget. but large differences will be caught. 
- temporary fix until implementing https://tree.taiga.io/project/orbs-network/us/681