### PR TITLE
Tech Debt - Block Storage tests

### DIFF
--- a/services/blockstorage/adapter/memory/memory_persistence.go
+++ b/services/blockstorage/adapter/memory/memory_persistence.go
@@ -119,7 +119,7 @@ func (bp *InMemoryBlockPersistence) GetBlockByTx(txHash primitives.Sha256, minBl
 	var candidateBlocks []*protocol.BlockPairContainer
 	for _, blockPair := range allBlocks {
 		bts := blockPair.TransactionsBlock.Header.Timestamp()
-		if maxBlockTs > bts && minBlockTs < bts {
+		if maxBlockTs >= bts && minBlockTs <= bts {
 			candidateBlocks = append(candidateBlocks, blockPair)
 		}
 	}

--- a/services/blockstorage/adapter/test/driver.go
+++ b/services/blockstorage/adapter/test/driver.go
@@ -25,10 +25,6 @@ import (
 	"time"
 )
 
-// TODO V1 TBD - do we want to fuss with simulating io errors? (tampering FS)
-// TODO V1 can we detect errors that indicate we need to open a writing file handle?
-// TODO V1 file format includes a file version, vchain id, network id, and if it doesn't match don't run!
-
 const blocksFilename = "blocks"
 
 func NewFilesystemAdapterDriver(logger log.Logger, conf config.FilesystemBlockPersistenceConfig) (adapter.BlockPersistence, func(), error) {

--- a/services/blockstorage/block_queries.go
+++ b/services/blockstorage/block_queries.go
@@ -13,10 +13,7 @@ import (
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
 	"github.com/pkg/errors"
-	"time"
 )
-
-const MAX_TX_SEARCH_TIME_RANGE_NANO = time.Hour
 
 func (s *service) GetLastCommittedBlockHeight(ctx context.Context, input *services.GetLastCommittedBlockHeightInput) (*services.GetLastCommittedBlockHeightOutput, error) {
 	b, err := s.persistence.GetLastBlock()
@@ -80,14 +77,6 @@ func (s *service) GetTransactionReceipt(ctx context.Context, input *services.Get
 
 	start := input.TransactionTimestamp - primitives.TimestampNano(graceNano)
 	end := input.TransactionTimestamp + primitives.TimestampNano(graceNano+txExpireNano)
-
-	if end-start > primitives.TimestampNano(MAX_TX_SEARCH_TIME_RANGE_NANO) {
-		receipt, err := s.createEmptyTransactionReceiptResult(ctx)
-		if err != nil {
-			return nil, err
-		}
-		return receipt, errors.Errorf("unsupported time range for tx receipt query. requested tx (hash/ts): %s/%s. verify config values satisfy: (2*BLOCK_STORAGE_TRANSACTION_RECEIPT_QUERY_TIMESTAMP_GRACE+TRANSACTION_EXPIRATION_WINDOW) <= %d", input.Txhash, input.TransactionTimestamp, MAX_TX_SEARCH_TIME_RANGE_NANO)
-	}
 
 	blockPair, txIdx, err := s.persistence.GetBlockByTx(input.Txhash, start, end)
 	if err != nil {

--- a/services/blockstorage/test/block_sync_full_flow_test.go
+++ b/services/blockstorage/test/block_sync_full_flow_test.go
@@ -44,7 +44,7 @@ func TestSyncPetitioner_CompleteSyncFlow(t *testing.T) {
 			return nil, nil
 		})
 
-		harness.consensus.Reset().When("HandleBlockConsensus", mock.Any, mock.Any).Call(func(ctx context.Context, input *handlers.HandleBlockConsensusInput) (*handlers.HandleBlockConsensusOutput, error) {
+		harness.consensus.When("HandleBlockConsensus", mock.Any, mock.Any).Call(func(ctx context.Context, input *handlers.HandleBlockConsensusInput) (*handlers.HandleBlockConsensusOutput, error) {
 			resultsForVerification.logHandleBlockConsensusCalls(t, input, NUM_BLOCKS)
 			requireValidHandleBlockConsensusMode(t, input.Mode)
 			return nil, nil

--- a/services/blockstorage/test/block_sync_server_test.go
+++ b/services/blockstorage/test/block_sync_server_test.go
@@ -25,7 +25,7 @@ func TestSourceRespondToAvailabilityRequests(t *testing.T) {
 		harness := newBlockStorageHarness(t).
 			withNodeAddress(sourceAddress).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		harness.commitSomeBlocks(ctx, 3)
@@ -69,7 +69,7 @@ func TestSourceDoesNotRespondToAvailabilityRequestIfSourceIsBehindPetitioner(t *
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 		harness.commitBlock(ctx, builders.BlockPair().WithHeight(primitives.BlockHeight(1)).Build())
 
@@ -87,7 +87,7 @@ func TestSourceIgnoresSendBlockAvailabilityRequestsIfFailedToRespond(t *testing.
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 		harness.commitSomeBlocks(ctx, 3)
 
@@ -112,7 +112,7 @@ func TestSourceRespondsWithChunks(t *testing.T) {
 			withBatchSize(batchSize).
 			withNodeAddress(keys.EcdsaSecp256K1KeyPairForTests(4).NodeAddress()).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		lastBlock := 12
@@ -161,7 +161,7 @@ func TestSourceIgnoresBlockSyncRequestIfSourceIsBehind(t *testing.T) {
 
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 		harness.commitSomeBlocks(ctx, lastBlock)
 

--- a/services/blockstorage/test/block_sync_server_test.go
+++ b/services/blockstorage/test/block_sync_server_test.go
@@ -22,7 +22,12 @@ import (
 func TestSourceRespondToAvailabilityRequests(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		sourceAddress := keys.EcdsaSecp256K1KeyPairForTests(4).NodeAddress()
-		harness := newBlockStorageHarness(t).withNodeAddress(sourceAddress).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withNodeAddress(sourceAddress).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
+
 		harness.commitSomeBlocks(ctx, 3)
 		senderAddress := keys.EcdsaSecp256K1KeyPairForTests(1).NodeAddress()
 
@@ -62,7 +67,10 @@ func TestSourceRespondToAvailabilityRequests(t *testing.T) {
 
 func TestSourceDoesNotRespondToAvailabilityRequestIfSourceIsBehindPetitioner(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 		harness.commitBlock(ctx, builders.BlockPair().WithHeight(primitives.BlockHeight(1)).Build())
 
 		harness.gossip.Never("SendBlockAvailabilityResponse", mock.Any, mock.Any)
@@ -77,7 +85,10 @@ func TestSourceDoesNotRespondToAvailabilityRequestIfSourceIsBehindPetitioner(t *
 
 func TestSourceIgnoresSendBlockAvailabilityRequestsIfFailedToRespond(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 		harness.commitSomeBlocks(ctx, 3)
 
 		harness.gossip.When("SendBlockAvailabilityResponse", mock.Any, mock.Any).Return(nil, errors.New("gossip failure")).Times(1)
@@ -101,6 +112,7 @@ func TestSourceRespondsWithChunks(t *testing.T) {
 			withBatchSize(batchSize).
 			withNodeAddress(keys.EcdsaSecp256K1KeyPairForTests(4).NodeAddress()).
 			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
 			start(ctx)
 
 		lastBlock := 12
@@ -147,7 +159,10 @@ func TestSourceIgnoresBlockSyncRequestIfSourceIsBehind(t *testing.T) {
 			WithLastCommittedBlockHeight(lastHeight).
 			Build()
 
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 		harness.commitSomeBlocks(ctx, lastBlock)
 
 		harness.gossip.Never("SendBlockSyncResponse", mock.Any, mock.Any)

--- a/services/blockstorage/test/block_sync_stress_deadlock_test.go
+++ b/services/blockstorage/test/block_sync_stress_deadlock_test.go
@@ -32,7 +32,7 @@ func TestSyncPetitioner_Stress_SingleThreadedConsensusAlgoDoesNotDeadlock(t *tes
 		targetBlockHeight := primitives.BlockHeight(100)
 
 		var topReportedHeight primitives.BlockHeight
-		harness.consensus.Reset().When("HandleBlockConsensus", mock.Any, mock.Any).Call(func(ctx context.Context, input *handlers.HandleBlockConsensusInput) (*handlers.HandleBlockConsensusOutput, error) {
+		harness.consensus.When("HandleBlockConsensus", mock.Any, mock.Any).Call(func(ctx context.Context, input *handlers.HandleBlockConsensusInput) (*handlers.HandleBlockConsensusOutput, error) {
 			if input.BlockPair != nil {
 				updateConsensusAlgoHeight <- struct{}{}
 				topReportedHeight = input.BlockPair.ResultsBlock.Header.BlockHeight()

--- a/services/blockstorage/test/block_sync_stress_race_test.go
+++ b/services/blockstorage/test/block_sync_stress_race_test.go
@@ -44,7 +44,7 @@ func TestSyncPetitioner_Stress_CommitsDuringSync(t *testing.T) {
 			return nil, nil
 		})
 
-		harness.consensus.Reset().When("HandleBlockConsensus", mock.Any, mock.Any).Call(func(ctx context.Context, input *handlers.HandleBlockConsensusInput) (*handlers.HandleBlockConsensusOutput, error) {
+		harness.consensus.When("HandleBlockConsensus", mock.Any, mock.Any).Call(func(ctx context.Context, input *handlers.HandleBlockConsensusInput) (*handlers.HandleBlockConsensusOutput, error) {
 			if input.Mode == handlers.HANDLE_BLOCK_CONSENSUS_MODE_VERIFY_AND_UPDATE && input.PrevCommittedBlockPair != nil {
 				currHeight := input.BlockPair.TransactionsBlock.Header.BlockHeight()
 				prevHeight := input.PrevCommittedBlockPair.TransactionsBlock.Header.BlockHeight()

--- a/services/blockstorage/test/block_sync_test.go
+++ b/services/blockstorage/test/block_sync_test.go
@@ -24,7 +24,10 @@ import (
 // TODO(v1) move to unit tests
 func TestSyncSource_IgnoresRangesOfBlockSyncRequestAccordingToLocalBatchSettings(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 
 		blocks := []*protocol.BlockPairContainer{
 			builders.BlockPair().WithHeight(primitives.BlockHeight(1)).WithBlockCreated(time.Now()).Build(),
@@ -74,7 +77,10 @@ func TestSyncSource_IgnoresRangesOfBlockSyncRequestAccordingToLocalBatchSettings
 
 func TestSyncPetitioner_BroadcastsBlockAvailabilityRequest(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncNoCommitTimeout(3 * time.Millisecond)
+		harness := newBlockStorageHarness(t).
+			withSyncNoCommitTimeout(3 * time.Millisecond).
+			withValidateConsensusAlgosAtLeast(0)
+
 		harness.gossip.When("BroadcastBlockAvailabilityRequest", mock.Any, mock.Any).Return(nil, nil).AtLeast(2)
 
 		harness.start(ctx)

--- a/services/blockstorage/test/block_sync_test.go
+++ b/services/blockstorage/test/block_sync_test.go
@@ -26,7 +26,7 @@ func TestSyncSource_IgnoresRangesOfBlockSyncRequestAccordingToLocalBatchSettings
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		blocks := []*protocol.BlockPairContainer{
@@ -79,7 +79,7 @@ func TestSyncPetitioner_BroadcastsBlockAvailabilityRequest(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncNoCommitTimeout(3 * time.Millisecond).
-			withValidateConsensusAlgosAtLeast(0)
+			expectValidateConsensusAlgos()
 
 		harness.gossip.When("BroadcastBlockAvailabilityRequest", mock.Any, mock.Any).Return(nil, nil).AtLeast(2)
 

--- a/services/blockstorage/test/commit_block_test.go
+++ b/services/blockstorage/test/commit_block_test.go
@@ -18,7 +18,10 @@ import (
 
 func TestCommitBlockSavesToPersistentStorage(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 
 		blockCreated := time.Now()
 		blockHeight := primitives.BlockHeight(1)
@@ -41,7 +44,10 @@ func TestCommitBlockSavesToPersistentStorage(t *testing.T) {
 
 func TestCommitBlockDoesNotUpdateCommittedBlockHeightAndTimestampIfStorageFails(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 
 		blockCreated := time.Now()
 		blockHeight := primitives.BlockHeight(1)
@@ -66,7 +72,11 @@ func TestCommitBlockDoesNotUpdateCommittedBlockHeightAndTimestampIfStorageFails(
 
 func TestCommitBlockReturnsErrorWhenProtocolVersionMismatches(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).allowingErrorsMatching("protocol version mismatch in transactions block header").start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			allowingErrorsMatching("protocol version mismatch in transactions block header").
+			start(ctx)
 
 		_, err := harness.commitBlock(ctx, builders.BlockPair().WithProtocolVersion(99999).Build())
 
@@ -76,7 +86,10 @@ func TestCommitBlockReturnsErrorWhenProtocolVersionMismatches(t *testing.T) {
 
 func TestCommitBlockDiscardsBlockIfAlreadyExists(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 		blockPair := builders.BlockPair().Build()
 
 		harness.commitBlock(ctx, blockPair)
@@ -91,7 +104,11 @@ func TestCommitBlockDiscardsBlockIfAlreadyExists(t *testing.T) {
 
 func TestCommitBlockReturnsErrorIfBlockExistsButHasDifferentTimestamp(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).allowingErrorsMatching("FORK!! block already in storage, timestamp mismatch").withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			allowingErrorsMatching("FORK!! block already in storage, timestamp mismatch").
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 
 		blockPair := builders.BlockPair()
 		harness.commitBlock(ctx, blockPair.Build())
@@ -107,7 +124,11 @@ func TestCommitBlockReturnsErrorIfBlockExistsButHasDifferentTimestamp(t *testing
 
 func TestCommitBlockReturnsErrorIfBlockExistsButHasDifferentTxBlock(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).allowingErrorsMatching("FORK!! block already in storage, transaction block header mismatch").withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			allowingErrorsMatching("FORK!! block already in storage, transaction block header mismatch").
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 
 		blockPair := builders.BlockPair()
 		harness.commitBlock(ctx, blockPair.Build())
@@ -125,7 +146,11 @@ func TestCommitBlockReturnsErrorIfBlockExistsButHasDifferentTxBlock(t *testing.T
 
 func TestCommitBlockReturnsErrorIfBlockExistsButHasDifferentRxBlock(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).allowingErrorsMatching("FORK!! block already in storage, results block header mismatch").withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			allowingErrorsMatching("FORK!! block already in storage, results block header mismatch").
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 
 		blockPair := builders.BlockPair()
 		harness.commitBlock(ctx, blockPair.Build())
@@ -143,7 +168,10 @@ func TestCommitBlockReturnsErrorIfBlockExistsButHasDifferentRxBlock(t *testing.T
 
 func TestCommitBlockReturnsErrorIfBlockIsNotSequential(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 
 		harness.commitBlock(ctx, builders.BlockPair().Build())
 

--- a/services/blockstorage/test/commit_block_test.go
+++ b/services/blockstorage/test/commit_block_test.go
@@ -20,7 +20,7 @@ func TestCommitBlockSavesToPersistentStorage(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		blockCreated := time.Now()
@@ -46,7 +46,7 @@ func TestCommitBlockDoesNotUpdateCommittedBlockHeightAndTimestampIfStorageFails(
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		blockCreated := time.Now()
@@ -74,7 +74,7 @@ func TestCommitBlockReturnsErrorWhenProtocolVersionMismatches(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			allowingErrorsMatching("protocol version mismatch in transactions block header").
 			start(ctx)
 
@@ -88,7 +88,7 @@ func TestCommitBlockDiscardsBlockIfAlreadyExists(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 		blockPair := builders.BlockPair().Build()
 
@@ -107,7 +107,7 @@ func TestCommitBlockReturnsErrorIfBlockExistsButHasDifferentTimestamp(t *testing
 		harness := newBlockStorageHarness(t).
 			allowingErrorsMatching("FORK!! block already in storage, timestamp mismatch").
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		blockPair := builders.BlockPair()
@@ -127,7 +127,7 @@ func TestCommitBlockReturnsErrorIfBlockExistsButHasDifferentTxBlock(t *testing.T
 		harness := newBlockStorageHarness(t).
 			allowingErrorsMatching("FORK!! block already in storage, transaction block header mismatch").
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		blockPair := builders.BlockPair()
@@ -149,7 +149,7 @@ func TestCommitBlockReturnsErrorIfBlockExistsButHasDifferentRxBlock(t *testing.T
 		harness := newBlockStorageHarness(t).
 			allowingErrorsMatching("FORK!! block already in storage, results block header mismatch").
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		blockPair := builders.BlockPair()
@@ -170,7 +170,7 @@ func TestCommitBlockReturnsErrorIfBlockIsNotSequential(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		harness.commitBlock(ctx, builders.BlockPair().Build())

--- a/services/blockstorage/test/generate_proofs_test.go
+++ b/services/blockstorage/test/generate_proofs_test.go
@@ -25,7 +25,7 @@ func TestGenerateProof(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		blockCreated := time.Now()
@@ -60,7 +60,7 @@ func TestGenerateProof_WrongTxHash(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		blockCreated := time.Now()

--- a/services/blockstorage/test/generate_proofs_test.go
+++ b/services/blockstorage/test/generate_proofs_test.go
@@ -23,7 +23,10 @@ import (
 
 func TestGenerateProof(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 
 		blockCreated := time.Now()
 		blockHeight := primitives.BlockHeight(1)
@@ -55,7 +58,10 @@ func TestGenerateProof(t *testing.T) {
 
 func TestGenerateProof_WrongTxHash(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 
 		blockCreated := time.Now()
 		blockHeight := primitives.BlockHeight(1)

--- a/services/blockstorage/test/harness.go
+++ b/services/blockstorage/test/harness.go
@@ -200,7 +200,7 @@ func (d *harness) failNextBlocks() {
 
 func (d *harness) commitSomeBlocks(ctx context.Context, count int) {
 	for i := 1; i <= count; i++ {
-		d.commitBlock(ctx, builders.BlockPair().WithHeight(primitives.BlockHeight(i)).Build())
+		_, _ = d.commitBlock(ctx, builders.BlockPair().WithHeight(primitives.BlockHeight(i)).Build())
 	}
 }
 
@@ -208,7 +208,7 @@ func (d *harness) setupCustomBlocksForInit() time.Time {
 	now := time.Now()
 	for i := 1; i <= 10; i++ {
 		now = now.Add(1 * time.Millisecond)
-		d.storageAdapter.WriteNextBlock(builders.BlockPair().WithHeight(primitives.BlockHeight(i)).WithBlockCreated(now).Build())
+		_, _ = d.storageAdapter.WriteNextBlock(builders.BlockPair().WithHeight(primitives.BlockHeight(i)).WithBlockCreated(now).Build())
 	}
 
 	return now

--- a/services/blockstorage/test/harness.go
+++ b/services/blockstorage/test/harness.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/orbs-network/go-mock"
-	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	"github.com/orbs-network/orbs-network-go/services/blockstorage"
 	"github.com/orbs-network/orbs-network-go/services/blockstorage/adapter/testkit"
@@ -34,8 +33,7 @@ type configForBlockStorageTests struct {
 	syncNoCommit          time.Duration
 	syncCollectResponses  time.Duration
 	syncCollectChunks     time.Duration
-	queryGraceStart       time.Duration
-	queryGraceEnd         time.Duration
+	queryGrace            time.Duration
 	queryExpirationWindow time.Duration
 	blockTrackerGrace     time.Duration
 }
@@ -61,7 +59,7 @@ func (c *configForBlockStorageTests) BlockSyncCollectChunksTimeout() time.Durati
 }
 
 func (c *configForBlockStorageTests) BlockStorageTransactionReceiptQueryTimestampGrace() time.Duration {
-	return c.queryGraceStart
+	return c.queryGrace
 }
 
 func (c *configForBlockStorageTests) TransactionExpirationWindow() time.Duration {
@@ -79,7 +77,7 @@ type harness struct {
 	consensus      *handlers.MockConsensusBlocksHandler
 	gossip         *gossiptopics.MockBlockSync
 	txPool         *services.MockTransactionPool
-	config         config.BlockStorageConfig
+	config         *configForBlockStorageTests
 	logger         log.Logger
 	logOutput      *log.TestOutput
 }
@@ -102,6 +100,13 @@ func (d *harness) withValidateConsensusAlgos(times int) *harness {
 	out := &handlers.HandleBlockConsensusOutput{}
 
 	d.consensus.When("HandleBlockConsensus", mock.Any, mock.Any).Return(out, nil).Times(times)
+	return d
+}
+
+func (d *harness) withValidateConsensusAlgosAtLeast(times int) *harness {
+	out := &handlers.HandleBlockConsensusOutput{}
+
+	d.consensus.When("HandleBlockConsensus", mock.Any, mock.Any).Return(out, nil).AtLeast(times)
 	return d
 }
 
@@ -155,27 +160,37 @@ func (d *harness) getBlock(height int) *protocol.BlockPairContainer {
 }
 
 func (d *harness) withSyncNoCommitTimeout(duration time.Duration) *harness {
-	d.config.(*configForBlockStorageTests).syncNoCommit = duration
+	d.config.syncNoCommit = duration
 	return d
 }
 
 func (d *harness) withSyncCollectResponsesTimeout(duration time.Duration) *harness {
-	d.config.(*configForBlockStorageTests).syncCollectResponses = duration
+	d.config.syncCollectResponses = duration
 	return d
 }
 
 func (d *harness) withSyncCollectChunksTimeout(duration time.Duration) *harness {
-	d.config.(*configForBlockStorageTests).syncCollectChunks = duration
+	d.config.syncCollectChunks = duration
 	return d
 }
 
 func (d *harness) withBatchSize(size uint32) *harness {
-	d.config.(*configForBlockStorageTests).syncBatchSize = size
+	d.config.syncBatchSize = size
+	return d
+}
+
+func (d *harness) withBlockStorageTransactionReceiptQueryTimestampGrace(value time.Duration) *harness {
+	d.config.queryGrace = value
+	return d
+}
+
+func (d *harness) withTransactionExpirationWindow(value time.Duration) *harness {
+	d.config.queryExpirationWindow = value
 	return d
 }
 
 func (d *harness) withNodeAddress(address primitives.NodeAddress) *harness {
-	d.config.(*configForBlockStorageTests).nodeAddress = address
+	d.config.nodeAddress = address
 	return d
 }
 
@@ -196,14 +211,10 @@ func (d *harness) setupCustomBlocksForInit() time.Time {
 		d.storageAdapter.WriteNextBlock(builders.BlockPair().WithHeight(primitives.BlockHeight(i)).WithBlockCreated(now).Build())
 	}
 
-	out := &handlers.HandleBlockConsensusOutput{}
-
-	d.consensus.When("HandleBlockConsensus", mock.Any, mock.Any).Return(out, nil).Times(1)
-
 	return now
 }
 
-func createConfig(nodeAddress primitives.NodeAddress) config.BlockStorageConfig {
+func createConfig(nodeAddress primitives.NodeAddress) *configForBlockStorageTests {
 	cfg := &configForBlockStorageTests{}
 	cfg.nodeAddress = nodeAddress
 	cfg.syncBatchSize = 2
@@ -211,8 +222,7 @@ func createConfig(nodeAddress primitives.NodeAddress) config.BlockStorageConfig 
 	cfg.syncCollectResponses = 5 * time.Millisecond
 	cfg.syncCollectChunks = 20 * time.Millisecond
 
-	cfg.queryGraceStart = 5 * time.Second
-	cfg.queryGraceEnd = 5 * time.Second
+	cfg.queryGrace = 5 * time.Second
 	cfg.queryExpirationWindow = 30 * time.Minute
 	cfg.blockTrackerGrace = 1 * time.Hour
 
@@ -232,16 +242,10 @@ func newBlockStorageHarness(tb testing.TB) *harness {
 
 	d.consensus = &handlers.MockConsensusBlocksHandler{}
 
-	// TODO(v1): this might create issues with some tests later on, should move it to behavior or some other means of setup
-	// Always expect at least 0 because sometimes it gets triggered because of the timings
-	// HandleBlockConsensus always gets called when we try to start the sync which happens automatically
-	d.consensus.When("HandleBlockConsensus", mock.Any, mock.Any).Return(nil, nil).AtLeast(0)
-
 	d.gossip = &gossiptopics.MockBlockSync{}
 	d.gossip.When("RegisterBlockSyncHandler", mock.Any).Return().Times(1)
 
 	d.txPool = &services.MockTransactionPool{}
-	// TODO(v1): this might create issues with some tests later on, should move it to behavior or some other means of setup
 	d.txPool.When("CommitTransactionReceipts", mock.Any, mock.Any).Call(func(ctx context.Context, input *services.CommitTransactionReceiptsInput) (*services.CommitTransactionReceiptsOutput, error) {
 		return &services.CommitTransactionReceiptsOutput{
 			NextDesiredBlockHeight: input.ResultsBlockHeader.BlockHeight() + 1,

--- a/services/blockstorage/test/harness.go
+++ b/services/blockstorage/test/harness.go
@@ -103,10 +103,10 @@ func (d *harness) withValidateConsensusAlgos(times int) *harness {
 	return d
 }
 
-func (d *harness) withValidateConsensusAlgosAtLeast(times int) *harness {
+func (d *harness) expectValidateConsensusAlgos() *harness {
 	out := &handlers.HandleBlockConsensusOutput{}
 
-	d.consensus.When("HandleBlockConsensus", mock.Any, mock.Any).Return(out, nil).AtLeast(times)
+	d.consensus.When("HandleBlockConsensus", mock.Any, mock.Any).Return(out, nil).AtLeast(0)
 	return d
 }
 

--- a/services/blockstorage/test/init_test.go
+++ b/services/blockstorage/test/init_test.go
@@ -18,7 +18,7 @@ func TestInitSetsLastCommittedBlockHeightToZero(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 
 		val, err := harness.blockStorage.GetLastCommittedBlockHeight(ctx, &services.GetLastCommittedBlockHeightInput{})
@@ -33,7 +33,7 @@ func TestInitSetsLastCommittedBlockHeightToZero(t *testing.T) {
 
 func TestInitSetsLastCommittedBlockHeightFromPersistence(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).withValidateConsensusAlgosAtLeast(0)
+		harness := newBlockStorageHarness(t).withSyncBroadcast(1).expectValidateConsensusAlgos()
 		now := harness.setupCustomBlocksForInit()
 		harness = harness.start(ctx)
 

--- a/services/blockstorage/test/init_test.go
+++ b/services/blockstorage/test/init_test.go
@@ -16,7 +16,10 @@ import (
 
 func TestInitSetsLastCommittedBlockHeightToZero(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 
 		val, err := harness.blockStorage.GetLastCommittedBlockHeight(ctx, &services.GetLastCommittedBlockHeightInput{})
 		require.NoError(t, err)
@@ -30,7 +33,7 @@ func TestInitSetsLastCommittedBlockHeightToZero(t *testing.T) {
 
 func TestInitSetsLastCommittedBlockHeightFromPersistence(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).withSyncBroadcast(1)
+		harness := newBlockStorageHarness(t).withSyncBroadcast(1).withValidateConsensusAlgosAtLeast(0)
 		now := harness.setupCustomBlocksForInit()
 		harness = harness.start(ctx)
 

--- a/services/blockstorage/test/transaction_receipt_test.go
+++ b/services/blockstorage/test/transaction_receipt_test.go
@@ -9,9 +9,11 @@ package test
 import (
 	"context"
 	"github.com/orbs-network/orbs-network-go/crypto/digest"
+	"github.com/orbs-network/orbs-network-go/services/blockstorage"
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-network-go/test/builders"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
+	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -41,7 +43,41 @@ func TestReturnTransactionReceiptIfTransactionNotFound(t *testing.T) {
 	})
 }
 
-// TODO(v1) return transaction receipt while the transaction timestamp is in the future (and too far ahead to be in the grace
+func TestGetTransactionReceipt_ProtectedAgainstMisconfiguration(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		harness := newBlockStorageHarness(t).
+			withSyncBroadcast(1).
+			withCommitStateDiff(1).
+			withValidateConsensusAlgos(1).
+			start(ctx)
+
+		// block closed with ts in the expiration window
+		block := builders.BlockPair().WithHeight(3).WithTransactions(10).WithReceiptsForTransactions().Build()
+		tx := block.TransactionsBlock.SignedTransactions[0].Transaction()
+		harness.commitBlock(ctx, block)
+
+		_, err := harness.blockStorage.GetTransactionReceipt(ctx, &services.GetTransactionReceiptInput{
+			Txhash:               digest.CalcTxHash(tx),
+			TransactionTimestamp: tx.Timestamp(),
+		})
+
+		require.NoError(t, err, "expected no error when config is not over the supported limit")
+
+		// override config values
+		harness.withBlockStorageTransactionReceiptQueryTimestampGrace(16 * time.Minute)
+		txQueryGrace := harness.config.BlockStorageTransactionReceiptQueryTimestampGrace()
+		txExpirationWnd := harness.config.TransactionExpirationWindow()
+
+		require.True(t, 2*txQueryGrace+txExpirationWnd > blockstorage.MAX_TX_SEARCH_TIME_RANGE_NANO, "Please select a value which satisfies: 2*grace+expiration >> MAX_TX_SEARCH_TIME_RANGE_NANO")
+
+		_, err = harness.blockStorage.GetTransactionReceipt(ctx, &services.GetTransactionReceiptInput{
+			Txhash:               digest.CalcTxHash(tx),
+			TransactionTimestamp: tx.Timestamp(),
+		})
+
+		require.Error(t, err, "expected error to be returned if config is over the supported limit")
+	})
+}
 
 func TestReturnTransactionReceipt(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
@@ -51,31 +87,66 @@ func TestReturnTransactionReceipt(t *testing.T) {
 			withValidateConsensusAlgos(1).
 			start(ctx)
 
-		block := builders.BlockPair().WithHeight(1).WithTransactions(10).WithReceiptsForTransactions().WithTimestampNow().Build()
-		harness.commitBlock(ctx, block)
+		txQueryGrace := harness.config.BlockStorageTransactionReceiptQueryTimestampGrace()
+		txExpirationWnd := harness.config.TransactionExpirationWindow()
 
-		// it will be similar data transactions, but with different time stamps (and hashes..)
-		block2 := builders.BlockPair().WithHeight(2).WithTransactions(10).WithReceiptsForTransactions().WithTimestampNow().Build()
+		// block1: txs with current time but block timestamps in the past before grace
+		block1 := builders.BlockPair().WithHeight(1).WithTransactions(10).WithReceiptsForTransactions().WithTimestampAheadBy(-1 * (txQueryGrace + time.Second)).Build()
+		harness.commitBlock(ctx, block1)
+
+		require.True(t, block1.TransactionsBlock.SignedTransactions[3].Transaction().Timestamp() > block1.TransactionsBlock.Header.Timestamp()+primitives.TimestampNano(txQueryGrace.Nanoseconds()), "expected block to be in the past")
+
+		// block closed with ts in the past within grace
+		block2 := builders.BlockPair().WithHeight(2).WithTransactions(10).WithReceiptsForTransactions().WithTimestampAheadBy(txQueryGrace / -2).Build()
 		harness.commitBlock(ctx, block2)
 
-		// taking a transaction at 'random' (they were created at random)
-		tx := block.TransactionsBlock.SignedTransactions[3].Transaction()
-		txHash := digest.CalcTxHash(tx)
+		// block closed with ts in the expiration window
+		block3 := builders.BlockPair().WithHeight(3).WithTransactions(10).WithReceiptsForTransactions().WithTimestampAheadBy(txExpirationWnd / 2).Build()
+		harness.commitBlock(ctx, block3)
 
-		// the block timestamp is just a couple of nanos ahead of the transactions, which is inside the grace
-		out, err := harness.blockStorage.GetTransactionReceipt(ctx, &services.GetTransactionReceiptInput{
-			Txhash:               txHash,
-			TransactionTimestamp: tx.Timestamp(),
-		})
+		// block closed with ts past the expiration window but within grace
+		block4 := builders.BlockPair().WithHeight(4).WithTransactions(10).WithReceiptsForTransactions().WithTimestampAheadBy(txExpirationWnd + txQueryGrace/2).Build()
+		harness.commitBlock(ctx, block4)
 
-		require.NoError(t, err, "receipt should be found in this flow")
-		require.NotNil(t, out.TransactionReceipt, "receipt should be found in this flow")
-		require.EqualValues(t, txHash, out.TransactionReceipt.Txhash(), "receipt should have the tx hash we looked for")
-		require.EqualValues(t, 1, out.BlockHeight, "receipt should have the block height of the block containing the transaction")
-		require.EqualValues(t, block.ResultsBlock.Header.Timestamp(), out.BlockTimestamp, "receipt should have the timestamp of the block containing the transaction")
+		// block closed with ts past both the expiration window and grace period
+		block5 := builders.BlockPair().WithHeight(5).WithTransactions(10).WithReceiptsForTransactions().WithTimestampAheadBy(txExpirationWnd + txQueryGrace + 1).Build()
+		harness.commitBlock(ctx, block5)
+
+		requireTransactionFoundInBlock(ctx, t, harness, block2)
+		requireTransactionFoundInBlock(ctx, t, harness, block3)
+		requireTransactionFoundInBlock(ctx, t, harness, block4)
+
+		requireTransactionNotFoundInBlock(ctx, t, harness, block1, block5)
+		requireTransactionNotFoundInBlock(ctx, t, harness, block5, block5)
 	})
 }
 
-// TODO(v1) return transaction receipt while the transaction timestamp is outside the grace (regular)
-// TODO(v1) return transaction receipt while the transaction timestamp is at the expire window
-// TODO(v1) return transaction receipt while the transaction timestamp is at the expire window and within the grace
+func requireTransactionFoundInBlock(ctx context.Context, t *testing.T, harness *harness, block *protocol.BlockPairContainer) {
+	txHash, out, err := searchForTx(block.TransactionsBlock.SignedTransactions[3].Transaction(), harness, ctx)
+
+	require.NoError(t, err, "receipt should be found in this flow")
+	require.NotNil(t, out.TransactionReceipt, "receipt should be found in this flow")
+	require.EqualValues(t, txHash, out.TransactionReceipt.Txhash(), "receipt should have the tx hash we looked for")
+	require.EqualValues(t, block.ResultsBlock.Header.BlockHeight(), out.BlockHeight, "receipt should have the block height of the block containing the transaction")
+	require.EqualValues(t, block.ResultsBlock.Header.Timestamp(), out.BlockTimestamp, "receipt should have the timestamp of the block containing the transaction")
+}
+
+func requireTransactionNotFoundInBlock(ctx context.Context, t *testing.T, harness *harness, block *protocol.BlockPairContainer, lastCommittedBlock *protocol.BlockPairContainer) {
+	_, out, err := searchForTx(block.TransactionsBlock.SignedTransactions[3].Transaction(), harness, ctx)
+
+	require.NoError(t, err, "receipt should be found in this flow")
+	require.Nil(t, out.TransactionReceipt, "receipt should not be found in this flow")
+	require.EqualValues(t, lastCommittedBlock.ResultsBlock.Header.BlockHeight(), out.BlockHeight, "result should have the currently top committed block height")
+	require.EqualValues(t, lastCommittedBlock.ResultsBlock.Header.Timestamp(), out.BlockTimestamp, "result should have the timestamp of the currently top committed block")
+}
+
+func searchForTx(tx *protocol.Transaction, harness *harness, ctx context.Context) (primitives.Sha256, *services.GetTransactionReceiptOutput, error) {
+	// taking a transaction at 'random' (they were created at random)
+	txHash := digest.CalcTxHash(tx)
+	// the block timestamp is just a couple of nanos ahead of the transactions, which is inside the grace
+	out, err := harness.blockStorage.GetTransactionReceipt(ctx, &services.GetTransactionReceiptInput{
+		Txhash:               txHash,
+		TransactionTimestamp: tx.Timestamp(),
+	})
+	return txHash, out, err
+}

--- a/services/blockstorage/test/validation_test.go
+++ b/services/blockstorage/test/validation_test.go
@@ -30,7 +30,11 @@ func TestValidateBlockWithValidProtocolVersion(t *testing.T) {
 
 func TestValidateBlockWithInvalidProtocolVersion(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		harness := newBlockStorageHarness(t).allowingErrorsMatching("protocol version mismatch in.*").withSyncBroadcast(1).start(ctx)
+		harness := newBlockStorageHarness(t).
+			allowingErrorsMatching("protocol version mismatch in.*").
+			withSyncBroadcast(1).
+			withValidateConsensusAlgosAtLeast(0).
+			start(ctx)
 		block := builders.BlockPair().Build()
 
 		block.TransactionsBlock.Header.MutateProtocolVersion(998)

--- a/services/blockstorage/test/validation_test.go
+++ b/services/blockstorage/test/validation_test.go
@@ -107,10 +107,3 @@ func TestValidateBlockWithInvalidHeight(t *testing.T) {
 		require.EqualError(t, err, "block height is 999, expected 2", "only rx block height was mutate, expected an error")
 	})
 }
-
-//TODO(v1) validate virtual chain
-//TODO(v1) validate transactions root hash
-//TODO(v1) validate metadata hash
-//TODO(v1) validate receipts root hash
-//TODO(v1) validate state diff hash
-//TODO(v1) validate block consensus

--- a/services/blockstorage/test/validation_test.go
+++ b/services/blockstorage/test/validation_test.go
@@ -33,7 +33,7 @@ func TestValidateBlockWithInvalidProtocolVersion(t *testing.T) {
 		harness := newBlockStorageHarness(t).
 			allowingErrorsMatching("protocol version mismatch in.*").
 			withSyncBroadcast(1).
-			withValidateConsensusAlgosAtLeast(0).
+			expectValidateConsensusAlgos().
 			start(ctx)
 		block := builders.BlockPair().Build()
 

--- a/test/builders/blocks.go
+++ b/test/builders/blocks.go
@@ -211,6 +211,13 @@ func (b *blockPair) WithTimestampNow() *blockPair {
 	return b
 }
 
+func (b *blockPair) WithTimestampAheadBy(duration time.Duration) *blockPair {
+	timeToUse := primitives.TimestampNano(time.Now().UnixNano() + duration.Nanoseconds())
+	b.txHeader.Timestamp = timeToUse
+	b.rxHeader.Timestamp = timeToUse
+	return b
+}
+
 func (b *blockPair) WithReceiptProofHash(hash primitives.Sha256) *blockPair {
 	b.rxProof = &protocol.ResultsBlockProofBuilder{
 		TransactionsBlockHash: hash,


### PR DESCRIPTION
## Description

Addressing several `//TODO`s in block storage:
1. Structural block validations were moved to `ConsensusContext` service so no need for tests for these validations in BlockStorage
1. Removed redundant sanity checks in `GetBlockByTx`
1. Added contract tests for `GetTransactionReceipt`
1. Expanded component test for `GetTransactionReceipt`
1. Removed the need for confusing `.Reset()` calls on Block Storage test harness mock objects in several tests
1. Reinstated `TestBlockPersistenceContract_WriteOutOfOrderPast_FailsWhenBlockDifferent` as `TestBlockPersistenceContract_WriteOutOfOrder_PastBlocksIgnored`
1. Removed stale `//TODO`s

