### PR TITLE
remove logging of metrics to logs on interval

### DIFF
--- a/bootstrap/gamma/server.go
+++ b/bootstrap/gamma/server.go
@@ -29,7 +29,6 @@ func StartGammaServer(serverAddress string, profiling bool, overrideConfigJson s
 		WithOutput(log.NewFormattingOutput(os.Stdout, log.NewHumanReadableFormatter())).
 		WithFilters(
 			//TODO(https://github.com/orbs-network/orbs-network-go/issues/585) what do we really want to output to the gamma server log? maybe some meaningful data for our users?
-			log.IgnoreMessagesMatching("Metric recorded"),
 			log.IgnoreMessagesMatching("state transitioning"),
 			log.IgnoreMessagesMatching("finished waiting for responses"),
 			log.IgnoreMessagesMatching("no responses received"),

--- a/bootstrap/node_logic.go
+++ b/bootstrap/node_logic.go
@@ -83,7 +83,7 @@ func NewNodeLogic(
 
 	metric.NewSystemReporter(ctx, metricRegistry, logger)
 	runtimeReporter := metric.NewRuntimeReporter(ctx, metricRegistry, logger)
-	metricRegistry.PeriodicallyReport(ctx, logger)
+	metricRegistry.PeriodicallyRotate(ctx, logger)
 
 	ethereumConnection.ReportConnectionStatus(ctx, metricRegistry, logger, 30*time.Second)
 

--- a/instrumentation/metric/_manual_system_test.go
+++ b/instrumentation/metric/_manual_system_test.go
@@ -30,7 +30,7 @@ func TestSystemMetrics(t *testing.T) {
 	m := NewRegistry()
 	l := log.GetLogger().WithOutput(log.NewFormattingOutput(os.Stderr, log.NewHumanReadableFormatter()))
 	NewSystemReporter(context.Background(), m, l)
-	m.PeriodicallyReport(context.Background(), l)
+	m.PeriodicallyRotate(context.Background(), l)
 
 	<-time.After(1 * time.Minute)
 }

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func getLogger(path string, silent bool, cfg config.NodeConfig) log.Logger {
 	conditionalFilter := log.NewConditionalFilter(false, nil)
 
 	if !cfg.LoggerFullLog() {
-		conditionalFilter = log.NewConditionalFilter(true, log.Or(log.OnlyErrors(), log.OnlyMetrics()))
+		conditionalFilter = log.NewConditionalFilter(true, log.OnlyErrors())
 	}
 
 	return logger.WithFilters(conditionalFilter)

--- a/test/acceptance/network_harness_builder.go
+++ b/test/acceptance/network_harness_builder.go
@@ -180,7 +180,7 @@ func (b *networkHarnessBuilder) makeLogger(tb testing.TB, testId string) (log.Lo
 			log.IgnoreMessagesMatching("transport message received"),
 		).
 		WithFilters(b.logFilters...)
-	//WithFilters(log.Or(log.OnlyErrors(), log.OnlyCheckpoints(), log.OnlyMetrics()))
+	//WithFilters(log.Or(log.OnlyErrors(), log.OnlyCheckpoints()))
 
 	return logger, testOutput
 }

--- a/test/acceptance/network_harness_builder.go
+++ b/test/acceptance/network_harness_builder.go
@@ -178,7 +178,6 @@ func (b *networkHarnessBuilder) makeLogger(tb testing.TB, testId string) (log.Lo
 		WithOutput(testOutput).
 		WithFilters(
 			log.IgnoreMessagesMatching("transport message received"),
-			log.IgnoreMessagesMatching("Metric recorded"),
 		).
 		WithFilters(b.logFilters...)
 	//WithFilters(log.Or(log.OnlyErrors(), log.OnlyCheckpoints(), log.OnlyMetrics()))

--- a/test/acceptance/quorum_size_test.go
+++ b/test/acceptance/quorum_size_test.go
@@ -22,7 +22,6 @@ func TestNetworkStartedWithEnoughNodes_SucceedsClosingBlocks_BenchmarkConsensus(
 		WithRequiredQuorumPercentage(66).
 		WithLogFilters(
 			log.ExcludeEntryPoint("BlockSync"),
-			log.IgnoreMessagesMatching("Metric recorded"),
 			log.ExcludeEntryPoint("LeanHelixConsensus")).
 		Start(t, func(t testing.TB, ctx context.Context, network *NetworkHarness) {
 			contract := network.DeployBenchmarkTokenContract(ctx, 5)

--- a/test/acceptance/service_sync_test.go
+++ b/test/acceptance/service_sync_test.go
@@ -84,7 +84,6 @@ func TestServiceBlockSync_StateStorage(t *testing.T) {
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS). // this test only runs with BenchmarkConsensus since we only create blocks compatible with that algo
 		WithInitialBlocks(blocks).
 		WithLogFilters(log.ExcludeField(gossip.LogTag),
-			log.IgnoreMessagesMatching("Metric recorded"),
 			log.ExcludeField(internodesync.LogTag)).
 		Start(t, func(t testing.TB, ctx context.Context, network *NetworkHarness) {
 

--- a/test/e2e/network.go
+++ b/test/e2e/network.go
@@ -65,7 +65,6 @@ func bootstrapE2ENetwork() (nodes []bootstrap.Node) {
 		log.String("_test", "e2e"),
 		log.String("_branch", os.Getenv("GIT_BRANCH")),
 		log.String("_commit", os.Getenv("GIT_COMMIT"))).
-		WithFilters(log.IgnoreMessagesMatching("Metric recorded")).
 		WithOutput(console)
 	leaderKeyPair := keys.EcdsaSecp256K1KeyPairForTests(0)
 	for i := 0; i < LOCAL_NETWORK_SIZE; i++ {


### PR DESCRIPTION
mute logging of system metrics to system logs:

monitoring (dashboard) now extracts the metrics directly via http polling, and not by extracting the metrics from the logs.

To make the logs more readable - muting automatic metrics logging.