### PR TITLE
return nil error when committing old block

### DIFF
--- a/services/blockstorage/validate_block.go
+++ b/services/blockstorage/validate_block.go
@@ -52,7 +52,7 @@ func (s *service) validateBlockDoesNotExist(ctx context.Context, txBlockHeader *
 		// we can't check for fork because we don't have the tx header of the old block easily accessible
 		errorMessage := "block already in storage, skipping"
 		logger.Info(errorMessage, log.BlockHeight(currentBlockHeight), log.Stringable("attempted-block-height", attemptedBlockHeight))
-		return false, errors.New(errorMessage)
+		return false, nil
 	} else if attemptedBlockHeight == currentBlockHeight {
 		// we can check for fork because we do have the tx header of the old block easily accessible
 		if txBlockHeader.Timestamp() != getBlockTimestamp(lastCommittedBlock) {


### PR DESCRIPTION
minor bug causing inconsistent responses when committing blocks to block storage in a race condition - the block was already committed.
In most flows the situation does nothing but does not return an error. it should be like that in all cases.

a deeper treatment of this logic will come as part of a fix to #742 