### PR TITLE
added a failing test for empty block time

### DIFF
--- a/test/acceptance/empty_block_time_test.go
+++ b/test/acceptance/empty_block_time_test.go
@@ -9,6 +9,8 @@ package acceptance
 import (
 	"context"
 	"github.com/orbs-network/orbs-network-go/test/acceptance/callcontract"
+	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
+	"github.com/orbs-network/scribe/log"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
@@ -28,5 +30,19 @@ func TestIncomingTransactionTriggersExactlyOneBlock(t *testing.T) {
 			heightAfterTx, _ := network.BlockPersistence(0).GetLastBlockHeight()
 
 			require.Equal(t, uint64(heightBeforeTx)+1, uint64(heightAfterTx), "incoming transaction triggered closure of more than one block")
+		})
+}
+
+func TestIncomingTransactionTriggersImmediateBlockClosure(t *testing.T) {
+	newHarness().
+		WithEmptyBlockTime(1*time.Hour).
+		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX).
+		WithLogFilters(log.ExcludeEntryPoint("BlockSync")).
+		Start(t, func(tb testing.TB, ctx context.Context, network *NetworkHarness) {
+			contract := callcontract.NewContractClient(network)
+			time.Sleep(1 * time.Second)
+			_, txHash := contract.Transfer(ctx, 0, 43, 5, 6)
+			network.WaitForTransactionInState(ctx, txHash)
+
 		})
 }

--- a/test/acceptance/empty_block_time_test.go
+++ b/test/acceptance/empty_block_time_test.go
@@ -40,8 +40,11 @@ func TestIncomingTransactionTriggersImmediateBlockClosure(t *testing.T) {
 		WithLogFilters(log.ExcludeEntryPoint("BlockSync")).
 		Start(t, func(tb testing.TB, ctx context.Context, network *NetworkHarness) {
 			contract := callcontract.NewContractClient(network)
-			time.Sleep(1 * time.Second)
+
+			network.WaitForBlock(ctx, 1) // wait for network to start closing blocks
+
 			_, txHash := contract.Transfer(ctx, 0, 43, 5, 6)
+
 			network.WaitForTransactionInState(ctx, txHash)
 
 		})

--- a/test/acceptance/network_harness.go
+++ b/test/acceptance/network_harness.go
@@ -206,3 +206,9 @@ func (n *NetworkHarness) DumpState() {
 		n.Logger.Info("state dump", log.Int("node", i), log.String("data", n.GetStatePersistence(i).Dump()))
 	}
 }
+
+func (n *NetworkHarness) WaitForBlock(ctx context.Context, height primitives.BlockHeight) {
+	for _, tracker := range n.transactionPoolBlockHeightTrackers {
+		tracker.WaitForBlock(ctx, height)
+	}
+}

--- a/test/acceptance/network_harness_builder.go
+++ b/test/acceptance/network_harness_builder.go
@@ -69,7 +69,9 @@ func newHarness() *networkHarnessBuilder {
 		WithNumNodes(DEFAULT_NODE_COUNT_FOR_ACCEPTANCE).
 		WithConsensusAlgos(algos...).
 		WithVirtualChainId(DEFAULT_ACCEPTANCE_VIRTUAL_CHAIN_ID).
-		AllowingErrors("ValidateBlockProposal failed.*") // it is acceptable for validation to fail in one or more nodes, as long as f+1 nodes are in agreement on a block and even if they do not, a new leader should eventually be able to reach consensus on the block
+		AllowingErrors(
+			"ValidateBlockProposal failed.*", // it is acceptable for validation to fail in one or more nodes, as long as f+1 nodes are in agreement on a block and even if they do not, a new leader should eventually be able to reach consensus on the block
+		)
 
 	return harness
 }


### PR DESCRIPTION
Added a test to assert that an incoming transaction trigger immediate block closure
This test fails because Lean Helix blocks the gossip goroutine