### PR TITLE
GetBlockByTimestamp fails when asking for the exact time of the latest block

### DIFF
--- a/services/crosschainconnector/ethereum/fake_block_and_timestamp_getter.go
+++ b/services/crosschainconnector/ethereum/fake_block_and_timestamp_getter.go
@@ -9,7 +9,7 @@ import (
 )
 
 const FAKE_CLIENT_NUMBER_OF_BLOCKS = 1000000
-const FAKE_CLIENT_LAST_TIMESTAMP_EXPECTED = 1506108783
+const FAKE_CLIENT_LAST_TIMESTAMP_EXPECTED = 1506108784
 
 var LastTimestampInFake = time.Unix(FAKE_CLIENT_LAST_TIMESTAMP_EXPECTED, 0)
 
@@ -23,7 +23,7 @@ func (f *FakeBlockAndTimestampGetter) ApproximateBlockAt(ctx context.Context, bl
 	if blockNumber == nil {
 		return &BlockHeightAndTime{
 			Number:      FAKE_CLIENT_NUMBER_OF_BLOCKS,
-			TimeSeconds: f.data[FAKE_CLIENT_NUMBER_OF_BLOCKS-1],
+			TimeSeconds: f.data[FAKE_CLIENT_NUMBER_OF_BLOCKS],
 		}, nil
 	}
 
@@ -52,7 +52,7 @@ func NewFakeBlockAndTimestampGetter(logger log.BasicLogger) *FakeBlockAndTimesta
 	secondsSpacer := int64(10)
 	timestampStart := int64(1500000000) // 2017/07/14 @ 14:40 - it will always end at 1506108783, or 2017/09/22 @ 19:3303
 	f.data[0] = timestampStart
-	for blockNumber := int64(1); blockNumber < FAKE_CLIENT_NUMBER_OF_BLOCKS; blockNumber++ {
+	for blockNumber := int64(1); blockNumber <= FAKE_CLIENT_NUMBER_OF_BLOCKS; blockNumber++ {
 		// important that the numbers will be always increasing but always less than spacer
 		if blockNumber%150 == 0 {
 			secondsJitter++

--- a/services/crosschainconnector/ethereum/fake_block_and_timestamp_getter_test.go
+++ b/services/crosschainconnector/ethereum/fake_block_and_timestamp_getter_test.go
@@ -1,14 +1,24 @@
 package ethereum
 
 import (
+	"context"
 	"github.com/orbs-network/orbs-network-go/instrumentation/log"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 // this test exists to make sure that the fake timestamp/block pairs remain constant, as other tests in the system (such as header_by_timestamp_finder_test.go) rely on these constant numbers
-func TestFakeBlockHeaderFetcher(t *testing.T) {
+func TestFakeBlockHeaderFetcherRawData(t *testing.T) {
 	ffc := NewFakeBlockAndTimestampGetter(log.DefaultTestingLogger(t))
 
-	require.EqualValues(t, FAKE_CLIENT_LAST_TIMESTAMP_EXPECTED, ffc.data[FAKE_CLIENT_NUMBER_OF_BLOCKS-1], "expected ffc last block to be of specific ts")
+	require.EqualValues(t, FAKE_CLIENT_LAST_TIMESTAMP_EXPECTED, ffc.data[FAKE_CLIENT_NUMBER_OF_BLOCKS], "expected ffc last block to be of specific ts")
+}
+
+func TestFakeBlockHeaderFetcherOfLatest(t *testing.T) {
+	ffc := NewFakeBlockAndTimestampGetter(log.DefaultTestingLogger(t))
+
+	b, err := ffc.ApproximateBlockAt(context.Background(), nil)
+	require.NoError(t, err, "should not fail getting 'latest' from fake db")
+	require.EqualValues(t, FAKE_CLIENT_LAST_TIMESTAMP_EXPECTED, b.TimeSeconds, "expected ffc last block to be of specific ts")
+	require.EqualValues(t, FAKE_CLIENT_NUMBER_OF_BLOCKS, b.Number, "expected last block of constant number")
 }


### PR DESCRIPTION
bug reproduced, please fix