### PR TITLE
Fixing some V1 TODOs

### DIFF
--- a/bootstrap/gamma/deploy_native_test.go
+++ b/bootstrap/gamma/deploy_native_test.go
@@ -8,9 +8,11 @@ package gamma
 
 import (
 	"context"
+	"fmt"
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-network-go/test/acceptance/callcontract"
 	"github.com/orbs-network/orbs-network-go/test/contracts"
+	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
 	"github.com/orbs-network/scribe/log"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -53,5 +55,5 @@ func TestNonLeaderDeploysNativeContract(t *testing.T) {
 	}
 
 	t.Run("Benchmark", testDeployNativeContractWithConfig(""))
-	t.Run("LeanHelix", testDeployNativeContractWithConfig(LEAN_HELIX_CONSENSUS_JSON))
+	t.Run("LeanHelix", testDeployNativeContractWithConfig(fmt.Sprintf(`{"active-consensus-algo":%d}`, consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX)))
 }

--- a/bootstrap/gamma/main/main.go
+++ b/bootstrap/gamma/main/main.go
@@ -14,12 +14,14 @@ import (
 	"strconv"
 )
 
-func main() {
-	port := flag.Int("port", 8080, "The port to bind the gamma server to")
-	profiling := flag.Bool("profiling", false, "enable profiling")
-	version := flag.Bool("version", false, "returns information about version")
-	overrideConfigJson := flag.String("override-config", "{}", "JSON-formatted config overrides, same format as the file config")
+var (
+	port               = flag.Int("port", 8080, "The port to bind the gamma server to")
+	profiling          = flag.Bool("profiling", false, "enable profiling")
+	version            = flag.Bool("version", false, "returns information about version")
+	overrideConfigJson = flag.String("override-config", "{}", "JSON-formatted config overrides, same format as the file config")
+)
 
+func main() {
 	flag.Parse()
 
 	if *version {

--- a/bootstrap/gamma/main/main.go
+++ b/bootstrap/gamma/main/main.go
@@ -29,6 +29,5 @@ func main() {
 
 	var serverAddress = ":" + strconv.Itoa(*port)
 
-	// TODO(v1) add WaitUntilShutdown so this behaves like the regular main (no blocking flag)
 	gamma.StartGammaServer(serverAddress, *profiling, *overrideConfigJson).WaitUntilShutdown()
 }

--- a/bootstrap/gamma/main/main.go
+++ b/bootstrap/gamma/main/main.go
@@ -35,5 +35,5 @@ func main() {
 		Profiling:          *profiling,
 		OverrideConfigJson: *overrideConfigJson,
 		Silent:             false,
-	})
+	}).WaitUntilShutdown()
 }

--- a/bootstrap/gamma/main/main.go
+++ b/bootstrap/gamma/main/main.go
@@ -30,5 +30,5 @@ func main() {
 	var serverAddress = ":" + strconv.Itoa(*port)
 
 	// TODO(v1) add WaitUntilShutdown so this behaves like the regular main (no blocking flag)
-	gamma.StartGammaServer(serverAddress, *profiling, *overrideConfigJson, true)
+	gamma.StartGammaServer(serverAddress, *profiling, *overrideConfigJson).WaitUntilShutdown()
 }

