### PR TITLE
Additions to Ron's test for compare() of state diffs

### DIFF
--- a/services/consensuscontext/validate_results_block_test.go
+++ b/services/consensuscontext/validate_results_block_test.go
@@ -267,18 +267,19 @@ func TestResultsBlockValidators(t *testing.T) {
 func TestCompare(t *testing.T) {
 
 	expectedDiffs := []*protocol.ContractStateDiff{
-		builders.ContractStateDiff().WithContractName("m1").WithStringRecord("mr1", "mv1").Build(),
+		builders.ContractStateDiff().WithContractName("m1").WithStringRecord("mr1", "mv1").WithStringRecord("mrSame", "mvSame").Build(),
 		builders.ContractStateDiff().WithContractName("m2").WithStringRecord("mr2", "mv2").Build(),
-		builders.ContractStateDiff().WithContractName("mSame").WithStringRecord("mrSame", "mvSame").Build(),
+		builders.ContractStateDiff().WithContractName("m4").WithStringRecord("mr4", "mv4").Build(),
 	}
 
-	calcualtedDiffs := []*protocol.ContractStateDiff{
-		builders.ContractStateDiff().WithContractName("mSame").WithStringRecord("mrSame", "mvSame").Build(),
+	calculatedDiffs := []*protocol.ContractStateDiff{
+		builders.ContractStateDiff().WithContractName("m1").WithStringRecord("mrSame", "mvSame").Build(),
+		builders.ContractStateDiff().WithContractName("m4").WithStringRecord("mr4", "mv4").WithStringRecord("mrNew", "mvNew").Build(),
 		builders.ContractStateDiff().WithContractName("m2").WithStringRecord("mr2", "mv3").Build(),
 		builders.ContractStateDiff().WithContractName("m3").WithStringRecord("mr3", "mv4").Build(),
 	}
 
-	require.EqualValues(t, compare(expectedDiffs, calcualtedDiffs), map[string]string{"m2/6d7232": "e: 6d7632 <==> c: 6d7633", "m3/6d7233": "e: NA <==> c: 6d7634", "m1/6d7231": "e: 6d7631 <==> c: NA"})
+	require.EqualValues(t, compare(expectedDiffs, calculatedDiffs), map[string]string{"m3/6d7233": "e: NA <==> c: 6d7634", "m1/6d7231": "e: 6d7631 <==> c: NA", "m4/6d724e6577": "e: NA <==> c: 6d764e6577", "m2/6d7232": "e: 6d7632 <==> c: 6d7633"})
 }
 
 func MockProcessTransactionSetThatReturns(err error) func(ctx context.Context, input *services.ProcessTransactionSetInput) (*services.ProcessTransactionSetOutput, error) {


### PR DESCRIPTION
Minor additions to state diff `compare()`'s test function that @ronnno  and I added.
I branched it off `master` - as agreed on Slack we'll have a discussion on this.