### PR TITLE
enforce network type field in blocks file header

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -137,6 +137,7 @@ type FilesystemBlockPersistenceConfig interface {
 	BlockStorageFileSystemDataDir() string
 	BlockStorageFileSystemMaxBlockSizeInBytes() uint32
 	VirtualChainId() primitives.VirtualChainId
+	NetworkType() protocol.SignerNetworkType
 }
 
 type GossipTransportConfig interface {

--- a/services/blockstorage/adapter/filesystem/codec.go
+++ b/services/blockstorage/adapter/filesystem/codec.go
@@ -39,7 +39,7 @@ func newCodec(maxBlockSize uint32) *codec {
 type blocksFileHeader struct {
 	Magic       uint32
 	FileVersion uint32
-	NetworkId   uint32
+	NetworkType uint32
 	ChainId     uint32
 }
 
@@ -108,11 +108,11 @@ func (bh *blockHeader) read(r io.Reader) error {
 	return nil
 }
 
-func newBlocksFileHeader(networkId, vchainId uint32) *blocksFileHeader {
+func newBlocksFileHeader(networkType, vchainId uint32) *blocksFileHeader {
 	return &blocksFileHeader{
 		Magic:       orbsFormatMagic,
 		FileVersion: orbsFormatVersion,
-		NetworkId:   networkId,
+		NetworkType: networkType,
 		ChainId:     vchainId,
 	}
 }

--- a/services/blockstorage/adapter/filesystem/file_system_persistence.go
+++ b/services/blockstorage/adapter/filesystem/file_system_persistence.go
@@ -122,50 +122,54 @@ func validateFileHeader(file *os.File, conf config.FilesystemBlockPersistenceCon
 	if err != nil {
 		return 0, err
 	}
-	if info.Size() == 0 { // write header
-		header := newBlocksFileHeader(0, uint32(conf.VirtualChainId()))
-		logger.Info("creating new blocks file", log.String("path", blocksFileName(conf)))
-		err = header.write(file)
-		if err != nil {
-			return 0, errors.Wrapf(err, "error writing blocks file header")
+	if info.Size() == 0 { // empty file
+		if err := writeNewFileHeader(file, conf, logger); err != nil {
+			return 0, err
 		}
-		err = file.Sync()
-		if err != nil {
-			return 0, errors.Wrapf(err, "error writing blocks file header")
-		}
-	} else { // validate header
-
-		offset, err := file.Seek(0, io.SeekStart)
-		if err != nil {
-			return 0, errors.Wrapf(err, "error reading blocks file header")
-		}
-		if offset != 0 {
-			return 0, fmt.Errorf("error reading blocks file header")
-		}
-
-		header := newBlocksFileHeader(0, 0)
-		err = header.read(file)
-		if err != nil {
-			return 0, errors.Wrapf(err, "error reading blocks file header")
-		}
-
-		// TODO V1 TBD
-		//if header.networkId != conf.NetworkId() {
-		//	return 0, fmt.Errorf("blocks file network id mismatch. found netowrk id %d expected %d",header.networkId, conf.NetworkId())
-		//}
-
-		if header.ChainId != uint32(conf.VirtualChainId()) {
-			return 0, fmt.Errorf("blocks file virtual chain id mismatch. found vchain id %d expected %d", header.ChainId, conf.VirtualChainId())
-		}
-
 	}
 
-	offset, err := file.Seek(0, io.SeekCurrent)
+	offset, err := file.Seek(0, io.SeekStart)
+	if err != nil {
+		return 0, errors.Wrapf(err, "error reading blocks file header")
+	}
+	if offset != 0 {
+		return 0, fmt.Errorf("error reading blocks file header")
+	}
+
+	header := newBlocksFileHeader(0, 0)
+	err = header.read(file)
+	if err != nil {
+		return 0, errors.Wrapf(err, "error reading blocks file header")
+	}
+
+	if header.NetworkType != uint32(conf.NetworkType()) {
+		return 0, fmt.Errorf("blocks file network id mismatch. found netowrk id %d expected %d", header.NetworkType, conf.NetworkType())
+	}
+
+	if header.ChainId != uint32(conf.VirtualChainId()) {
+		return 0, fmt.Errorf("blocks file virtual chain id mismatch. found vchain id %d expected %d", header.ChainId, conf.VirtualChainId())
+	}
+
+	offset, err = file.Seek(0, io.SeekCurrent) // read current offset
 	if err != nil {
 		return 0, errors.Wrapf(err, "error reading blocks file header")
 	}
 
 	return offset, nil
+}
+
+func writeNewFileHeader(file *os.File, conf config.FilesystemBlockPersistenceConfig, logger log.Logger) error {
+	header := newBlocksFileHeader(uint32(conf.NetworkType()), uint32(conf.VirtualChainId()))
+	logger.Info("creating new blocks file", log.String("path", blocksFileName(conf)))
+	err := header.write(file)
+	if err != nil {
+		return errors.Wrapf(err, "error writing blocks file header")
+	}
+	err = file.Sync()
+	if err != nil {
+		return errors.Wrapf(err, "error writing blocks file header")
+	}
+	return nil
 }
 
 func closeOnContextDone(ctx context.Context, file *os.File, logger log.Logger) {

--- a/services/blockstorage/adapter/filesystem/file_system_persistence.go
+++ b/services/blockstorage/adapter/filesystem/file_system_persistence.go
@@ -143,7 +143,7 @@ func validateFileHeader(file *os.File, conf config.FilesystemBlockPersistenceCon
 	}
 
 	if header.NetworkType != uint32(conf.NetworkType()) {
-		return 0, fmt.Errorf("blocks file network id mismatch. found netowrk id %d expected %d", header.NetworkType, conf.NetworkType())
+		return 0, fmt.Errorf("blocks file network type mismatch. found netowrk type %d expected %d", header.NetworkType, conf.NetworkType())
 	}
 
 	if header.ChainId != uint32(conf.VirtualChainId()) {

--- a/services/blockstorage/adapter/test/detect_vchain_mismatch_test.go
+++ b/services/blockstorage/adapter/test/detect_vchain_mismatch_test.go
@@ -28,3 +28,19 @@ func TestPersistenceAdapter_DetectsVirtualChainMismatch(t *testing.T) {
 	_, _, err := NewFilesystemAdapterDriver(log.DefaultTestingLogger(t), conf)
 	require.Error(t, err, "expected error when trying to open a blocks file from a different virtual chain")
 }
+
+func TestPersistenceAdapter_DetectsNeworkTypeMismatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping Integration tests in short mode")
+	}
+
+	conf := newTempFileConfig()
+	defer conf.cleanDir()
+
+	writeRandomBlocksToFile(t, conf, 1, rand.NewControlledRand(t))
+
+	conf.setNetworkType(conf.networkType + 1)
+
+	_, _, err := NewFilesystemAdapterDriver(log.DefaultTestingLogger(t), conf)
+	require.Error(t, err, "expected error when trying to open a blocks file from a different network type")
+}

--- a/services/blockstorage/adapter/test/driver.go
+++ b/services/blockstorage/adapter/test/driver.go
@@ -48,8 +48,9 @@ func NewFilesystemAdapterDriver(logger log.Logger, conf config.FilesystemBlockPe
 }
 
 type localConfig struct {
-	dir     string
-	chainId primitives.VirtualChainId
+	dir         string
+	chainId     primitives.VirtualChainId
+	networkType protocol.SignerNetworkType
 }
 
 func newTempFileConfig() *localConfig {
@@ -58,8 +59,9 @@ func newTempFileConfig() *localConfig {
 		panic(err)
 	}
 	return &localConfig{
-		dir:     dirName,
-		chainId: 0xFF,
+		dir:         dirName,
+		chainId:     0xFF,
+		networkType: protocol.NETWORK_TYPE_TEST_NET,
 	}
 }
 func (l *localConfig) BlockStorageFileSystemDataDir() string {
@@ -74,12 +76,20 @@ func (l *localConfig) VirtualChainId() primitives.VirtualChainId {
 	return l.chainId
 }
 
+func (l *localConfig) NetworkType() protocol.SignerNetworkType {
+	return l.networkType
+}
+
 func (l *localConfig) cleanDir() {
 	_ = os.RemoveAll(l.BlockStorageFileSystemDataDir()) // ignore errors - nothing to do
 }
 
-func (l *localConfig) setVirtualChainId(id primitives.VirtualChainId) {
-	l.chainId = id
+func (l *localConfig) setVirtualChainId(value primitives.VirtualChainId) {
+	l.chainId = value
+}
+
+func (l *localConfig) setNetworkType(value protocol.SignerNetworkType) {
+	l.networkType = value
 }
 
 func getFileSize(t *testing.T, conf *localConfig) int64 {

--- a/services/blockstorage/adapter/test/main/create_adapter_and_sleep_main.go
+++ b/services/blockstorage/adapter/test/main/create_adapter_and_sleep_main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"github.com/orbs-network/orbs-network-go/services/blockstorage/adapter/test"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
+	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/scribe/log"
 	"os"
 	"time"
@@ -28,10 +29,15 @@ func main() {
 type localConfig struct {
 	dir            string
 	virtualChainId primitives.VirtualChainId
+	networkType    protocol.SignerNetworkType
 }
 
 func (l *localConfig) VirtualChainId() primitives.VirtualChainId {
 	return l.virtualChainId
+}
+
+func (l *localConfig) NetworkType() protocol.SignerNetworkType {
+	return l.networkType
 }
 
 func (l *localConfig) BlockStorageFileSystemDataDir() string {


### PR DESCRIPTION
## Description

Validate `NETWORK_TYPE` configuration value matches the value found in blocks file header, on filesystem block storage adapter init. Fail loading if values do not match.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/orbs-network/orbs-contributor-guide/blob/master/CONTRIBUTING.md) doc
- [ ] I have opened an issue and discussed the solution suggested in this PR
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Currently network type is not in use. production configurations use the reserved value 0.
