### PR TITLE
Add dependency on contract-external-libraries-go

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 Dockerfile*
-docker-*
+docker*
+_out
+_reports
 _logs
 *.log
 _tmp

--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "vendor/golang.org/x/net"]
 	path = vendor/golang.org/x/net
 	url = https://go.googlesource.com/net
+[submodule "vendor/github.com/orbs-network/contract-external-libraries-go"]
+	path = vendor/github.com/orbs-network/contract-external-libraries-go
+	url = https://github.com/orbs-network/contract-external-libraries-go

--- a/docker/build/Dockerfile.export
+++ b/docker/build/Dockerfile.export
@@ -3,7 +3,6 @@ FROM golang:1.11.4-alpine
 RUN apk add --no-cache gcc musl-dev
 
 ADD ./vendor/github.com/orbs-network/orbs-contract-sdk/go/ /go/src/github.com/orbs-network/orbs-network-go/vendor/github.com/orbs-network/orbs-contract-sdk/go/
-ADD ./vendor/github.com/orbs-network/contract-external-libraries-go/ /go/src/github.com/orbs-network/orbs-network-go/vendor/github.com/orbs-network/contract-external-libraries-go/
 
 ADD ./_bin/orbs-node /opt/orbs/
 

--- a/docker/build/Dockerfile.export
+++ b/docker/build/Dockerfile.export
@@ -3,6 +3,7 @@ FROM golang:1.11.4-alpine
 RUN apk add --no-cache gcc musl-dev
 
 ADD ./vendor/github.com/orbs-network/orbs-contract-sdk/go/ /go/src/github.com/orbs-network/orbs-network-go/vendor/github.com/orbs-network/orbs-contract-sdk/go/
+ADD ./vendor/github.com/orbs-network/contract-external-libraries-go/ /go/src/github.com/orbs-network/orbs-network-go/vendor/github.com/orbs-network/contract-external-libraries-go/
 
 ADD ./_bin/orbs-node /opt/orbs/
 

--- a/docker/build/Dockerfile.export.experimental
+++ b/docker/build/Dockerfile.export.experimental
@@ -1,0 +1,3 @@
+FROM orbs:export
+
+ADD ./vendor/github.com/orbs-network/contract-external-libraries-go/ /go/src/github.com/orbs-network/orbs-network-go/vendor/github.com/orbs-network/contract-external-libraries-go/

--- a/docker/build/Dockerfile.gamma
+++ b/docker/build/Dockerfile.gamma
@@ -3,6 +3,7 @@ FROM golang:1.11.4-alpine
 RUN apk add --no-cache gcc musl-dev
 
 ADD ./vendor/github.com/orbs-network/orbs-contract-sdk/go/ /go/src/github.com/orbs-network/orbs-network-go/vendor/github.com/orbs-network/orbs-contract-sdk/go/
+ADD ./vendor/github.com/orbs-network/contract-external-libraries-go/ /go/src/github.com/orbs-network/orbs-network-go/vendor/github.com/orbs-network/contract-external-libraries-go/
 
 ADD ./_bin/gamma-server /opt/orbs/
 

--- a/docker/build/Dockerfile.gamma
+++ b/docker/build/Dockerfile.gamma
@@ -3,7 +3,6 @@ FROM golang:1.11.4-alpine
 RUN apk add --no-cache gcc musl-dev
 
 ADD ./vendor/github.com/orbs-network/orbs-contract-sdk/go/ /go/src/github.com/orbs-network/orbs-network-go/vendor/github.com/orbs-network/orbs-contract-sdk/go/
-ADD ./vendor/github.com/orbs-network/contract-external-libraries-go/ /go/src/github.com/orbs-network/orbs-network-go/vendor/github.com/orbs-network/contract-external-libraries-go/
 
 ADD ./_bin/gamma-server /opt/orbs/
 

--- a/docker/build/Dockerfile.gamma.experimental
+++ b/docker/build/Dockerfile.gamma.experimental
@@ -1,0 +1,3 @@
+FROM orbs:gamma-server
+
+ADD ./vendor/github.com/orbs-network/contract-external-libraries-go/ /go/src/github.com/orbs-network/orbs-network-go/vendor/github.com/orbs-network/contract-external-libraries-go/

--- a/docker/build/build.sh
+++ b/docker/build/build.sh
@@ -27,3 +27,10 @@ docker cp orbs_build:$SRC/_bin .
 docker build -f ./docker/build/Dockerfile.export -t orbs:export .
 docker build -f ./docker/build/Dockerfile.gamma -t orbs:gamma-server .
 docker build -f ./docker/build/Dockerfile.signer -t orbs:signer .
+
+# Builds experimental features (extra libraries)
+if [[ $CIRCLE_TAG != v* ]] ;
+then
+    docker build -f ./docker/build/Dockerfile.export.experimental -t orbs:export .
+    docker build -f ./docker/build/Dockerfile.gamma.experimental -t orbs:gamma-server .
+fi

--- a/services/processor/native/sanitize_code.go
+++ b/services/processor/native/sanitize_code.go
@@ -37,6 +37,10 @@ func SanitizerConfigForProduction() *sanitizer.SanitizerConfig {
 			`"github.com/orbs-network/orbs-contract-sdk/go/sdk/v1/service"`:  "SDK",
 			`"github.com/orbs-network/orbs-contract-sdk/go/sdk/v1/state"`:    "SDK",
 
+			// Contract external libraries
+			`"github.com/orbs-network/contract-external-libraries-go/v1/keys"`:    "Contract external libraries",
+			`"github.com/orbs-network/contract-external-libraries-go/v1/structs"`: "Contract external libraries",
+
 			// Text
 			`"strings"`:       "Text manipulation",
 			`"strconv"`:       "Text manipulation",


### PR DESCRIPTION
Following conversation with @OdedWx and @erankirsh:
- [x] struct serialization extracted to a separate repo: https://github.com/orbs-network/contract-external-libraries-go
- [x] added this repo as a dependency for **experimental** builds