### PR TITLE
Add GC tracing to test.common.sh long-running tests

### DIFF
--- a/test.common.sh
+++ b/test.common.sh
@@ -33,7 +33,7 @@ go_test_junit_report () {
 
     mkdir -p $OUT_DIR
     mkdir -p $REPORTS_DIR
-    go test -v $@ &> ${OUT_DIR}/test.out || true # so that we always go to the junit report step
+    GODEBUG=gctrace=1 go test -v $@ &> ${OUT_DIR}/test.out || true # so that we always go to the junit report step
     go-junit-report -set-exit-code < ${OUT_DIR}/test.out > ${OUT_DIR}/results.xml
     EXIT_CODE=$?
 


### PR DESCRIPTION
Print garbage collector statistics during nightly runs.
