### PR TITLE
Increased benchmark token contract deployment timeout from 1s to 5s d…

### DIFF
--- a/test/acceptance/network_harness.go
+++ b/test/acceptance/network_harness.go
@@ -151,7 +151,7 @@ func (n *NetworkHarness) EthereumSimulator() *ethereumAdapter.EthereumSimulator 
 func (n *NetworkHarness) DeployBenchmarkTokenContract(ctx context.Context, ownerAddressIndex int) callcontract.BenchmarkTokenClient {
 	bt := callcontract.NewContractClient(n)
 
-	benchmarkDeploymentTimeout := 1 * time.Second
+	benchmarkDeploymentTimeout := 5 * time.Second
 	timeoutCtx, cancel := context.WithTimeout(ctx, benchmarkDeploymentTimeout)
 	defer cancel()
 


### PR DESCRIPTION
…ue to timeout in acceptance tests that tamper messages

Closes #914 .


Should decide if 5s is the right time @talkol @electricmonk @gadcl 