### PR TITLE
Disable histograms to try and get rid of mem leaks in nightly

### DIFF
--- a/instrumentation/metric/registry.go
+++ b/instrumentation/metric/registry.go
@@ -19,8 +19,8 @@ const REPORT_INTERVAL = 30 * time.Second
 const AGGREGATION_SPAN = 10 * time.Minute
 
 type Factory interface {
-	NewHistogram(name string, maxValue int64) *Histogram
-	NewLatency(name string, maxDuration time.Duration) *Histogram
+	NewHistogram(name string, maxValue int64) Histogram
+	NewLatency(name string, maxDuration time.Duration) Histogram
 	NewGauge(name string) *Gauge
 	NewRate(name string) *Rate
 	NewText(name string, defaultValue ...string) *Text
@@ -80,13 +80,13 @@ func (r *inMemoryRegistry) NewGauge(name string) *Gauge {
 	return g
 }
 
-func (r *inMemoryRegistry) NewLatency(name string, maxDuration time.Duration) *Histogram {
+func (r *inMemoryRegistry) NewLatency(name string, maxDuration time.Duration) Histogram {
 	h := newHistogram(name, maxDuration.Nanoseconds(), int(AGGREGATION_SPAN/REPORT_INTERVAL))
 	r.register(h)
 	return h
 }
 
-func (r *inMemoryRegistry) NewHistogram(name string, maxValue int64) *Histogram {
+func (r *inMemoryRegistry) NewHistogram(name string, maxValue int64) Histogram {
 	h := newHistogram(name, maxValue, int(AGGREGATION_SPAN/REPORT_INTERVAL))
 	r.register(h)
 	return h
@@ -139,8 +139,8 @@ func (r *inMemoryRegistry) PeriodicallyReport(ctx context.Context, logger log.Ba
 		defer r.mu.Unlock()
 		for _, m := range r.mu.metrics {
 			switch m.(type) {
-			case *Histogram:
-				m.(*Histogram).Rotate()
+			case *histogram:
+				m.(*histogram).Rotate()
 			}
 		}
 	}, func() {

--- a/services/blockstorage/internodesync/factory.go
+++ b/services/blockstorage/internodesync/factory.go
@@ -163,32 +163,32 @@ type stateMetrics struct {
 }
 
 type idleStateMetrics struct {
-	timeSpentInState *metric.Histogram
+	timeSpentInState metric.Histogram
 	timesReset       *metric.Gauge
 	timesExpired     *metric.Gauge
 }
 
 type collectingStateMetrics struct {
-	timeSpentInState                         *metric.Histogram
+	timeSpentInState                         metric.Histogram
 	timesSucceededSendingAvailabilityRequest *metric.Gauge
 	timesFailedSendingAvailabilityRequest    *metric.Gauge
 }
 
 type finishedCollectingStateMetrics struct {
-	timeSpentInState               *metric.Histogram
+	timeSpentInState               metric.Histogram
 	finishedWithNoResponsesCount   *metric.Gauge
 	finishedWithSomeResponsesCount *metric.Gauge
 }
 
 type waitingStateMetrics struct {
-	timeSpentInState *metric.Histogram
+	timeSpentInState metric.Histogram
 	timesTimeout     *metric.Gauge
 	timesSuccessful  *metric.Gauge
 	timesByzantine   *metric.Gauge
 }
 
 type processingStateMetrics struct {
-	timeSpentInState       *metric.Histogram
+	timeSpentInState       metric.Histogram
 	blocksRate             *metric.Rate
 	committedBlocks        *metric.Gauge
 	failedCommitBlocks     *metric.Gauge

--- a/services/consensusalgo/benchmarkconsensus/service.go
+++ b/services/consensusalgo/benchmarkconsensus/service.go
@@ -57,10 +57,10 @@ type service struct {
 }
 
 type metrics struct {
-	consensusRoundTickTime     *metric.Histogram
+	consensusRoundTickTime     metric.Histogram
 	failedConsensusTicksRate   *metric.Rate
 	timedOutConsensusTicksRate *metric.Rate
-	votingTime                 *metric.Histogram
+	votingTime                 metric.Histogram
 	lastCommittedTime          *metric.Gauge
 }
 

--- a/services/consensusalgo/leanhelixconsensus/service.go
+++ b/services/consensusalgo/leanhelixconsensus/service.go
@@ -43,8 +43,8 @@ type service struct {
 }
 
 type metrics struct {
-	timeSinceLastCommitMillis   *metric.Histogram
-	timeSinceLastElectionMillis *metric.Histogram
+	timeSinceLastCommitMillis   metric.Histogram
+	timeSinceLastElectionMillis metric.Histogram
 	currentLeaderMemberId       *metric.Text
 	currentElectionCount        *metric.Gauge
 	lastCommittedTime           *metric.Gauge

--- a/services/consensuscontext/service.go
+++ b/services/consensuscontext/service.go
@@ -21,9 +21,9 @@ import (
 var LogTag = log.Service("consensus-context")
 
 type metrics struct {
-	createTxBlockTime                         *metric.Histogram
-	createResultsBlockTime                    *metric.Histogram
-	processTransactionsSeInCreateResultsBlock *metric.Histogram
+	createTxBlockTime                         metric.Histogram
+	createResultsBlockTime                    metric.Histogram
+	processTransactionsSeInCreateResultsBlock metric.Histogram
 	transactionsRate                          *metric.Rate
 }
 

--- a/services/crosschainconnector/ethereum/timestampfinder/timestamp_finder.go
+++ b/services/crosschainconnector/ethereum/timestampfinder/timestamp_finder.go
@@ -39,7 +39,7 @@ type finder struct {
 }
 
 type timestampBlockFinderMetrics struct {
-	timeToFindBlock     *metric.Histogram
+	timeToFindBlock     metric.Histogram
 	stepsRequired       *metric.Rate
 	totalTimesCalled    *metric.Gauge
 	cacheHits           *metric.Gauge

--- a/services/gossip/adapter/tcp/direct_transport.go
+++ b/services/gossip/adapter/tcp/direct_transport.go
@@ -38,7 +38,7 @@ type metrics struct {
 	activeIncomingConnections *metric.Gauge
 	activeOutgoingConnections *metric.Gauge
 
-	outgoingMessageSize *metric.Histogram
+	outgoingMessageSize metric.Histogram
 }
 
 type directTransport struct {

--- a/services/processor/native/service.go
+++ b/services/processor/native/service.go
@@ -44,8 +44,8 @@ type service struct {
 
 type metrics struct {
 	deployedContracts       *metric.Gauge
-	processCallTime         *metric.Histogram
-	contractCompilationTime *metric.Histogram
+	processCallTime         metric.Histogram
+	contractCompilationTime metric.Histogram
 }
 
 func getMetrics(m metric.Factory) *metrics {

--- a/services/publicapi/service.go
+++ b/services/publicapi/service.go
@@ -33,9 +33,9 @@ type service struct {
 }
 
 type metrics struct {
-	sendTransactionTime                *metric.Histogram
-	getTransactionStatusTime           *metric.Histogram
-	runQueryTime                       *metric.Histogram
+	sendTransactionTime                metric.Histogram
+	getTransactionStatusTime           metric.Histogram
+	runQueryTime                       metric.Histogram
 	totalTransactionsFromClients       *metric.Gauge
 	totalTransactionsErrNilRequest     *metric.Gauge
 	totalTransactionsErrInvalidRequest *metric.Gauge

--- a/services/transactionpool/pending_pool.go
+++ b/services/transactionpool/pending_pool.go
@@ -42,8 +42,8 @@ type pendingPoolMetrics struct {
 	transactionCountGauge    *metric.Gauge
 	poolSizeInBytesGauge     *metric.Gauge
 	transactionRatePerSecond *metric.Rate
-	transactionSpentInQueue  *metric.Histogram
-	transactionServiceTime   *metric.Histogram
+	transactionSpentInQueue  metric.Histogram
+	transactionServiceTime   metric.Histogram
 }
 
 func newPendingPoolMetrics(factory metric.Factory) *pendingPoolMetrics {

--- a/test/acceptance/network_harness_builder.go
+++ b/test/acceptance/network_harness_builder.go
@@ -178,7 +178,7 @@ func (b *networkHarnessBuilder) makeLogger(tb testing.TB, testId string) (log.Ba
 		WithOutput(testOutput).
 		WithFilters(
 			log.IgnoreMessagesMatching("transport message received"),
-			log.IgnoreMessagesMatching("Metric recorded"),
+			//log.IgnoreMessagesMatching("Metric recorded"),
 		).
 		WithFilters(b.logFilters...)
 	//WithFilters(log.Or(log.OnlyErrors(), log.OnlyCheckpoints(), log.OnlyMetrics()))


### PR DESCRIPTION
This is not a good thing - obviously we need histograms, but must check if this is the cause of mem leaks on nightly.
Histograms are the greatest memory hogger between tests, after logs (logs have been fixed in prev PR which was already merged).