### PR TITLE
Exponential Backoff Election Trigger: impl + use

### DIFF
--- a/services/consensusalgo/leanhelixconsensus/election_trigger.go
+++ b/services/consensusalgo/leanhelixconsensus/election_trigger.go
@@ -1,0 +1,79 @@
+package leanhelixconsensus
+
+import (
+	"context"
+	lhmetrics "github.com/orbs-network/lean-helix-go/instrumentation/metrics"
+	lh "github.com/orbs-network/lean-helix-go/services/interfaces"
+	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
+	"math"
+	"time"
+)
+
+var TIMEOUT_EXP_BASE = float64(2.0) // Modifying this value from 2.0 will affect its unit tests which are time-based
+
+type exponentialBackoffElectionTrigger struct {
+	electionChannel chan func(ctx context.Context)
+	minTimeout      time.Duration
+	view            primitives.View
+	blockHeight     primitives.BlockHeight
+	electionHandler func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics))
+	onElectionCB    func(m lhmetrics.ElectionMetrics)
+	logger          log.BasicLogger
+	triggerTimer    *time.Timer
+}
+
+func NewExponentialBackoffElectionTrigger(logger log.BasicLogger, minTimeout time.Duration, onElectionCB func(m lhmetrics.ElectionMetrics)) lh.ElectionTrigger {
+
+	return &exponentialBackoffElectionTrigger{
+		electionChannel: make(chan func(ctx context.Context), 1), // buffered so trigger goroutine can terminate regardless of channel reader
+		minTimeout:      minTimeout,
+		onElectionCB:    onElectionCB,
+		logger:          logger,
+	}
+}
+
+func (e *exponentialBackoffElectionTrigger) RegisterOnElection(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, electionHandler func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics))) {
+	if e.electionHandler == nil || e.view != view || e.blockHeight != blockHeight {
+		timeout := e.CalcTimeout(view)
+		e.view = view
+		e.blockHeight = blockHeight
+		e.safeTimerStop()
+		e.triggerTimer = time.AfterFunc(timeout, e.sendTrigger)
+	}
+	e.electionHandler = electionHandler
+}
+
+func (e *exponentialBackoffElectionTrigger) ElectionChannel() chan func(ctx context.Context) {
+	return e.electionChannel
+}
+
+func (e *exponentialBackoffElectionTrigger) safeTimerStop() {
+	if e.triggerTimer != nil {
+		active := e.triggerTimer.Stop()
+		if !active {
+			select {
+			case <-e.triggerTimer.C:
+			default:
+			}
+		}
+	}
+}
+
+func (e *exponentialBackoffElectionTrigger) trigger(ctx context.Context) {
+	if e.electionHandler != nil {
+		e.electionHandler(ctx, e.blockHeight, e.view, e.onElectionCB)
+	}
+}
+
+func (e *exponentialBackoffElectionTrigger) sendTrigger() {
+	e.logger.Info("election trigger triggered",
+		log.Uint64("lh-election-block-height", uint64(e.blockHeight)),
+		log.Uint64("lh-election-view", uint64(e.view)))
+	e.electionChannel <- e.trigger
+}
+
+func (e *exponentialBackoffElectionTrigger) CalcTimeout(view primitives.View) time.Duration {
+	timeoutMultiplier := time.Duration(int64(math.Pow(TIMEOUT_EXP_BASE, float64(view))))
+	return timeoutMultiplier * e.minTimeout
+}

