### PR TITLE
added more time for the test to complete

### DIFF
--- a/services/consensusalgo/leanhelixconsensus/election_trigger_test.go
+++ b/services/consensusalgo/leanhelixconsensus/election_trigger_test.go
@@ -53,7 +53,7 @@ func TestCallbackTriggerOnce(t *testing.T) {
 		}
 		et.RegisterOnElection(ctx, 10, 0, cb)
 
-		time.Sleep(25 * time.Millisecond)
+		time.Sleep(250 * time.Millisecond)
 
 		require.Exactly(t, 1, callCount, "Trigger callback called more than once")
 	})


### PR DESCRIPTION
still time based
can change it to a channel, but then to check if it is not happening the second time i will take a time.After() on a channel select, which is exactly the same as just sleeping (what its doing now)