### PR TITLE
Histograms now retain history for 10 minutes

### DIFF
--- a/bootstrap/node_logic.go
+++ b/bootstrap/node_logic.go
@@ -76,7 +76,7 @@ func NewNodeLogic(
 	consensusAlgos = append(consensusAlgos, leanHelixAlgo)
 
 	runtimeReporter := metric.NewRuntimeReporter(ctx, metricRegistry, logger)
-	metricRegistry.ReportEvery(ctx, nodeConfig.MetricsReportInterval(), logger)
+	metricRegistry.PeriodicallyReport(ctx, logger)
 
 	logger.Info("Node started")
 

--- a/config/config.go
+++ b/config/config.go
@@ -74,9 +74,6 @@ type NodeConfig interface {
 	// processor
 	ProcessorArtifactPath() string
 
-	// metrics
-	MetricsReportInterval() time.Duration
-
 	// ethereum connector (crosschain)
 	EthereumEndpoint() string
 

--- a/config/hardcoded_config.go
+++ b/config/hardcoded_config.go
@@ -328,10 +328,6 @@ func (c *config) GossipNetworkTimeout() time.Duration {
 	return c.kv[GOSSIP_NETWORK_TIMEOUT].DurationValue
 }
 
-func (c *config) MetricsReportInterval() time.Duration {
-	return c.kv[METRICS_REPORT_INTERVAL].DurationValue
-}
-
 func (c *config) BenchmarkConsensusRequiredQuorumPercentage() uint32 {
 	return c.kv[BENCHMARK_CONSENSUS_REQUIRED_QUORUM_PERCENTAGE].Uint32Value
 }

--- a/config/system_factory_presets.go
+++ b/config/system_factory_presets.go
@@ -70,7 +70,6 @@ func defaultProductionConfig() mutableNodeConfig {
 
 	cfg.SetDuration(GOSSIP_CONNECTION_KEEP_ALIVE_INTERVAL, 1*time.Second)
 	cfg.SetDuration(GOSSIP_NETWORK_TIMEOUT, 30*time.Second)
-	cfg.SetDuration(METRICS_REPORT_INTERVAL, 30*time.Second)
 
 	cfg.SetActiveConsensusAlgo(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS)
 	cfg.SetString(ETHEREUM_ENDPOINT, "http://localhost:8545")

--- a/instrumentation/metric/histogram.go
+++ b/instrumentation/metric/histogram.go
@@ -33,10 +33,10 @@ func floatToMillis(nanoseconds float64) float64 {
 	return nanoseconds / 1e+6
 }
 
-func newHistogram(name string, max int64) *Histogram {
+func newHistogram(name string, max int64, n int) *Histogram {
 	return &Histogram{
 		namedMetric: namedMetric{name: name},
-		histo:       hdrhistogram.NewWindowed(5, 0, max, 1),
+		histo:       hdrhistogram.NewWindowed(n, 0, max, 1),
 	}
 }
 
@@ -71,7 +71,7 @@ func (h *Histogram) String() string {
 }
 
 func (h *Histogram) Export() exportedMetric {
-	histo := h.histo.Current
+	histo := h.histo.Merge()
 
 	return &histogramExport{
 		h.name,


### PR DESCRIPTION
- now reporting merged histogram rather than last on so that we retain the history from n last ticks
- retaining 10 minutes of histogram history