--- a/services/consensusalgo/leanhelixconsensus/election_trigger_test.go
+++ b/services/consensusalgo/leanhelixconsensus/election_trigger_test.go
@@ -1,0 +1,228 @@
+package leanhelixconsensus
+
+import (
+	"context"
+	lhmetrics "github.com/orbs-network/lean-helix-go/instrumentation/metrics"
+	"github.com/orbs-network/lean-helix-go/services/interfaces"
+	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
+	"github.com/orbs-network/orbs-network-go/test"
+	"github.com/stretchr/testify/require"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"testing"
+	"time"
+)
+
+func buildElectionTrigger(ctx context.Context, t *testing.T, timeout time.Duration) interfaces.ElectionTrigger {
+	et := NewExponentialBackoffElectionTrigger(log.DefaultTestingLogger(t), timeout, nil)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case trigger := <-et.ElectionChannel():
+				trigger(ctx)
+			}
+		}
+	}()
+
+	return et
+}
+
+// TODO Consider removing this test entirely - sleeps in tests are bad
+func TestCallbackTrigger(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		et := buildElectionTrigger(ctx, t, 50*time.Millisecond)
+
+		wasCalled := false
+		cb := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics)) {
+			wasCalled = true
+		}
+		et.RegisterOnElection(ctx, 20, 0, cb)
+
+		time.Sleep(80 * time.Millisecond)
+
+		require.True(t, wasCalled, "Did not call the timer callback")
+	})
+}
+
+func TestCallbackTriggerOnce(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		et := buildElectionTrigger(ctx, t, 10*time.Millisecond)
+
+		callCount := 0
+		cb := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics)) {
+			callCount++
+		}
+		et.RegisterOnElection(ctx, 10, 0, cb)
+
+		time.Sleep(25 * time.Millisecond)
+
+		require.Exactly(t, 1, callCount, "Trigger callback called more than once")
+	})
+}
+
+func TestCallbackTriggerTwiceInARow(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		et := buildElectionTrigger(ctx, t, 10*time.Millisecond)
+
+		callCount := 0
+		cb := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics)) {
+			callCount++
+		}
+		et.RegisterOnElection(ctx, 10, 0, cb)
+
+		time.Sleep(25 * time.Millisecond)
+
+		et.RegisterOnElection(ctx, 11, 0, cb)
+		time.Sleep(25 * time.Millisecond)
+
+		require.Exactly(t, 2, callCount, "Trigger callback twice without getting stuck")
+	})
+}
+
+func TestIgnoreSameViewOrHeight(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		et := buildElectionTrigger(ctx, t, 30*time.Millisecond)
+
+		callCount := 0
+		cb := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics)) {
+			callCount++
+		}
+
+		et.RegisterOnElection(ctx, 10, 0, cb)
+		time.Sleep(10 * time.Millisecond)
+		et.RegisterOnElection(ctx, 10, 0, cb)
+		time.Sleep(10 * time.Millisecond)
+		et.RegisterOnElection(ctx, 10, 0, cb)
+		time.Sleep(20 * time.Millisecond)
+		et.RegisterOnElection(ctx, 10, 0, cb)
+
+		require.Exactly(t, 1, callCount, "Trigger callback called more than once")
+	})
+}
+
+func TestNotTriggerIfSameViewButDifferentHeight(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		et := buildElectionTrigger(ctx, t, 30*time.Millisecond)
+
+		beforeSecondRegister := false
+		cb1 := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics)) {
+			beforeSecondRegister = true
+		}
+
+		afterSecondRegister := false
+		cb2 := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics)) {
+			afterSecondRegister = true
+		}
+
+		et.RegisterOnElection(ctx, 10, 0, cb1)
+		time.Sleep(3 * time.Millisecond)
+
+		et.RegisterOnElection(ctx, 11, 0, cb2)
+		time.Sleep(50 * time.Millisecond)
+
+		require.False(t, beforeSecondRegister, "should not trigger the first one")
+		require.True(t, afterSecondRegister, "should only trigger the second one")
+
+	})
+}
+
+func TestNotTriggerIfSameHeightButDifferentView(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		et := buildElectionTrigger(ctx, t, 30*time.Millisecond)
+
+		callCount := 0
+		cb := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics)) {
+			callCount++
+		}
+
+		et.RegisterOnElection(ctx, 10, 0, cb)
+		time.Sleep(10 * time.Millisecond)
+		et.RegisterOnElection(ctx, 10, 1, cb)
+		time.Sleep(10 * time.Millisecond)
+		et.RegisterOnElection(ctx, 10, 2, cb)
+		time.Sleep(10 * time.Millisecond)
+		et.RegisterOnElection(ctx, 10, 3, cb)
+		time.Sleep(10 * time.Millisecond)
+		et.RegisterOnElection(ctx, 10, 4, cb)
+		time.Sleep(10 * time.Millisecond)
+		et.RegisterOnElection(ctx, 10, 5, cb)
+
+		require.Exactly(t, 0, callCount, "Trigger callback called")
+	})
+}
+
+func TestViewChanges(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		et := buildElectionTrigger(ctx, t, 50*time.Millisecond)
+
+		wasCalled := false
+		cb := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics)) {
+			wasCalled = true
+		}
+
+		et.RegisterOnElection(ctx, 10, 0, cb) // 2 ** 0 * 20 = 20
+		time.Sleep(10 * time.Millisecond)
+
+		et.RegisterOnElection(ctx, 10, 1, cb) // 2 ** 1 * 20 = 40
+		time.Sleep(30 * time.Millisecond)
+
+		et.RegisterOnElection(ctx, 10, 2, cb) // 2 ** 2 * 20 = 80
+		time.Sleep(70 * time.Millisecond)
+
+		et.RegisterOnElection(ctx, 10, 3, cb) // 2 ** 3 * 20 = 160
+
+		require.False(t, wasCalled, "Trigger the callback even if a new Register was called with a new view")
+	})
+}
+
+func TestViewPowTimeout(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		et := buildElectionTrigger(ctx, t, 10*time.Millisecond)
+
+		wasCalled := false
+		cb := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics)) {
+			wasCalled = true
+		}
+
+		et.RegisterOnElection(ctx, 10, 2, cb) // 2 ** 2 * 10 = 40
+		time.Sleep(30 * time.Millisecond)
+		require.False(t, wasCalled, "Triggered the callback too early")
+		time.Sleep(30 * time.Millisecond)
+		require.True(t, wasCalled, "Did not trigger the callback after the required timeout")
+	})
+}
+
+func TestElectionTriggerDoesNotLeak(t *testing.T) {
+	// this test checks that after multiple registrations, there are no goroutine leaks
+	test.WithContext(func(ctx context.Context) {
+		et := buildElectionTrigger(ctx, t, time.Millisecond)
+
+		callCount := 0
+		cb := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB func(m lhmetrics.ElectionMetrics)) {
+			callCount++
+		}
+		start := runtime.NumGoroutine()
+
+		for block := 10; block < 100; block++ {
+			et.RegisterOnElection(ctx, primitives.BlockHeight(block), 0, cb)
+			time.Sleep(2 * time.Millisecond)
+		}
+
+		end := runtime.NumGoroutine()
+
+		require.True(t, callCount > 1, "the callback must be called more than once") // sanity
+
+		if start > end {
+			return
+		}
+
+		if start != end {
+			pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+		}
+		require.Equal(t, start, end, "goroutine number should be the same")
+	})
+}