--- a/bootstrap/gamma/server.go
+++ b/bootstrap/gamma/server.go
@@ -47,6 +47,7 @@ func StartGammaServer(config GammaServerConfig) *GammaServer {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	rootLogger := getLogger(config.Silent)
+	rootLogger.Info("Starting gamma server", log.String("server-address", config.ServerAddress))
 
 	network := NewDevelopmentNetwork(ctx, rootLogger, config.OverrideConfigJson)
 	rootLogger.Info("finished creating development network")

--- a/bootstrap/gamma/simple_transfer_test.go
+++ b/bootstrap/gamma/simple_transfer_test.go
@@ -8,8 +8,10 @@ package gamma
 
 import (
 	"context"
+	"fmt"
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-network-go/test/acceptance/callcontract"
+	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
 	"github.com/orbs-network/scribe/log"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -39,6 +41,6 @@ func testSimpleTransfer(jsonConfig string) func(t *testing.T) {
 
 func TestSimpleTransfer(t *testing.T) {
 	t.Run("Benchmark", testSimpleTransfer(""))
-	t.Run("LeanHelix", testSimpleTransfer(LEAN_HELIX_CONSENSUS_JSON))
+	t.Run("LeanHelix", testSimpleTransfer(fmt.Sprintf(`{"active-consensus-algo":%d}`, consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX)))
 
 }

--- a/bootstrap/inmemory/network.go
+++ b/bootstrap/inmemory/network.go
@@ -77,8 +77,8 @@ func NewNetworkWithNumOfNodes(
 		dep := &NodeDependencies{}
 		if provider == nil {
 			dep.BlockPersistence = blockStorageMemoryAdapter.NewBlockPersistence(nodeLogger, metricRegistry)
-			dep.Compiler = nativeProcessorAdapter.NewNativeCompiler(cfgTemplate, nodeLogger, metricRegistry)
-			dep.EtherConnection = ethereumAdapter.NewEthereumRpcConnection(cfgTemplate, nodeLogger)
+			dep.Compiler = nativeProcessorAdapter.NewNativeCompiler(cfg, nodeLogger, metricRegistry)
+			dep.EtherConnection = ethereumAdapter.NewEthereumRpcConnection(cfg, nodeLogger)
 			dep.StatePersistence = stateStorageMemoryAdapter.NewStatePersistence(metricRegistry)
 			dep.StateBlockHeightReporter = synchronization.NopHeightReporter{}
 			dep.TransactionPoolBlockHeightReporter = synchronization.NewBlockTracker(nodeLogger, 0, math.MaxUint16)

--- a/bootstrap/node.go
+++ b/bootstrap/node.go
@@ -17,12 +17,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter/tcp"
 	nativeProcessorAdapter "github.com/orbs-network/orbs-network-go/services/processor/native/adapter"
 	stateStorageAdapter "github.com/orbs-network/orbs-network-go/services/statestorage/adapter/memory"
-	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"github.com/orbs-network/scribe/log"
-	"os"
-	"os/signal"
-	"sync"
-	"syscall"
 	"time"
 )
 
@@ -32,11 +27,8 @@ type Node interface {
 }
 
 type node struct {
-	httpServer   httpserver.HttpServer
-	logic        NodeLogic
-	shutdownCond *sync.Cond
-	ctxCancel    context.CancelFunc
-	logger       log.Logger
+	OrbsProcess
+	logic NodeLogic
 }
 
 func getMetricRegistry(nodeConfig config.NodeConfig) metric.Registry {
@@ -71,31 +63,7 @@ func NewNode(nodeConfig config.NodeConfig, logger log.Logger) Node {
 	httpServer := httpserver.NewHttpServer(nodeConfig, nodeLogger, nodeLogic.PublicApi(), metricRegistry)
 
 	return &node{
-		logic:        nodeLogic,
-		httpServer:   httpServer,
-		shutdownCond: sync.NewCond(&sync.Mutex{}),
-		ctxCancel:    ctxCancel,
-		logger:       nodeLogger,
+		logic:       nodeLogic,
+		OrbsProcess: NewOrbsProcess(nodeLogger, ctxCancel, httpServer),
 	}
-}
-
-func (n *node) GracefulShutdown(timeout time.Duration) {
-	n.ctxCancel()
-	n.httpServer.GracefulShutdown(timeout)
-	n.shutdownCond.Broadcast()
-}
-
-func (n *node) WaitUntilShutdown() {
-	// if waiting for shutdown, listen for sigint and sigterm
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
-	supervised.GoOnce(n.logger, func() {
-		<-signalChan
-		n.logger.Info("terminating node gracefully due to os signal received")
-		n.GracefulShutdown(0)
-	})
-
-	n.shutdownCond.L.Lock()
-	n.shutdownCond.Wait()
-	n.shutdownCond.L.Unlock()
 }

--- a/bootstrap/process.go
+++ b/bootstrap/process.go
@@ -1,0 +1,50 @@
+package bootstrap
+
+import (
+	"context"
+	"github.com/orbs-network/orbs-network-go/bootstrap/httpserver"
+	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
+	"github.com/orbs-network/scribe/log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type OrbsProcess struct {
+	CancelFunc   context.CancelFunc
+	Logger       log.Logger
+	HttpServer   httpserver.HttpServer
+	shutdownCond *sync.Cond
+}
+
+func NewOrbsProcess(logger log.Logger, cancelFunc context.CancelFunc, httpserver httpserver.HttpServer) OrbsProcess {
+	return OrbsProcess{
+		shutdownCond: sync.NewCond(&sync.Mutex{}),
+		Logger:       logger,
+		CancelFunc:   cancelFunc,
+		HttpServer:   httpserver,
+	}
+}
+
+func (n *OrbsProcess) GracefulShutdown(timeout time.Duration) {
+	n.CancelFunc()
+	n.HttpServer.GracefulShutdown(timeout)
+	n.shutdownCond.Broadcast()
+}
+
+func (n *OrbsProcess) WaitUntilShutdown() {
+	// if waiting for shutdown, listen for sigint and sigterm
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
+	supervised.GoOnce(n.Logger, func() {
+		<-signalChan
+		n.Logger.Info("terminating node gracefully due to os signal received")
+		n.GracefulShutdown(0)
+	})
+
+	n.shutdownCond.L.Lock()
+	n.shutdownCond.Wait()
+	n.shutdownCond.L.Unlock()
+}

--- a/config/factory.go
+++ b/config/factory.go
@@ -7,6 +7,7 @@
 package config
 
 import (
+	"fmt"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"path/filepath"
 )
@@ -38,6 +39,7 @@ func (c *config) ForNode(nodeAddress primitives.NodeAddress, privateKey primitiv
 	cloned := c.Clone()
 	cloned.SetNodeAddress(nodeAddress)
 	cloned.SetNodePrivateKey(privateKey)
+	cloned.SetString(PROCESSOR_ARTIFACT_PATH, fmt.Sprintf("%s/%s", GetProjectSourceTmpPath(), nodeAddress))
 	return cloned
 }
 

--- a/config/file_config_test.go
+++ b/config/file_config_test.go
@@ -9,7 +9,6 @@ package config
 import (
 	"encoding/hex"
 	"github.com/orbs-network/orbs-network-go/test/crypto/keys"
-	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"testing"
@@ -159,12 +158,7 @@ func TestSetGossipPort(t *testing.T) {
 }
 
 func TestMergeWithFileConfig(t *testing.T) {
-	nodes := make(map[string]ValidatorNode)
-	keyPair := keys.EcdsaSecp256K1KeyPairForTests(2)
-
-	cfg := ForAcceptanceTestNetwork(nodes,
-		keyPair.NodeAddress(),
-		consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS, 30, 100, 42, 10*time.Millisecond)
+	cfg := ForProduction("/")
 
 	require.EqualValues(t, 0, len(cfg.GenesisValidatorNodes()))
 

--- a/config/service_factory_presets.go
+++ b/config/service_factory_presets.go
@@ -107,6 +107,21 @@ func ForLeanHelixConsensusTests(keyPair *testKeys.TestEcdsaSecp256K1KeyPair) Lea
 	return cfg
 }
 
+func ForBenchmarkConsensusTests(keyPair *testKeys.TestEcdsaSecp256K1KeyPair, leaderKeyPair *testKeys.TestEcdsaSecp256K1KeyPair, validators map[string]ValidatorNode) NodeConfig {
+	cfg := emptyConfig()
+	cfg.SetGenesisValidatorNodes(validators)
+	cfg.SetBenchmarkConsensusConstantLeader(leaderKeyPair.NodeAddress())
+	cfg.SetActiveConsensusAlgo(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS)
+	cfg.SetUint32(CONSENSUS_CONTEXT_MAXIMUM_TRANSACTIONS_IN_BLOCK, 1)
+	cfg.SetUint32(VIRTUAL_CHAIN_ID, 42)
+	cfg.SetDuration(BENCHMARK_CONSENSUS_RETRY_INTERVAL, 5*time.Millisecond)
+	cfg.SetUint32(BENCHMARK_CONSENSUS_REQUIRED_QUORUM_PERCENTAGE, 66)
+	cfg.SetNodeAddress(keyPair.NodeAddress())
+	cfg.SetNodePrivateKey(keyPair.PrivateKey())
+
+	return cfg
+}
+
 func ForNativeProcessorTests(id primitives.VirtualChainId) NativeProcessorConfig {
 	cfg := emptyConfig()
 	cfg.SetUint32(VIRTUAL_CHAIN_ID, uint32(id))

--- a/crypto/signature/ecdsa_secp256k1_test.go
+++ b/crypto/signature/ecdsa_secp256k1_test.go
@@ -78,4 +78,40 @@ func TestRecoverEcdsaSecp256K1_SigLengthIncorrect(t *testing.T) {
 	require.Error(t, err, "should return error on incorrect sig length")
 }
 
-// TODO (v1) add benchmarks like in ed25519
+func BenchmarkSignEcdsaSecp256K1(b *testing.B) {
+	kp := keys.EcdsaSecp256K1KeyPairForTests(1)
+	for i := 0; i < b.N; i++ {
+		if _, err := SignEcdsaSecp256K1(kp.PrivateKey(), someDataToSign_EcdsaSecp256K1); err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkVerifyEcdsaSecp256K1(b *testing.B) {
+	b.StopTimer()
+	kp := keys.EcdsaSecp256K1KeyPairForTests(1)
+
+	if sig, err := SignEcdsaSecp256K1(kp.PrivateKey(), someDataToSign_EcdsaSecp256K1); err != nil {
+		b.Error(err)
+	} else {
+		b.StartTimer()
+		for i := 0; i < b.N; i++ {
+			if !VerifyEcdsaSecp256K1(kp.PublicKey(), someDataToSign_EcdsaSecp256K1, sig) {
+				b.Error("verification failed")
+			}
+		}
+	}
+}
+
+func BenchmarkSignAndVerifyEcdsaSecp256K1(b *testing.B) {
+	kp := keys.EcdsaSecp256K1KeyPairForTests(1)
+	for i := 0; i < b.N; i++ {
+		if sig, err := SignEcdsaSecp256K1(kp.PrivateKey(), someDataToSign_EcdsaSecp256K1); err != nil {
+			b.Error(err)
+		} else {
+			if !VerifyEcdsaSecp256K1(kp.PublicKey(), someDataToSign_EcdsaSecp256K1, sig) {
+				b.Error("verification failed")
+			}
+		}
+	}
+}

--- a/services/consensusalgo/benchmarkconsensus/test/harness.go
+++ b/services/consensusalgo/benchmarkconsensus/test/harness.go
@@ -14,13 +14,11 @@ import (
 	"github.com/orbs-network/orbs-network-go/services/consensusalgo/benchmarkconsensus"
 	testKeys "github.com/orbs-network/orbs-network-go/test/crypto/keys"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
-	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
 	"github.com/orbs-network/orbs-spec/types/go/services"
 	"github.com/orbs-network/orbs-spec/types/go/services/gossiptopics"
 	"github.com/orbs-network/orbs-spec/types/go/services/handlers"
 	"github.com/orbs-network/scribe/log"
 	"testing"
-	"time"
 )
 
 const NETWORK_SIZE = 5
@@ -61,19 +59,7 @@ func newHarness(tb testing.TB, isLeader bool) *harness {
 	}
 
 	//TODO(v1) don't use acceptance tests config! use a per-service config
-	cfg := config.ForAcceptanceTestNetwork(
-		genesisValidatorNodes,
-		leaderKeyPair().NodeAddress(),
-		consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS,
-		1,
-		100,
-		42,
-		10*time.Millisecond,
-	)
-
-	cfg.SetDuration(config.BENCHMARK_CONSENSUS_RETRY_INTERVAL, 5*time.Millisecond)
-	cfg.SetUint32(config.BENCHMARK_CONSENSUS_REQUIRED_QUORUM_PERCENTAGE, 66)
-
+	cfg := config.ForBenchmarkConsensusTests(nodeKeyPair, leaderKeyPair(), genesisValidatorNodes)
 	log := log.DefaultTestingLogger(tb)
 
 	gossip := &gossiptopics.MockBenchmarkConsensus{}
@@ -89,7 +75,7 @@ func newHarness(tb testing.TB, isLeader bool) *harness {
 		blockStorage:     blockStorage,
 		consensusContext: consensusContext,
 		reporting:        log,
-		config:           cfg.OverrideNodeSpecificValues(":8080", 0, nodeKeyPair.NodeAddress(), nodeKeyPair.PrivateKey(), ""),
+		config:           cfg,
 		service:          nil,
 		registry:         metric.NewRegistry(),
 	}

--- a/services/gossip/adapter/tcp/direct_transport.go
+++ b/services/gossip/adapter/tcp/direct_transport.go
@@ -89,7 +89,9 @@ func NewDirectTransport(ctx context.Context, config config.GossipTransportConfig
 
 	// client goroutines
 	for peerNodeAddress, peer := range t.config.GossipPeers() {
+		t.mutex.Lock()
 		t.connect(ctx, peerNodeAddress, peer)
+		t.mutex.Unlock()
 	}
 
 	return t

--- a/services/gossip/adapter/testkit/tamperers.go
+++ b/services/gossip/adapter/testkit/tamperers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
 	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"github.com/orbs-network/orbs-network-go/test/rand"
-	"runtime"
 	"sync"
 	"time"
 )
@@ -123,7 +122,6 @@ func (o *pausingTamperer) StopTampering(ctx context.Context) {
 	o.transport.removeOngoingTamperer(o)
 	for _, message := range o.messages {
 		o.transport.Send(ctx, message)
-		runtime.Gosched() // TODO(v1): this is required or else messages arrive in the opposite order after resume (supposedly fixed now when we moved to channels in transport)
 	}
 }
 

--- a/test/acceptance/ethereum_interop_test.go
+++ b/test/acceptance/ethereum_interop_test.go
@@ -66,7 +66,7 @@ func readStringFromEthereumReaderAt(ctx context.Context, network *NetworkHarness
 func deployOrbsContractCallingEthereum(parent context.Context, network *NetworkHarness) {
 	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
-	ethereumReaderCode := "foo" // TODO (v1) this junk argument is very confusing
+	ethereumReaderCode := "[placeholder for contract code which doesn't matter because native compiler is mocked]"
 	network.MockContract(&sdkContext.ContractInfo{
 		PublicMethods: ethereum_caller_mock.PUBLIC,
 		SystemMethods: ethereum_caller_mock.SYSTEM,


### PR DESCRIPTION
* Added benchmarks for ECDSA signing
* Unified `WaitUntilShutdown()` mechanism in Orbs Node main and Gamma main
* Added a mutex in TCP Transport construction to prevent concurrent map access issue (rare)
* Removed wrong usage of acceptance test config factory in non-acceptance tests
* Gamma e2e now tests `main()` 