### PR TITLE
adding a new workflow that is about tagged artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  untagged-build:
     jobs:
       - tests
       - e2e
@@ -180,10 +180,29 @@ workflows:
             - tests
             - e2e
           filters:
+            branches:
+              only: master
+
+  tagged-build:
+    jobs:
+      - tests:
+          filters:
+            tags:
+              only: /^v.*/
+      - e2e:
+          filters:
+            tags:
+              only: /^v.*/
+      - release_gamma:
+          requires:
+            - tests
+            - e2e
+          filters:
             tags:
               only: /^v.*/
             branches:
               only: master
+
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
This PR is an attempt to try and fix the problem with CircleCI not buildling our GitHub tags
and introduces a new workflow which is using `filters` for all the related jobs which are required
to build and release a `gamma-server` Docker image based on a release tag.