### PR TITLE
added a skip for the block storage test on remote networks

### DIFF
--- a/test/e2e/block_storage_init_test.go
+++ b/test/e2e/block_storage_init_test.go
@@ -9,6 +9,7 @@ package e2e
 import (
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/stretchr/testify/require"
+	"os"
 	"testing"
 	"time"
 )
@@ -17,6 +18,12 @@ func TestInitialBlockHeight(t *testing.T) {
 	const expectedBlocks = 500
 	if testing.Short() {
 		t.Skip("Skipping E2E tests in short mode")
+	}
+
+	// This test is useless against remote networks since we cannot tamper with their storage
+	// So for the time being we skip this test.
+	if runningAgainstRemoteEnv := len(os.Getenv("API_ENDPOINT")) > 0; runningAgainstRemoteEnv == true {
+		t.Skip("Running against remote network - skipping")
 	}
 
 	runMultipleTimes(t, func(t *testing.T) {

--- a/test/e2e/block_storage_init_test.go
+++ b/test/e2e/block_storage_init_test.go
@@ -9,7 +9,6 @@ package e2e
 import (
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/stretchr/testify/require"
-	"os"
 	"testing"
 	"time"
 )
@@ -20,14 +19,15 @@ func TestInitialBlockHeight(t *testing.T) {
 		t.Skip("Skipping E2E tests in short mode")
 	}
 
-	// This test is useless against remote networks since we cannot tamper with their storage
-	// So for the time being we skip this test.
-	if runningAgainstRemoteEnv := len(os.Getenv("API_ENDPOINT")) > 0; runningAgainstRemoteEnv == true {
-		t.Skip("Running against remote network - skipping")
-	}
-
 	runMultipleTimes(t, func(t *testing.T) {
 		h := newHarness()
+
+		// This test is useless against remote networks since we cannot tamper with their storage
+		// So for the time being we skip this test
+		if !h.config.bootstrap {
+			t.Skip("Running against remote network - skipping")
+		}
+
 		require.True(t, test.Eventually(2*time.Second, func() bool {
 			blockHeight := h.getMetrics()["BlockStorage.BlockHeight"]["Value"].(float64)
 			return blockHeight >= expectedBlocks

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -44,6 +44,7 @@ const START_HTTP_PORT = 8090
 
 type harness struct {
 	client *orbsClient.OrbsClient
+	config *E2EConfig
 }
 
 func newHarness() *harness {
@@ -51,6 +52,7 @@ func newHarness() *harness {
 
 	return &harness{
 		client: orbsClient.NewClient(config.baseUrl, config.virtualChainId, codec.NETWORK_TYPE_TEST_NET),
+		config: &config,
 	}
 }
 


### PR DESCRIPTION
Adding a skip on a test regarding block storage which is not suitable for running against remote networks where tampering of the block storage file isn't trivial