--- a/services/consensusalgo/leanhelixconsensus/service.go
+++ b/services/consensusalgo/leanhelixconsensus/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/orbs-network/lean-helix-go"
 	lhmetrics "github.com/orbs-network/lean-helix-go/instrumentation/metrics"
-	"github.com/orbs-network/lean-helix-go/services/electiontrigger"
 	lh "github.com/orbs-network/lean-helix-go/services/interfaces"
 	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/crypto/digest"
@@ -106,7 +105,7 @@ func NewLeanHelixConsensusAlgo(
 	}
 
 	// TODO https://github.com/orbs-network/orbs-network-go/issues/786 Implement election trigger here, run its goroutine under "supervised"
-	electionTrigger := electiontrigger.NewTimerBasedElectionTrigger(config.LeanHelixConsensusRoundTimeoutInterval(), s.onElection) // Configure to be ~5 times the minimum wait for transactions (consensus context)
+	electionTrigger := NewExponentialBackoffElectionTrigger(logger, config.LeanHelixConsensusRoundTimeoutInterval(), s.onElection) // Configure to be ~5 times the minimum wait for transactions (consensus context)
 	logger.Info("Election trigger set", log.String("election-trigger-timeout", config.LeanHelixConsensusRoundTimeoutInterval().String()))
 
 	leanHelixConfig := &lh.Config{

--- a/services/consensusalgo/leanhelixconsensus/test/election_trigger_stress_test.go
+++ b/services/consensusalgo/leanhelixconsensus/test/election_trigger_stress_test.go
@@ -1,0 +1,44 @@
+package test
+
+import (
+	"context"
+	"github.com/orbs-network/lean-helix-go/services/interfaces"
+	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
+	"github.com/orbs-network/orbs-network-go/instrumentation/log"
+	"github.com/orbs-network/orbs-network-go/services/consensusalgo/leanhelixconsensus"
+	"github.com/orbs-network/orbs-network-go/test"
+	"testing"
+	"time"
+)
+
+func buildElectionTrigger(ctx context.Context, logger log.BasicLogger, timeout time.Duration) interfaces.ElectionTrigger {
+	et := leanhelixconsensus.NewExponentialBackoffElectionTrigger(logger, timeout, nil)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				logger.Info("BAD")
+				return
+			case trigger := <-et.ElectionChannel():
+				trigger(ctx)
+			}
+		}
+	}()
+
+	return et
+}
+
+func TestStress_FrequentRegisters(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		et := buildElectionTrigger(ctx, log.DefaultTestingLogger(t), 1*time.Microsecond)
+
+		var counter int32
+		for h := primitives.BlockHeight(1); h < primitives.BlockHeight(1000); h++ {
+			et.RegisterOnElection(ctx, h, 0, nil)
+			counter++
+			time.Sleep(1 * time.Microsecond)
+		}
+		t.Log(counter)
+	})
+
+}


### PR DESCRIPTION
Exponential backoff election trigger with tests.
This does not affect any other part of the system (still using benchmark consensus)