### PR TITLE
Log config in acceptance tests

### DIFF
--- a/bootstrap/inmemory/network.go
+++ b/bootstrap/inmemory/network.go
@@ -58,21 +58,7 @@ func NewNetworkWithNumOfNodes(
 		Transport: transport,
 	}
 	parent.Info("acceptance network node order", log.StringableSlice("addresses", nodeOrder))
-
-	// This is an OPINIONATED list of important config properties to print to aid debugging
-	configStr := fmt.Sprintf("CONFIG_PROPS: public-api-tx-timeout=%s lh-election-timeout=%s node-sync-nocommit-interval=%s node-sync-collect-chunks-timeout=%s node-sync-collect-response-timeout=%s block-tracker-grace-timeout=%s gossip-timeout=%s, block-sync-num-blocks-in-batch=%d papi-node-sync-warning-time=%s txpool-time-between-empty-blocks=%s",
-		cfgTemplate.PublicApiSendTransactionTimeout(),
-		cfgTemplate.LeanHelixConsensusRoundTimeoutInterval(),
-		cfgTemplate.BlockSyncNoCommitInterval(),
-		cfgTemplate.BlockSyncCollectChunksTimeout(),
-		cfgTemplate.BlockSyncCollectResponseTimeout(),
-		cfgTemplate.BlockTrackerGraceTimeout(),
-		cfgTemplate.GossipNetworkTimeout(),
-		cfgTemplate.BlockSyncNumBlocksInBatch(),
-		cfgTemplate.PublicApiNodeSyncWarningTime(),
-		cfgTemplate.TransactionPoolTimeBetweenEmptyBlocks(),
-	)
-	parent.Info(configStr)
+	parent.Info(configToStr(cfgTemplate))
 
 	for _, address := range nodeOrder {
 		federationNode := federation[address.KeyForMap()]
@@ -96,6 +82,23 @@ func NewNetworkWithNumOfNodes(
 	}
 
 	return network // call network.CreateAndStartNodes to launch nodes in the network
+}
+
+func configToStr(cfgTemplate config.OverridableConfig) string {
+	// This is an OPINIONATED list of important config properties to print to aid debugging
+	configStr := fmt.Sprintf("CONFIG_PROPS: public-api-tx-timeout=%s lh-election-timeout=%s node-sync-nocommit-interval=%s node-sync-collect-chunks-timeout=%s node-sync-collect-response-timeout=%s block-tracker-grace-timeout=%s gossip-timeout=%s, block-sync-num-blocks-in-batch=%d papi-node-sync-warning-time=%s txpool-time-between-empty-blocks=%s",
+		cfgTemplate.PublicApiSendTransactionTimeout(),
+		cfgTemplate.LeanHelixConsensusRoundTimeoutInterval(),
+		cfgTemplate.BlockSyncNoCommitInterval(),
+		cfgTemplate.BlockSyncCollectChunksTimeout(),
+		cfgTemplate.BlockSyncCollectResponseTimeout(),
+		cfgTemplate.BlockTrackerGraceTimeout(),
+		cfgTemplate.GossipNetworkTimeout(),
+		cfgTemplate.BlockSyncNumBlocksInBatch(),
+		cfgTemplate.PublicApiNodeSyncWarningTime(),
+		cfgTemplate.TransactionPoolTimeBetweenEmptyBlocks(),
+	)
+	return configStr
 }
 
 func (n *Network) addNode(name string, cfg config.NodeConfig, nodeDependencies *NodeDependencies, metricRegistry metric.Registry, logger log.BasicLogger) {


### PR DESCRIPTION
Enough with the guesswork!
Now logging the current config on every *acceptance* test start.
Just grep for CONFIG_PROPS in the log file.
This is an opinionated list of what I think is important. Feel free to modify.