### PR TITLE
Add TPS benchmark to acceptance test suite

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,6 +106,7 @@ type NodeConfig interface {
 type OverridableConfig interface {
 	NodeConfig
 	ForNode(nodeAddress primitives.NodeAddress, privateKey primitives.EcdsaSecp256K1PrivateKey) NodeConfig
+	MergeWithFileConfig(source string) (mutableNodeConfig, error)
 }
 
 type mutableNodeConfig interface {
@@ -121,7 +122,6 @@ type mutableNodeConfig interface {
 	SetNodePrivateKey(key primitives.EcdsaSecp256K1PrivateKey) mutableNodeConfig
 	SetBenchmarkConsensusConstantLeader(key primitives.NodeAddress) mutableNodeConfig
 	SetActiveConsensusAlgo(algoType consensus.ConsensusAlgoType) mutableNodeConfig
-	MergeWithFileConfig(source string) (mutableNodeConfig, error)
 	Clone() mutableNodeConfig
 }
 

--- a/test/acceptance/network_harness.go
+++ b/test/acceptance/network_harness.go
@@ -53,14 +53,15 @@ func usingABenchmarkConsensusNetwork(tb testing.TB, f func(ctx context.Context, 
 	ctx, cancel := context.WithCancel(context.Background())
 	supervised.Recover(logger, func() {
 		defer cancel()
-		network := newAcceptanceTestNetwork(ctx, logger, consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS, nil, 2, DEFAULT_ACCEPTANCE_MAX_TX_PER_BLOCK, DEFAULT_ACCEPTANCE_REQUIRED_QUORUM_PERCENTAGE, DEFAULT_ACCEPTANCE_VIRTUAL_CHAIN_ID, DEFAULT_ACCEPTANCE_EMPTY_BLOCK_TIME)
+		network := newAcceptanceTestNetwork(ctx, logger, consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS, nil, 2, DEFAULT_ACCEPTANCE_MAX_TX_PER_BLOCK, DEFAULT_ACCEPTANCE_REQUIRED_QUORUM_PERCENTAGE, DEFAULT_ACCEPTANCE_VIRTUAL_CHAIN_ID, DEFAULT_ACCEPTANCE_EMPTY_BLOCK_TIME, nil)
 		network.CreateAndStartNodes(ctx, 2)
 		f(ctx, network)
 	})
 }
 
 func newAcceptanceTestNetwork(ctx context.Context, testLogger log.Logger, consensusAlgo consensus.ConsensusAlgoType, preloadedBlocks []*protocol.BlockPairContainer,
-	numNodes int, maxTxPerBlock uint32, requiredQuorumPercentage uint32, vcid primitives.VirtualChainId, emptyBlockTime time.Duration) *NetworkHarness {
+	numNodes int, maxTxPerBlock uint32, requiredQuorumPercentage uint32, vcid primitives.VirtualChainId, emptyBlockTime time.Duration,
+	configOverride func(cfg config.OverridableConfig) config.OverridableConfig) *NetworkHarness {
 
 	testLogger.Info("===========================================================================")
 	testLogger.Info("creating acceptance test network", log.String("consensus", consensusAlgo.String()), log.Int("num-nodes", numNodes))
@@ -77,7 +78,8 @@ func newAcceptanceTestNetwork(ctx context.Context, testLogger log.Logger, consen
 		nodeOrder = append(nodeOrder, nodeAddress)
 	}
 
-	cfgTemplate := config.ForAcceptanceTestNetwork(
+	var cfgTemplate config.OverridableConfig
+	cfgTemplate = config.ForAcceptanceTestNetwork(
 		genesisValidatorNodes,
 		leaderKeyPair.NodeAddress(),
 		consensusAlgo,
@@ -86,6 +88,10 @@ func newAcceptanceTestNetwork(ctx context.Context, testLogger log.Logger, consen
 		vcid,
 		emptyBlockTime,
 	)
+
+	if configOverride != nil {
+		cfgTemplate = configOverride(cfgTemplate)
+	}
 
 	sharedTamperingTransport := gossipTestAdapter.NewTamperingTransport(testLogger, memoryGossip.NewTransport(ctx, testLogger, genesisValidatorNodes))
 	sharedCompiler := nativeProcessorAdapter.NewCompiler()

--- a/test/acceptance/network_harness_builder.go
+++ b/test/acceptance/network_harness_builder.go
@@ -8,6 +8,7 @@ package acceptance
 
 import (
 	"context"
+	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter/memory"
 	"github.com/orbs-network/orbs-network-go/synchronization/supervised"
 	"github.com/orbs-network/orbs-network-go/test"
@@ -37,6 +38,7 @@ type networkHarnessBuilder struct {
 	consensusAlgos           []consensus.ConsensusAlgoType
 	testId                   string
 	setupFunc                func(ctx context.Context, network *NetworkHarness)
+	configOverride           func(config config.OverridableConfig) config.OverridableConfig
 	logFilters               []log.Filter
 	maxTxPerBlock            uint32
 	allowedErrors            []string
@@ -139,7 +141,7 @@ func (b *networkHarnessBuilder) runTest(tb testing.TB, consensusAlgo consensus.C
 		// TODO: if we experience flakiness during system shutdown move TestTerminated to be under test.WithContextWithTimeout
 
 		test.WithContextWithTimeout(TEST_TIMEOUT_HARD_LIMIT, func(ctx context.Context) {
-			network := newAcceptanceTestNetwork(ctx, logger, consensusAlgo, b.blockChain, b.numNodes, b.maxTxPerBlock, b.requiredQuorumPercentage, b.virtualChainId, b.emptyBlockTime)
+			network := newAcceptanceTestNetwork(ctx, logger, consensusAlgo, b.blockChain, b.numNodes, b.maxTxPerBlock, b.requiredQuorumPercentage, b.virtualChainId, b.emptyBlockTime, b.configOverride)
 
 			logger.Info("acceptance network created")
 			defer printTestIdOnFailure(tb, testId)
@@ -212,6 +214,11 @@ func (b *networkHarnessBuilder) WithVirtualChainId(id primitives.VirtualChainId)
 
 func (b *networkHarnessBuilder) WithEmptyBlockTime(emptyBlockTime time.Duration) *networkHarnessBuilder {
 	b.emptyBlockTime = emptyBlockTime
+	return b
+}
+
+func (b *networkHarnessBuilder) WithConfigOverride(f func(cfg config.OverridableConfig) config.OverridableConfig) *networkHarnessBuilder {
+	b.configOverride = f
 	return b
 }
 

--- a/test/acceptance/stress_benchmark_test.go
+++ b/test/acceptance/stress_benchmark_test.go
@@ -1,0 +1,47 @@
+package acceptance
+
+import (
+	"context"
+	"fmt"
+	"github.com/orbs-network/orbs-network-go/config"
+	"github.com/orbs-network/orbs-network-go/test/rand"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func BenchmarkHappyFlow1k(b *testing.B) {
+	numTransactions := 1000
+
+	rnd := rand.NewControlledRand(b)
+	newHarness().Start(b, func(t testing.TB, ctx context.Context, network *NetworkHarness) {
+		for n := 0; n < b.N; n++ {
+			b.StartTimer()
+			transferDuration, waitDuration := sendTransfersAndAssertTotalBalance(ctx, network, t, numTransactions, rnd)
+			b.StopTimer()
+
+			fmt.Println("finished sending ", numTransactions, "transactions in", transferDuration)
+			fmt.Println("finished waiting for", numTransactions, "transactions in", waitDuration)
+		}
+	})
+}
+
+func BenchmarkHappyFlow1kWithOverrides(b *testing.B) {
+	numTransactions := 1000
+
+	rnd := rand.NewControlledRand(b)
+	newHarness().WithConfigOverride(func(cfg config.OverridableConfig) config.OverridableConfig {
+		c, err := cfg.MergeWithFileConfig(`{
+	"transaction-pool-propagation-batch-size": 1000
+}`)
+		require.NoError(b, err)
+		return c
+	}).Start(b, func(t testing.TB, ctx context.Context, network *NetworkHarness) {
+		for n := 0; n < b.N; n++ {
+			b.StartTimer()
+			transferDuration, waitDuration := sendTransfersAndAssertTotalBalance(ctx, network, t, numTransactions, rnd)
+			b.StopTimer()
+			fmt.Println("finished sending ", numTransactions, "transactions in", transferDuration)
+			fmt.Println("finished waiting for", numTransactions, "transactions in", waitDuration)
+		}
+	})
+}

--- a/test/acceptance/stress_benchmark_test.go
+++ b/test/acceptance/stress_benchmark_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/test/rand"
@@ -25,13 +26,63 @@ func BenchmarkHappyFlow1k(b *testing.B) {
 	})
 }
 
+type EssentialMetricsHistogram struct {
+	Min     float64
+	P50     float64
+	P95     float64
+	P99     float64
+	Max     float64
+	Avg     float64
+	Samples int64
+}
+
+type EssentialMetrics struct {
+	BlockHeight              uint64
+	TxTimeSpentInQueueMillis EssentialMetricsHistogram
+	TxCommitRatePerSecond    float64
+}
+
+func parseEssentialMetricsHistogram(value map[string]interface{}) EssentialMetricsHistogram {
+	return EssentialMetricsHistogram{
+		Min:     value["Min"].(float64),
+		Max:     value["Max"].(float64),
+		P50:     value["P50"].(float64),
+		P95:     value["P95"].(float64),
+		P99:     value["P99"].(float64),
+		Avg:     value["Avg"].(float64),
+		Samples: int64(value["Samples"].(float64)),
+	}
+}
+
+func parseEssentialMetrics(info interface{}) EssentialMetrics {
+	raw, _ := json.Marshal(info)
+	m := make(map[string]map[string]interface{})
+	json.Unmarshal(raw, &m)
+
+	e := EssentialMetrics{}
+
+	for key, value := range m {
+		switch key {
+		case "BlockStorage.BlockHeight":
+			e.BlockHeight = uint64(value["Value"].(float64))
+		case "TransactionPool.PendingPool.TimeSpentInQueue.Millis":
+			e.TxTimeSpentInQueueMillis = parseEssentialMetricsHistogram(value)
+		case "TransactionPool.CommitRate.PerSecond":
+			e.TxCommitRatePerSecond = value["Rate"].(float64)
+		}
+	}
+
+	return e
+}
+
 func BenchmarkHappyFlow1kWithOverrides(b *testing.B) {
 	numTransactions := 1000
 
 	rnd := rand.NewControlledRand(b)
 	newHarness().WithConfigOverride(func(cfg config.OverridableConfig) config.OverridableConfig {
 		c, err := cfg.MergeWithFileConfig(`{
-	"transaction-pool-propagation-batch-size": 1000
+	"consensus-context-maximum-transactions-in-block": 70,
+	"transaction-pool-propagation-batch-size": 100
 }`)
 		require.NoError(b, err)
 		return c
@@ -43,5 +94,8 @@ func BenchmarkHappyFlow1kWithOverrides(b *testing.B) {
 			fmt.Println("finished sending ", numTransactions, "transactions in", transferDuration)
 			fmt.Println("finished waiting for", numTransactions, "transactions in", waitDuration)
 		}
+
+		e := parseEssentialMetrics(network.MetricRegistry(0).ExportAll())
+		fmt.Println("stats", e)
 	})
 }

--- a/test/acceptance/stress_test.go
+++ b/test/acceptance/stress_test.go
@@ -117,10 +117,12 @@ func TestWithNPctChance_ManualCheck(t *testing.T) {
 	t.Logf("Manual test for WithPercentChance: Tries=%d Chance=%d%% Hits=%d\n", tries, pct, hits)
 }
 
-func sendTransfersAndAssertTotalBalance(ctx context.Context, network *NetworkHarness, t testing.TB, numTransactions int, ctrlRand *rand.ControlledRand) {
+func sendTransfersAndAssertTotalBalance(ctx context.Context, network *NetworkHarness, t testing.TB, numTransactions int, ctrlRand *rand.ControlledRand) (transferDuration time.Duration, waitDuration time.Duration) {
 	fromAddress := 5
 	toAddress := 6
 	contract := network.DeployBenchmarkTokenContract(ctx, fromAddress)
+
+	start := time.Now()
 
 	var expectedSum uint64 = 0
 	var txHashes []primitives.Sha256
@@ -131,9 +133,15 @@ func sendTransfersAndAssertTotalBalance(ctx context.Context, network *NetworkHar
 		txHash := contract.TransferInBackground(ctx, ctrlRand.Intn(network.Size()), amount, fromAddress, toAddress)
 		txHashes = append(txHashes, txHash)
 	}
+
+	transferDuration = time.Since(start)
+	startWaiting := time.Now()
+
 	for _, txHash := range txHashes {
 		network.WaitForTransactionInState(ctx, txHash)
 	}
+
+	waitDuration = time.Since(startWaiting)
 
 	for i := 0; i < network.Size(); i++ {
 		actualSum := contract.GetBalance(ctx, i, toAddress)
@@ -142,4 +150,6 @@ func sendTransfersAndAssertTotalBalance(ctx context.Context, network *NetworkHar
 		actualRemainder := contract.GetBalance(ctx, i, fromAddress)
 		require.EqualValuesf(t, benchmarktoken.TOTAL_SUPPLY-expectedSum, actualRemainder, "sender balance did not equal expected balance in node %d", i)
 	}
+
+	return
 }


### PR DESCRIPTION
## Description

Adds two benchmarks (one baseline and one with ability to override current config values) for processing 1000 simple transactions.

Takes `3s` to complete with LH and `1s` to complete with benchmark.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/orbs-network/orbs-contributor-guide/blob/master/CONTRIBUTING.md) doc
- [ ] I have opened an issue and discussed the solution suggested in this PR
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If anyone wants to dig around looking for a low hanging fruit in regards to performance it's probably the best place to look.