### PR TITLE
Property "block-height" now logged as decimal instead of hexadecimal

### DIFF
--- a/instrumentation/log/basic_logger_test.go
+++ b/instrumentation/log/basic_logger_test.go
@@ -107,8 +107,8 @@ func TestCompareLogger(t *testing.T) {
 
 	require.Equal(t, "expectation", jsonMap["level"])
 	require.Equal(t, "020363", jsonMap["bytes"])
-	require.Equal(t, "22b8", jsonMap["actual-block-height"])
-	require.Equal(t, "270f", jsonMap["expected-block-height"])
+	require.Equal(t, float64(8888), jsonMap["actual-block-height"])
+	require.Equal(t, float64(9999), jsonMap["expected-block-height"])
 }
 
 func TestNestedLogger(t *testing.T) {
@@ -159,7 +159,7 @@ func TestCustomLogFormatter(t *testing.T) {
 	require.Regexp(t, "Service initialized", out)
 	require.Regexp(t, "node=node1", out)
 	require.Regexp(t, "service=public-api", out)
-	require.Regexp(t, "block-height=270f", out)
+	require.Regexp(t, "block-height=9999", out)
 	require.Regexp(t, "vchainId=7b", out)
 	require.Regexp(t, "bytes=020363", out)
 	require.Regexp(t, "some-int-value=12", out)

--- a/instrumentation/log/field.go
+++ b/instrumentation/log/field.go
@@ -152,7 +152,7 @@ func Error(value error) *Field {
 }
 
 func BlockHeight(value primitives.BlockHeight) *Field {
-	return &Field{Key: "block-height", StringVal: value.String(), Type: StringType}
+	return &Field{Key: "block-height", Uint: uint64(value), Type: UintType}
 }
 
 func VirtualChainId(value primitives.VirtualChainId) *Field {

--- a/services/consensusalgo/leanhelixconsensus/service.go
+++ b/services/consensusalgo/leanhelixconsensus/service.go
@@ -188,7 +188,7 @@ func (s *service) HandleLeanHelixMessage(ctx context.Context, input *gossiptopic
 
 func (s *service) onCommit(ctx context.Context, block lh.Block, blockProof []byte) {
 	logger := s.logger.WithTags(trace.LogFieldFrom(ctx))
-	logger.Info("YEYYYY CONSENSUS!!!! will save to block storage", log.Stringable("block-height", block.Height()))
+	logger.Info("YEYYYY CONSENSUS!!!! will save to block storage", log.BlockHeight(primitives.BlockHeight(block.Height())))
 	blockPairWrapper := block.(*BlockPairWrapper)
 	blockPair := blockPairWrapper.blockPair
 


### PR DESCRIPTION
High time we did that - we use decimal in monitoring, in Lean Helix logs and when talking, therefore logging "block-height" is now decimal too.