### PR TITLE
resolve issue 524

### DIFF
--- a/services/blockstorage/adapter/filesystem/file_system_persistence.go
+++ b/services/blockstorage/adapter/filesystem/file_system_persistence.go
@@ -220,7 +220,7 @@ func buildIndex(r io.Reader, firstBlockOffset int64, logger log.Logger, c blockC
 	return bhIndex, nil
 }
 
-func (f *FilesystemBlockPersistence) WriteNextBlock(blockPair *protocol.BlockPairContainer) (bool, error) {
+func (f *FilesystemBlockPersistence) WriteNextBlock(blockPair *protocol.BlockPairContainer) (bool, primitives.BlockHeight, error) {
 	f.blockWriter.Lock()
 	defer f.blockWriter.Unlock()
 
@@ -228,27 +228,24 @@ func (f *FilesystemBlockPersistence) WriteNextBlock(blockPair *protocol.BlockPai
 
 	currentTop := f.bhIndex.getLastBlockHeight()
 	if bh != currentTop+1 {
-		if bh <= currentTop {
-			return false, nil
-		}
-		return false, fmt.Errorf("attempt to write block %d out of order. current top height is %d", bh, currentTop)
+		return false, currentTop, nil
 	}
 
 	n, err := f.blockWriter.writeBlock(blockPair)
 	if err != nil {
-		return false, err
+		return false, currentTop, err
 	}
 
 	startPos := f.bhIndex.fetchBlockOffset(bh)
 	err = f.bhIndex.appendBlock(startPos, startPos+int64(n), blockPair)
 	if err != nil {
-		return false, errors.Wrap(err, "failed to update index after writing block")
+		return false, currentTop, errors.Wrap(err, "failed to update index after writing block")
 	}
 
-	f.blockTracker.IncrementTo(currentTop + 1)
+	f.blockTracker.IncrementTo(bh)
 	f.metrics.size.Add(int64(n))
 
-	return true, nil
+	return true, bh, nil
 }
 
 func (f *FilesystemBlockPersistence) ScanBlocks(from primitives.BlockHeight, pageSize uint8, cursor adapter.CursorFunc) error {

--- a/services/blockstorage/adapter/memory/memory_persistence.go
+++ b/services/blockstorage/adapter/memory/memory_persistence.go
@@ -8,7 +8,6 @@ package memory
 
 import (
 	"fmt"
-	"github.com/orbs-network/orbs-network-go/instrumentation/logfields"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	"github.com/orbs-network/orbs-network-go/services/blockstorage/adapter"
 	"github.com/orbs-network/orbs-network-go/synchronization"
@@ -76,38 +75,31 @@ func (bp *InMemoryBlockPersistence) GetLastBlockHeight() (primitives.BlockHeight
 	return primitives.BlockHeight(len(bp.blockChain.blocks)), nil
 }
 
-func (bp *InMemoryBlockPersistence) WriteNextBlock(blockPair *protocol.BlockPairContainer) (bool, error) {
+func (bp *InMemoryBlockPersistence) WriteNextBlock(blockPair *protocol.BlockPairContainer) (bool, primitives.BlockHeight, error) {
 
-	added, err := bp.validateAndAddNextBlock(blockPair)
+	added, pHeight, err := bp.validateAndAddNextBlock(blockPair)
 	if err != nil || !added {
-		return added, err
+		return added, pHeight, err
 	}
 
 	bp.metrics.size.Add(sizeOfBlock(blockPair))
 
-	return added, nil
+	return added, pHeight, nil
 }
 
-func (bp *InMemoryBlockPersistence) validateAndAddNextBlock(blockPair *protocol.BlockPairContainer) (bool, error) {
+func (bp *InMemoryBlockPersistence) validateAndAddNextBlock(blockPair *protocol.BlockPairContainer) (bool, primitives.BlockHeight, error) {
 	bp.blockChain.Lock()
 	defer bp.blockChain.Unlock()
 
-	if !(blockPair.ResultsBlock.BlockProof.IsTypeBenchmarkConsensus() || blockPair.ResultsBlock.BlockProof.IsTypeLeanHelix()) {
-		return false, errors.Errorf("block persistence tried to write block with invalid proof type: %s", blockPair.ResultsBlock.BlockProof)
+	currentTop := primitives.BlockHeight(len(bp.blockChain.blocks))
+
+	if primitives.BlockHeight(len(bp.blockChain.blocks))+1 != blockPair.TransactionsBlock.Header.BlockHeight() {
+		return false, currentTop, nil
 	}
 
-	if primitives.BlockHeight(len(bp.blockChain.blocks))+1 < blockPair.TransactionsBlock.Header.BlockHeight() {
-		return false, errors.Errorf("block persistence tried to write next block with height %d when %d exist", blockPair.TransactionsBlock.Header.BlockHeight(), len(bp.blockChain.blocks))
-	}
-
-	if primitives.BlockHeight(len(bp.blockChain.blocks))+1 > blockPair.TransactionsBlock.Header.BlockHeight() {
-		bp.Logger.Info("block persistence ignoring write next block. incorrect height", log.Uint64("incoming-block-height", uint64(blockPair.TransactionsBlock.Header.BlockHeight())), logfields.BlockHeight(primitives.BlockHeight(len(bp.blockChain.blocks))))
-		// TODO(v1): since we're skipping the add, byte-compare the block header to make sure we don't have a fork
-		return false, nil
-	}
 	bp.blockChain.blocks = append(bp.blockChain.blocks, blockPair)
 	bp.tracker.IncrementTo(blockPair.ResultsBlock.Header.BlockHeight())
-	return true, nil
+	return true, blockPair.ResultsBlock.Header.BlockHeight(), nil
 }
 
 func (bp *InMemoryBlockPersistence) GetBlockByTx(txHash primitives.Sha256, minBlockTs primitives.TimestampNano, maxBlockTs primitives.TimestampNano) (*protocol.BlockPairContainer, int, error) {

--- a/services/blockstorage/adapter/memory/memory_persistence.go
+++ b/services/blockstorage/adapter/memory/memory_persistence.go
@@ -78,11 +78,10 @@ func (bp *InMemoryBlockPersistence) GetLastBlockHeight() (primitives.BlockHeight
 func (bp *InMemoryBlockPersistence) WriteNextBlock(blockPair *protocol.BlockPairContainer) (bool, primitives.BlockHeight, error) {
 
 	added, pHeight := bp.validateAndAddNextBlock(blockPair)
-	if !added {
-		return added, pHeight, nil
-	}
 
-	bp.metrics.size.Add(sizeOfBlock(blockPair))
+	if added {
+		bp.metrics.size.Add(sizeOfBlock(blockPair))
+	}
 
 	return added, pHeight, nil
 }

--- a/services/blockstorage/adapter/persistence.go
+++ b/services/blockstorage/adapter/persistence.go
@@ -18,7 +18,7 @@ import (
 type CursorFunc func(first primitives.BlockHeight, page []*protocol.BlockPairContainer) (wantsMore bool)
 
 type BlockPersistence interface {
-	WriteNextBlock(blockPair *protocol.BlockPairContainer) (bool, error)
+	WriteNextBlock(blockPair *protocol.BlockPairContainer) (bool, primitives.BlockHeight, error)
 
 	ScanBlocks(from primitives.BlockHeight, pageSize uint8, f CursorFunc) error
 

--- a/services/blockstorage/adapter/test/concurrency_test.go
+++ b/services/blockstorage/adapter/test/concurrency_test.go
@@ -30,8 +30,10 @@ func TestCanWriteAndScanConcurrently(t *testing.T) {
 	require.NoError(t, err)
 	defer closeAdapter()
 
-	_, err = fsa.WriteNextBlock(blocks[0]) // write only the first block in the chain
-	require.NoError(t, err)
+	added, newHeight, err := fsa.WriteNextBlock(blocks[0]) // write only the first block in the chain
+	require.NoError(t, err, "expected successful writing of first block")
+	require.True(t, added, "expected block to be persisted")
+	require.EqualValues(t, 1, newHeight, "expected persisted height to be 1")
 
 	var topHeightRead primitives.BlockHeight
 	secondBlockWritten, midScan, finishedScan := newSignalChan(), newSignalChan(), newSignalChan()
@@ -50,8 +52,10 @@ func TestCanWriteAndScanConcurrently(t *testing.T) {
 
 	waitFor(midScan)
 
-	_, err = fsa.WriteNextBlock(blocks[1]) // write the second block while a block scan is ongoing
+	added, newHeight, err = fsa.WriteNextBlock(blocks[1]) // write the second block while a block scan is ongoing
 	require.NoError(t, err, "should be able to write block while scanning")
+	require.True(t, added, "expected successful writing of second block")
+	require.EqualValues(t, 2, newHeight, "expected persisted height to be 2")
 
 	signal(secondBlockWritten)
 

--- a/services/blockstorage/adapter/test/contract_test.go
+++ b/services/blockstorage/adapter/test/contract_test.go
@@ -57,9 +57,10 @@ func TestBlockPersistenceContract_WritesBlockAndRetrieves(t *testing.T) {
 
 		withEachAdapter(t, func(t *testing.T, adapter adapter.BlockPersistence) {
 			for _, b := range blocks {
-				added, err := adapter.WriteNextBlock(b)
+				added, pHeight, err := adapter.WriteNextBlock(b)
 				require.NoError(t, err, "write should succeed")
 				require.True(t, added, "block should actually be added (it's not duplicate)")
+				require.EqualValues(t, b.TransactionsBlock.Header.BlockHeight(), pHeight, "expected height to be reported correctly")
 			}
 
 			// test ScanBlocks
@@ -91,50 +92,59 @@ func TestBlockPersistenceContract_ReadUnknownBlocksReturnsError(t *testing.T) {
 	})
 }
 
-func TestBlockPersistenceContract_WriteOutOfOrderFuture_Fails(t *testing.T) {
+func TestBlockPersistenceContract_WriteOutOfOrderFuture_DoesNotFail(t *testing.T) {
 	withEachAdapter(t, func(t *testing.T, adapter adapter.BlockPersistence) {
-		added, err := adapter.WriteNextBlock(builders.BlockPair().WithHeight(2).Build())
-		require.Error(t, err, "write should fail")
+		added, persistedHeight, err := adapter.WriteNextBlock(builders.BlockPair().WithHeight(1).Build())
+		require.NoError(t, err)
+		require.True(t, added)
+		require.EqualValues(t, 1, persistedHeight)
+
+		added, persistedHeight, err = adapter.WriteNextBlock(builders.BlockPair().WithHeight(3).Build())
+		require.NoError(t, err, "no IO error, bloc is ignored since out of order")
 		require.False(t, added, "block should not be added (due to failure)")
+		require.EqualValues(t, 1, persistedHeight, "persisted height should be reported correctly")
 	})
 }
 
-func TestBlockPersistenceContract_WriteOutOfOrderPast_NotFailsWhenBlockIdentical(t *testing.T) {
-	withEachAdapter(t, func(t *testing.T, adapter adapter.BlockPersistence) {
-		block1 := builders.BlockPair().WithHeight(1).Build()
-		block2 := builders.BlockPair().WithHeight(2).WithPrevBlock(block1).Build()
-
-		added, err := adapter.WriteNextBlock(block1)
-		require.NoError(t, err, "write should succeed")
-		require.True(t, added, "block should actually be added (it's not duplicate)")
-		added, err = adapter.WriteNextBlock(block2)
-		require.NoError(t, err, "write should succeed")
-		require.True(t, added, "block should actually be added (it's not duplicate)")
-
-		added, err = adapter.WriteNextBlock(block1)
-		require.NoError(t, err, "write should succeed")
-		require.False(t, added, "block should not be added though (it's duplicate)")
-	})
-}
-
-func TestBlockPersistenceContract_WriteOutOfOrderPast_FailsWhenBlockDifferent(t *testing.T) {
-	t.Skip("fails with In_Memory_Adapter and should be fixed") // TODO(v1): fix
+func TestBlockPersistenceContract_WriteOutOfOrderPast_NotFailsWithoutError(t *testing.T) {
 	withEachAdapter(t, func(t *testing.T, adapter adapter.BlockPersistence) {
 		now := time.Now()
-		block1 := builders.BlockPair().WithHeight(1).WithBlockCreated(now).Build()
+		block1 := builders.BlockPair().WithHeight(1).WithTransactions(1).WithBlockCreated(now).Build()
 		block2 := builders.BlockPair().WithHeight(2).WithPrevBlock(block1).Build()
-		otherBlock1 := builders.BlockPair().WithHeight(1).WithBlockCreated(now.Add(1 * time.Second)).Build()
+		otherBlockDifferentTimestamp := builders.BlockPair().WithHeight(1).WithBlockCreated(now.Add(1 * time.Second)).Build()
+		otherBlockDifferentTransactionsBlock := builders.BlockPair().WithHeight(1).WithTransactions(2).WithBlockCreated(now).Build()
+		otherBlockDifferentResultsBlock := builders.BlockPair().WithHeight(1).WithTransactions(1).WithReceiptsForTransactions().WithBlockCreated(now).Build()
 
-		added, err := adapter.WriteNextBlock(block1)
+		added, pHeight, err := adapter.WriteNextBlock(block1)
 		require.NoError(t, err, "write should succeed")
 		require.True(t, added, "block should actually be added (it's not duplicate)")
-		added, err = adapter.WriteNextBlock(block2)
+		require.EqualValues(t, 1, pHeight)
+
+		added, pHeight, err = adapter.WriteNextBlock(block2)
 		require.NoError(t, err, "write should succeed")
 		require.True(t, added, "block should actually be added (it's not duplicate)")
+		require.EqualValues(t, 2, pHeight)
 
-		added, err = adapter.WriteNextBlock(otherBlock1)
-		require.Error(t, err, "write of a different old block should fail")
+		// write past blocks:
+		added, pHeight, err = adapter.WriteNextBlock(block1)
+		require.NoError(t, err, "expected past blocks to be ignored")
 		require.False(t, added, "block should not be added (due to failure)")
+		require.EqualValues(t, 2, pHeight, "expected persisted height to not change")
+
+		added, pHeight, err = adapter.WriteNextBlock(otherBlockDifferentTimestamp)
+		require.NoError(t, err, "expected past blocks to be ignored without checking content")
+		require.False(t, added, "block should not be added (due to failure)")
+		require.EqualValues(t, 2, pHeight, "expected persisted height to not change")
+
+		added, pHeight, err = adapter.WriteNextBlock(otherBlockDifferentResultsBlock)
+		require.NoError(t, err, "expected past blocks to be ignored without checking content")
+		require.False(t, added, "block should not be added (due to failure)")
+		require.EqualValues(t, 2, pHeight, "expected persisted height to not change")
+
+		added, pHeight, err = adapter.WriteNextBlock(otherBlockDifferentTransactionsBlock)
+		require.NoError(t, err, "expected past blocks to be ignored without checking content")
+		require.False(t, added, "block should not be added (due to failure)")
+		require.EqualValues(t, 2, pHeight, "expected persisted height to not change")
 	})
 }
 
@@ -143,10 +153,10 @@ func TestBlockPersistenceContract_ReturnsTwoBlocks(t *testing.T) {
 		block1 := builders.BlockPair().WithHeight(1).Build()
 		block2 := builders.BlockPair().WithHeight(2).WithPrevBlock(block1).Build()
 
-		added, err := adapter.WriteNextBlock(block1)
+		added, _, err := adapter.WriteNextBlock(block1)
 		require.NoError(t, err, "write should succeed")
 		require.True(t, added, "block should actually be added (it's not duplicate)")
-		added, err = adapter.WriteNextBlock(block2)
+		added, _, err = adapter.WriteNextBlock(block2)
 		require.NoError(t, err, "write should succeed")
 		require.True(t, added, "block should actually be added (it's not duplicate)")
 
@@ -165,12 +175,13 @@ func TestBlockPersistenceContract_BlockTrackerBlocksUntilRequestedHeight(t *test
 		// block until timeout before block is written
 		shortDeadlineCtx, _ := context.WithTimeout(context.Background(), 5*time.Millisecond)
 		err := adapter.GetBlockTracker().WaitForBlock(shortDeadlineCtx, 1)
-		require.Error(t, err)
+		require.Error(t, err, "expected timeout to expire when requested block height not available")
 
 		// write block height 1
-		added, err := adapter.WriteNextBlock(builders.BlockPair().WithHeight(1).Build())
+		added, newHeight, err := adapter.WriteNextBlock(builders.BlockPair().WithHeight(1).Build())
 		require.NoError(t, err, "write should succeed")
 		require.True(t, added, "block should actually be added (it's not duplicate)")
+		require.EqualValues(t, 1, newHeight, "expected persisted height to be 1")
 
 		// block tracker returns from wait immediately without error
 		shortDeadlineCtx, _ = context.WithTimeout(context.Background(), 5*time.Millisecond)
@@ -186,9 +197,10 @@ func TestBlockPersistenceContract_ReturnsLastBlockHeight(t *testing.T) {
 		require.EqualValues(t, 0, h)
 
 		// write block height 1
-		added, err := adapter.WriteNextBlock(builders.BlockPair().WithHeight(1).Build())
+		added, persistedHeight, err := adapter.WriteNextBlock(builders.BlockPair().WithHeight(1).Build())
 		require.NoError(t, err, "write should succeed")
 		require.True(t, added, "block should actually be added (it's not duplicate)")
+		require.EqualValues(t, 1, persistedHeight, "expected persisted height to be 1")
 
 		h, err = adapter.GetLastBlockHeight()
 		require.NoError(t, err)
@@ -205,7 +217,7 @@ func TestBlockPersistenceContract_ReturnsTransactionsAndResultsBlock(t *testing.
 		}
 
 		for _, b := range blocks {
-			added, err := adapter.WriteNextBlock(b)
+			added, _, err := adapter.WriteNextBlock(b)
 			require.NoError(t, err)
 			require.True(t, added)
 		}
@@ -233,7 +245,7 @@ func TestBlockPersistenceContract_ReturnsBlockByTx(t *testing.T) {
 		}
 
 		for _, b := range blocks {
-			added, err := adapter.WriteNextBlock(b)
+			added, _, err := adapter.WriteNextBlock(b)
 			require.NoError(t, err, "write should succeed")
 			require.True(t, added, "block should actually be added (it's not duplicate)")
 		}

--- a/services/blockstorage/adapter/test/driver.go
+++ b/services/blockstorage/adapter/test/driver.go
@@ -124,7 +124,7 @@ func writeRandomBlocksToFile(t *testing.T, conf *localConfig, numBlocks int32, c
 	blockChain := builders.RandomizedBlockChain(numBlocks, ctrlRand)
 
 	for _, block := range blockChain {
-		_, err = fsa.WriteNextBlock(block)
+		_, _, err = fsa.WriteNextBlock(block)
 		require.NoError(t, err)
 	}
 	return blockChain

--- a/services/blockstorage/adapter/test/persistence_test.go
+++ b/services/blockstorage/adapter/test/persistence_test.go
@@ -32,8 +32,10 @@ func TestPersistenceAdapter_CanAccessBlocksOutOfOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, block := range blocks { // write some blocks
-		_, err = adapter1.WriteNextBlock(block)
+		added, pHeight, err := adapter1.WriteNextBlock(block)
 		require.NoError(t, err)
+		require.True(t, added)
+		require.EqualValues(t, block.TransactionsBlock.Header.BlockHeight(), pHeight)
 	}
 
 	requireCanReadAllBlocksInRandomOrder(t, adapter1, blocks, ctrlRand)

--- a/services/blockstorage/adapter/testkit/tampering_persistence.go
+++ b/services/blockstorage/adapter/testkit/tampering_persistence.go
@@ -46,18 +46,20 @@ func (bp *tamperingBlockPersistence) FailNextBlocks() {
 	bp.failNextBlocks = true
 }
 
-func (bp *tamperingBlockPersistence) WriteNextBlock(blockPair *protocol.BlockPairContainer) (bool, error) {
+func (bp *tamperingBlockPersistence) WriteNextBlock(blockPair *protocol.BlockPairContainer) (bool, primitives.BlockHeight, error) {
 	if bp.failNextBlocks {
-		return false, errors.New("could not write a block")
+		return false, 0, errors.New("could not write a block")
 	}
-	added, err := bp.InMemoryBlockPersistence.WriteNextBlock(blockPair)
+
+	added, pHeight, err := bp.InMemoryBlockPersistence.WriteNextBlock(blockPair)
 	if err != nil {
-		return added, err
+		return added, pHeight, err
 	}
+
 	if added {
 		bp.advertiseAllTransactions(blockPair.TransactionsBlock)
 	}
-	return added, nil
+	return added, pHeight, nil
 }
 
 func (bp *tamperingBlockPersistence) advertiseAllTransactions(block *protocol.TransactionsBlockContainer) {

--- a/services/blockstorage/commit_block.go
+++ b/services/blockstorage/commit_block.go
@@ -8,9 +8,12 @@ package blockstorage
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"github.com/orbs-network/orbs-network-go/instrumentation/logfields"
 	"github.com/orbs-network/orbs-network-go/instrumentation/trace"
 	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
+	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
 	"github.com/orbs-network/scribe/log"
 	"time"
@@ -27,32 +30,24 @@ func (s *service) CommitBlock(ctx context.Context, input *services.CommitBlockIn
 func (s *service) commitBlock(ctx context.Context, input *services.CommitBlockInput, notifyNodeSync bool) (*services.CommitBlockOutput, error) {
 	logger := s.logger.WithTags(trace.LogFieldFrom(ctx))
 
-	txBlockHeader := input.BlockPair.TransactionsBlock.Header
-	rsBlockHeader := input.BlockPair.ResultsBlock.Header
-
-	logger.Info("Trying to commit a block", logfields.BlockHeight(txBlockHeader.BlockHeight()))
+	proposedBlockHeight := input.BlockPair.TransactionsBlock.Header.BlockHeight()
+	logger.Info("Trying to commit a block", logfields.BlockHeight(proposedBlockHeight))
 
 	if err := s.validateProtocolVersion(input.BlockPair); err != nil {
 		return nil, err
 	}
 
-	// the source of truth for the last committed block is persistence
-	lastCommittedBlock, err := s.persistence.GetLastBlock()
+	added, persistedHeight, err := s.persistence.WriteNextBlock(input.BlockPair)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO(https://github.com/orbs-network/orbs-network-go/issues/524): the logic here aborting commits for already committed blocks is duplicated in the adapter because this is not under lock. synchronize to avoid duplicating logic in adapter
-	if ok, err := s.validateBlockDoesNotExist(ctx, txBlockHeader, rsBlockHeader, lastCommittedBlock); err != nil || !ok {
-		return nil, err
+	if proposedBlockHeight > persistedHeight+1 {
+		return nil, fmt.Errorf("attempt to write future block %d. current top height is %d", proposedBlockHeight, persistedHeight)
 	}
 
-	if err := s.validateConsecutiveBlockHeight(input.BlockPair, lastCommittedBlock); err != nil {
-		return nil, err
-	}
-
-	if _, err := s.persistence.WriteNextBlock(input.BlockPair); err != nil {
-		return nil, err
+	if !added {
+		return nil, s.detectForks(input.BlockPair, logger)
 	}
 
 	s.metrics.blockHeight.Update(int64(input.BlockPair.TransactionsBlock.Header.BlockHeight()))
@@ -65,7 +60,43 @@ func (s *service) commitBlock(ctx context.Context, input *services.CommitBlockIn
 		})
 	}
 
-	logger.Info("committed a block", logfields.BlockHeight(txBlockHeader.BlockHeight()), log.Int("num-transactions", len(input.BlockPair.TransactionsBlock.SignedTransactions)))
+	logger.Info("committed a block", logfields.BlockHeight(proposedBlockHeight), log.Int("num-transactions", len(input.BlockPair.TransactionsBlock.SignedTransactions)))
 
 	return nil, nil
+}
+
+func (s *service) detectForks(proposedBlock *protocol.BlockPairContainer, logger log.Logger) error {
+	txBlockHeader := proposedBlock.TransactionsBlock.Header
+	rsBlockHeader := proposedBlock.ResultsBlock.Header
+	proposedBlockHeight := txBlockHeader.BlockHeight()
+
+	storedRsBlock, err := s.persistence.GetResultsBlock(proposedBlockHeight)
+	if err != nil {
+		return err
+	}
+
+	storedTxBlock, err := s.persistence.GetTransactionsBlock(proposedBlockHeight)
+	if err != nil {
+		return err
+	}
+
+	if txBlockHeader.Timestamp() != storedTxBlock.Header.Timestamp() {
+		errorMessage := "FORK!! block already in storage, timestamp mismatch"
+		// fork found! this is a major error we must report to logs
+		logger.Error(errorMessage, logfields.BlockHeight(proposedBlockHeight), log.Stringable("new-block", txBlockHeader), log.Stringable("existing-block", storedTxBlock.Header))
+		return errors.New(errorMessage)
+	} else if !txBlockHeader.Equal(storedTxBlock.Header) {
+		errorMessage := "FORK!! block already in storage, transaction block header mismatch"
+		// fork found! this is a major error we must report to logs
+		logger.Error(errorMessage, logfields.BlockHeight(proposedBlockHeight), log.Stringable("new-block", txBlockHeader), log.Stringable("existing-block", storedTxBlock.Header))
+		return errors.New(errorMessage)
+	} else if !rsBlockHeader.Equal(storedRsBlock.Header) {
+		errorMessage := "FORK!! block already in storage, results block header mismatch"
+		// fork found! this is a major error we must report to logs
+		s.logger.Error(errorMessage, logfields.BlockHeight(proposedBlockHeight), log.Stringable("new-block", rsBlockHeader), log.Stringable("existing-block", storedRsBlock.Header))
+		return errors.New(errorMessage)
+	}
+
+	logger.Info("block already in storage, skipping", logfields.BlockHeight(proposedBlockHeight))
+	return nil
 }

--- a/services/blockstorage/commit_block_test.go
+++ b/services/blockstorage/commit_block_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 the orbs-network-go authors
+// This file is part of the orbs-network-go library in the Orbs project.
+//
+// This source code is licensed under the MIT license found in the LICENSE file in the root directory of this source tree.
+// The above notice should be included in all copies or substantial portions of the software.
+
+package blockstorage
+
+import (
+	"github.com/orbs-network/orbs-network-go/test/builders"
+	"github.com/orbs-network/scribe/log"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestDetectForkReturnsErrorOnDifferentTimestamp(t *testing.T) {
+	blockBuilder := builders.BlockPair()
+	blockPair := blockBuilder.Build()
+
+	mutatedBlockPair := blockBuilder.WithBlockCreated(time.Now().Add(1 * time.Hour)).Build()
+
+	err := detectForks(mutatedBlockPair, blockPair.TransactionsBlock.Header, blockPair.ResultsBlock.Header, log.DefaultTestingLoggerAllowingErrors(t, "FORK!!"))
+
+	require.EqualError(t, err, "FORK!! block already in storage, timestamp mismatch", "same block, different timestamp should return an error")
+}
+
+func TestDetectForkReturnsErrorOnDifferentTxBlock(t *testing.T) {
+	blockBuilder := builders.BlockPair()
+	blockPair := blockBuilder.Build()
+
+	mutatedBlockPair := blockBuilder.Build()
+	mutatedBlockPair.TransactionsBlock.Header.MutateNumSignedTransactions(999)
+
+	err := detectForks(mutatedBlockPair, blockPair.TransactionsBlock.Header, blockPair.ResultsBlock.Header, log.DefaultTestingLoggerAllowingErrors(t, "FORK!!"))
+
+	require.EqualError(t, err, "FORK!! block already in storage, transaction block header mismatch", "same block, different transactions block header should return an error")
+}
+
+func TestDetectForkReturnsErrorOnDifferentRxBlock(t *testing.T) {
+	blockBuilder := builders.BlockPair()
+	blockPair := blockBuilder.Build()
+	mutatedBlockPair := blockBuilder.Build()
+	mutatedBlockPair.ResultsBlock.Header.MutateNumTransactionReceipts(999)
+
+	err := detectForks(mutatedBlockPair, blockPair.TransactionsBlock.Header, blockPair.ResultsBlock.Header, log.DefaultTestingLoggerAllowingErrors(t, "FORK!!"))
+
+	require.EqualError(t, err, "FORK!! block already in storage, results block header mismatch", "same block, different results block header should return an error")
+}

--- a/services/blockstorage/test/commit_block_test.go
+++ b/services/blockstorage/test/commit_block_test.go
@@ -77,14 +77,22 @@ func TestCommitBlockReturnsErrorWhenProtocolVersionMismatches(t *testing.T) {
 func TestCommitBlockDiscardsBlockIfAlreadyExists(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
-		blockPair := builders.BlockPair().Build()
+		block1 := builders.BlockPair().WithHeight(1).Build()
+		block2 := builders.BlockPair().WithHeight(2).Build()
 
-		harness.commitBlock(ctx, blockPair)
-		_, err := harness.commitBlock(ctx, blockPair)
-
+		_, err := harness.commitBlock(ctx, block1)
 		require.NoError(t, err)
 
-		require.EqualValues(t, 1, harness.numOfWrittenBlocks(), "block should be written only once")
+		_, err = harness.commitBlock(ctx, block2)
+		require.NoError(t, err)
+
+		_, err = harness.commitBlock(ctx, block1)
+		require.NoError(t, err, "expected existing block to be silently ignored")
+
+		_, err = harness.commitBlock(ctx, block2)
+		require.NoError(t, err, "expected existing block to be silently ignored")
+
+		require.EqualValues(t, 2, harness.numOfWrittenBlocks(), "block should be written only once")
 		harness.verifyMocks(t, 1)
 	})
 }
@@ -141,15 +149,24 @@ func TestCommitBlockReturnsErrorIfBlockExistsButHasDifferentRxBlock(t *testing.T
 	})
 }
 
-func TestCommitBlockReturnsErrorIfBlockIsNotSequential(t *testing.T) {
+func TestCommitBlockReturnsErrorIfBlockInFuture(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		harness := newBlockStorageHarness(t).withSyncBroadcast(1).start(ctx)
 
-		harness.commitBlock(ctx, builders.BlockPair().Build())
+		now := time.Now()
+		block1 := builders.BlockPair().WithHeight(1).WithTransactions(1).WithBlockCreated(now).Build()
+		block2 := builders.BlockPair().WithHeight(2).WithPrevBlock(block1).Build()
 
-		_, err := harness.commitBlock(ctx, builders.BlockPair().WithHeight(1000).Build())
-		require.EqualError(t, err, "block height is 1000, expected 2", "block height was mutate to be invalid, should return an error")
-		require.EqualValues(t, 1, harness.numOfWrittenBlocks(), "only one block should have been written")
+		_, err := harness.commitBlock(ctx, block1)
+		require.NoError(t, err)
+		_, err = harness.commitBlock(ctx, block2)
+		require.NoError(t, err)
+
+		futureBlock := builders.BlockPair().WithHeight(1000).Build()
+
+		_, err = harness.commitBlock(ctx, futureBlock)
+		require.EqualError(t, err, "attempt to write future block 1000. current top height is 2", "block height was mutate to be invalid, should return an error")
+		require.EqualValues(t, 2, harness.numOfWrittenBlocks(), "only 2 blocks should have been written")
 		harness.verifyMocks(t, 1)
 	})
 }


### PR DESCRIPTION
## Description

1. resolves #524
2. more consistent fork detection behavior. previously were open to race conditions which could prevent fork detection, now resolved.
3. comply with spec and check for forks for any attempt to write a block which already exists in storage - and not just for forks in the top persisted block

## Further comments

`BlockPersistence.WriteNextBlock()` now also returns the top persisted block height, and does not return an error if a future block is attempted. it merely returns false on the `added` param. the calling service later examines the result of the execution and executes the spec:
1. If the block was not `added` to persistent storage and the proposed block height is higher than the expected block height, the service now returns the error according to the spec. the adapter remains free of service logic. it merely adds the 
2. An error returned from `BlockPersistence.WriteNextBlock()` is always an IO error - never a block ordering issues. these concerns are in the service only