### PR TITLE
Shut down gamma with debug call

### DIFF
--- a/bootstrap/gamma/server.go
+++ b/bootstrap/gamma/server.go
@@ -63,6 +63,8 @@ func StartGammaServer(config GammaServerConfig) *GammaServer {
 		network:     network,
 	}
 
+	s.addGammaHandlers(httpServer.Router())
+
 	return s
 }
 

--- a/bootstrap/gamma/server_handlers.go
+++ b/bootstrap/gamma/server_handlers.go
@@ -1,0 +1,21 @@
+package gamma
+
+import (
+	"net/http"
+	"time"
+)
+
+func (s *GammaServer) addGammaHandlers(router *http.ServeMux) {
+	router.HandleFunc("/debug/gamma/shutdown", s.shutdownHandler)
+}
+
+func (s *GammaServer) shutdownHandler(writer http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodPost {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	writer.Write([]byte(`{"status":"shutting down"}`))
+
+	s.GracefulShutdown(1 * time.Second)
+}


### PR DESCRIPTION
## Description

This PR introduces an API call that shuts down Gamma.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/orbs-network/orbs-contributor-guide/blob/master/CONTRIBUTING.md) doc
- [ ] I have opened an issue and discussed the solution suggested in this PR
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This is a requirement from @gilamran so he can continue his work on Playground. Essentially, in case of shutdown a hard reset of individual gamma server will happen, but it will be automatically restarted by docker.