### PR TITLE
Issue/tcp timeout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,7 @@ type NodeConfig interface {
 	GossipListenPort() uint16
 	GossipConnectionKeepAliveInterval() time.Duration
 	GossipNetworkTimeout() time.Duration
+	GossipReconnectInterval() time.Duration
 
 	// public api
 	PublicApiSendTransactionTimeout() time.Duration
@@ -145,6 +146,7 @@ type GossipTransportConfig interface {
 	GossipListenPort() uint16
 	GossipConnectionKeepAliveInterval() time.Duration
 	GossipNetworkTimeout() time.Duration
+	GossipReconnectInterval() time.Duration
 }
 
 // Config based on https://github.com/orbs-network/orbs-spec/blob/master/behaviors/config/services.md#consensus-context

--- a/config/hardcoded_config.go
+++ b/config/hardcoded_config.go
@@ -80,6 +80,7 @@ const (
 	GOSSIP_LISTEN_PORT                    = "GOSSIP_LISTEN_PORT"
 	GOSSIP_CONNECTION_KEEP_ALIVE_INTERVAL = "GOSSIP_CONNECTION_KEEP_ALIVE_INTERVAL"
 	GOSSIP_NETWORK_TIMEOUT                = "GOSSIP_NETWORK_TIMEOUT"
+	GOSSIP_RECONNECT_INTERVAL             = "GOSSIP_RECONNECT_INTERVAL"
 
 	PUBLIC_API_SEND_TRANSACTION_TIMEOUT = "PUBLIC_API_SEND_TRANSACTION_TIMEOUT"
 	PUBLIC_API_NODE_SYNC_WARNING_TIME   = "PUBLIC_API_NODE_SYNC_WARNING_TIME"
@@ -336,6 +337,10 @@ func (c *config) GossipConnectionKeepAliveInterval() time.Duration {
 
 func (c *config) GossipNetworkTimeout() time.Duration {
 	return c.kv[GOSSIP_NETWORK_TIMEOUT].DurationValue
+}
+
+func (c *config) GossipReconnectInterval() time.Duration {
+	return c.kv[GOSSIP_RECONNECT_INTERVAL].DurationValue
 }
 
 func (c *config) BenchmarkConsensusRequiredQuorumPercentage() uint32 {

--- a/config/service_factory_presets.go
+++ b/config/service_factory_presets.go
@@ -21,6 +21,8 @@ func ForDirectTransportTests(gossipPeers map[string]GossipPeer, keepAliveInterva
 
 	cfg.SetDuration(GOSSIP_CONNECTION_KEEP_ALIVE_INTERVAL, keepAliveInterval)
 	cfg.SetDuration(GOSSIP_NETWORK_TIMEOUT, networkTimeout)
+	cfg.SetDuration(GOSSIP_RECONNECT_INTERVAL, 20*time.Millisecond)
+
 	return cfg
 }
 
@@ -32,6 +34,8 @@ func ForGossipAdapterTests(nodeAddress primitives.NodeAddress, gossipListenPort 
 	cfg.SetUint32(GOSSIP_LISTEN_PORT, uint32(gossipListenPort))
 	cfg.SetDuration(GOSSIP_CONNECTION_KEEP_ALIVE_INTERVAL, 20*time.Millisecond)
 	cfg.SetDuration(GOSSIP_NETWORK_TIMEOUT, 1*time.Second)
+	cfg.SetDuration(GOSSIP_RECONNECT_INTERVAL, 20*time.Millisecond)
+
 	return cfg
 }
 

--- a/config/service_factory_presets.go
+++ b/config/service_factory_presets.go
@@ -14,13 +14,13 @@ import (
 	"time"
 )
 
-func ForDirectTransportTests(gossipPeers map[string]GossipPeer, keepAliveInterval time.Duration) GossipTransportConfig {
+func ForDirectTransportTests(gossipPeers map[string]GossipPeer, keepAliveInterval time.Duration, networkTimeout time.Duration) GossipTransportConfig {
 	cfg := emptyConfig()
 	cfg.SetNodeAddress(testKeys.EcdsaSecp256K1KeyPairForTests(0).NodeAddress())
 	cfg.SetGossipPeers(gossipPeers)
 
-	cfg.SetDuration(GOSSIP_CONNECTION_KEEP_ALIVE_INTERVAL, 20*time.Millisecond)
-	cfg.SetDuration(GOSSIP_NETWORK_TIMEOUT, keepAliveInterval)
+	cfg.SetDuration(GOSSIP_CONNECTION_KEEP_ALIVE_INTERVAL, keepAliveInterval)
+	cfg.SetDuration(GOSSIP_NETWORK_TIMEOUT, networkTimeout)
 	return cfg
 }
 

--- a/config/system_factory_presets.go
+++ b/config/system_factory_presets.go
@@ -77,6 +77,7 @@ func defaultProductionConfig() mutableNodeConfig {
 
 	cfg.SetDuration(GOSSIP_CONNECTION_KEEP_ALIVE_INTERVAL, 1*time.Second)
 	cfg.SetDuration(GOSSIP_NETWORK_TIMEOUT, 30*time.Second)
+	cfg.SetDuration(GOSSIP_RECONNECT_INTERVAL, 5*time.Second)
 
 	// 10 minutes + 60 blocks is about 25 minutes
 	cfg.SetDuration(ETHEREUM_FINALITY_TIME_COMPONENT, 10*time.Minute)
@@ -149,6 +150,7 @@ func ForE2E(
 
 	cfg.SetDuration(GOSSIP_CONNECTION_KEEP_ALIVE_INTERVAL, 500*time.Millisecond)
 	cfg.SetDuration(GOSSIP_NETWORK_TIMEOUT, 4*time.Second)
+	cfg.SetDuration(GOSSIP_RECONNECT_INTERVAL, 500*time.Millisecond)
 
 	cfg.SetString(ETHEREUM_ENDPOINT, ethereumEndpoint)
 	cfg.SetUint32(BLOCK_STORAGE_FILE_SYSTEM_MAX_BLOCK_SIZE_IN_BYTES, 64*1024*1024)

--- a/services/gossip/adapter/tcp/direct_harness.go
+++ b/services/gossip/adapter/tcp/direct_harness.go
@@ -25,7 +25,7 @@ import (
 
 const NETWORK_SIZE = 3
 const TEST_KEEP_ALIVE_INTERVAL = 20 * time.Millisecond
-const TEST_NETWORK_TIMEOUT = 20 * time.Millisecond
+const TEST_NETWORK_TIMEOUT = 1 * time.Second
 
 const HARNESS_PEER_READ_TIMEOUT = 1 * time.Second
 const HARNESS_OUTGOING_CONNECTIONS_INIT_TIMEOUT = 3 * time.Second

--- a/services/gossip/adapter/tcp/direct_outgoing.go
+++ b/services/gossip/adapter/tcp/direct_outgoing.go
@@ -26,7 +26,7 @@ func (t *directTransport) clientMainLoop(parentCtx context.Context, queue *trans
 
 		if err != nil {
 			t.logger.Info("cannot connect to gossip peer endpoint", log.String("peer", queue.networkAddress), trace.LogFieldFrom(ctx))
-			time.Sleep(t.config.GossipConnectionKeepAliveInterval())
+			time.Sleep(t.config.GossipReconnectInterval())
 			continue
 		}
 

--- a/services/gossip/adapter/tcp/direct_outgoing_test.go
+++ b/services/gossip/adapter/tcp/direct_outgoing_test.go
@@ -109,15 +109,9 @@ func TestDirectOutgoing_ErrorDuringSendCausesReconnect(t *testing.T) {
 		h := newDirectHarnessWithConnectedPeers(t, ctx)
 		defer h.cleanupConnectedPeers()
 
-		err := h.transport.Send(ctx, &adapter.TransportData{
-			SenderNodeAddress:      h.config.NodeAddress(),
-			RecipientMode:          gossipmessages.RECIPIENT_LIST_MODE_LIST,
-			RecipientNodeAddresses: []primitives.NodeAddress{h.nodeAddressForPeer(1)},
-			Payloads:               [][]byte{{0x11}, {0x22, 0x33}},
-		})
-		require.NoError(t, err, "adapter Send should not fail")
-
-		h.peersListenersConnections[1].Close() // break the pipe during Send
+		// simulate some network issue supposedly leading to a closed connection
+		err := h.peersListenersConnections[1].Close()
+		require.NoError(t, err, "expected the connection to successfully close")
 
 		h.peersListenersConnections[1], err = h.peersListeners[1].Accept()
 		require.NoError(t, err, "test peer server did not accept new connection from local transport")

--- a/services/gossip/adapter/tcp/direct_outgoing_test.go
+++ b/services/gossip/adapter/tcp/direct_outgoing_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
 	"github.com/stretchr/testify/require"
+	"net"
 	"testing"
+	"time"
 )
 
 func TestDirectOutgoing_ConnectionsToAllPeersOnInitWhileContextIsLive(t *testing.T) {
@@ -109,15 +111,43 @@ func TestDirectOutgoing_ErrorDuringSendCausesReconnect(t *testing.T) {
 		h := newDirectHarnessWithConnectedPeers(t, ctx)
 		defer h.cleanupConnectedPeers()
 
-		// simulate some network issue supposedly leading to a closed connection
+		// simulate some network issue supposedly leading to a momentarily closed connection
 		err := h.peersListenersConnections[1].Close()
 		require.NoError(t, err, "expected the connection to successfully close")
 
 		h.peersListenersConnections[1], err = h.peersListeners[1].Accept()
-		require.NoError(t, err, "test peer server did not accept new connection from local transport")
+		require.NoError(t, err, "client loop did not reconnect immediately after connection closed")
 
 		data, err := h.peerListenerReadTotal(1, 4)
-		require.NoError(t, err, "test peer server could not read keepalive from local transport")
+		require.NoError(t, err, "client loop did not send keep alive message over idle connection as expected")
 		require.Equal(t, exampleWireProtocolEncoding_KeepAlive(), data)
+	})
+}
+
+func TestDirectOutgoing_OutgoingMessageQueueDisabledWhenConnectionClosed(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+
+		h := newDirectHarnessWithConnectedPeers(t, ctx)
+		defer h.cleanupConnectedPeers()
+
+		// remote peer closes connection
+		err := h.peersListeners[1].Close() // suspend listener to control when connection will be recovered
+		require.NoError(t, err, "failed to stop listener")
+		err = h.peersListenersConnections[1].Close() // close connection to simulate network issues
+		require.NoError(t, err, "failed to close connection")
+
+		require.True(t, test.Eventually(3*time.Second, func() bool {
+			return !h.allOutgoingQueuesEnabled()
+		}), "expected one queue to become disabled after successfully closing its outgoing connection")
+
+		// remote peer comes back online
+		h.peersListeners[1], err = net.Listen("tcp", h.peersListeners[1].Addr().String()) // recover listener
+		require.NoError(t, err, "test peer server could not listen")
+		h.peersListenersConnections[1], err = h.peersListeners[1].Accept() // obtain recovered connection
+		require.NoError(t, err, "test peer server did not accept new connection from local transport")
+
+		require.True(t, test.Eventually(3*time.Second, func() bool {
+			return h.allOutgoingQueuesEnabled()
+		}), "expected all queues to return to enabled state once connection is recovered")
 	})
 }


### PR DESCRIPTION
resolves #973

- fixed several minor issues causing flakiness in DirectTransport tests. see #973 

- added `GOSSIP_RECONNECT_INTERVAL` config value to guarantee that we never sleep for very long durations between reconnect attempts in tests which override `GOSSIP_CONNECTION_KEEP_ALIVE_INTERVAL` to very high values - since the second value was used to sleep between reconnect attempts.

- in `TestDirectOutgoing_ErrorDuringSendCausesReconnect` avoid possible race condition (theoretical - not observed) in case `Send()` queues a message just before `Close()` is called (while the queue is enabled) but the message remains in queue - then the connection is closed and immediately reopened, and only after the queue is re-enabled the message is sent by the clientLoop - the test would fail because we expect an empty keep alive but would receive a valid message. fixed by avoiding `Send` altogether - in any case we don't know if it happens before after or during the `Close`