### PR TITLE
Allow gamma to modify next block time

### DIFF
--- a/bootstrap/gamma/deploy_native_test.go
+++ b/bootstrap/gamma/deploy_native_test.go
@@ -22,7 +22,7 @@ import (
 func testDeployNativeContractWithConfig(jsonConfig string) func(t *testing.T) {
 	return func(t *testing.T) {
 		test.WithContext(func(ctx context.Context) {
-			network := NewDevelopmentNetwork(ctx, log.DefaultTestingLogger(t), jsonConfig)
+			network := NewDevelopmentNetwork(ctx, log.DefaultTestingLogger(t), nil, jsonConfig)
 			contract := callcontract.NewContractClient(network)
 
 			counterStart := contracts.MOCK_COUNTER_CONTRACT_START_FROM

--- a/bootstrap/gamma/development_network.go
+++ b/bootstrap/gamma/development_network.go
@@ -11,12 +11,13 @@ import (
 	"github.com/orbs-network/orbs-network-go/bootstrap/inmemory"
 	"github.com/orbs-network/orbs-network-go/config"
 	gossipAdapter "github.com/orbs-network/orbs-network-go/services/gossip/adapter/memory"
+	"github.com/orbs-network/orbs-network-go/services/transactionpool/adapter"
 	"github.com/orbs-network/orbs-network-go/test/crypto/keys"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/scribe/log"
 )
 
-func NewDevelopmentNetwork(ctx context.Context, logger log.Logger, overrideConfigJson string) *inmemory.Network {
+func NewDevelopmentNetwork(ctx context.Context, logger log.Logger, maybeClock adapter.Clock, overrideConfigJson string) *inmemory.Network {
 	numNodes := 5 // Comfortable number for LeanHelix if we choose to use it
 	logger.Info("creating development network")
 
@@ -45,7 +46,7 @@ func NewDevelopmentNetwork(ctx context.Context, logger log.Logger, overrideConfi
 		panic(err)
 	}
 
-	network := inmemory.NewNetworkWithNumOfNodes(validatorNodes, nodeOrder, privateKeys, logger, configWithOverrides, sharedTransport, nil)
+	network := inmemory.NewNetworkWithNumOfNodes(validatorNodes, nodeOrder, privateKeys, logger, configWithOverrides, sharedTransport, maybeClock, nil)
 	network.CreateAndStartNodes(ctx, numNodes)
 	return network
 }

--- a/bootstrap/gamma/e2e/gamma_e2e_test.go
+++ b/bootstrap/gamma/e2e/gamma_e2e_test.go
@@ -4,54 +4,25 @@
 // This source code is licensed under the MIT license found in the LICENSE file in the root directory of this source tree.
 // The above notice should be included in all copies or substantial portions of the software.
 
-package gamma
+package e2e
 
 import (
-	"encoding/json"
-	"flag"
 	"fmt"
 	"github.com/orbs-network/orbs-client-sdk-go/codec"
 	orbsClient "github.com/orbs-network/orbs-client-sdk-go/orbs"
+	"github.com/orbs-network/orbs-network-go/bootstrap/gamma"
 	"github.com/orbs-network/orbs-network-go/test"
-	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 )
 
-const WAIT_FOR_BLOCK_TIMEOUT = 10 * time.Second
-
-type metrics map[string]map[string]interface{}
-
-func waitForBlock(endpoint string, targetBlockHeight primitives.BlockHeight) func() bool {
-	return func() bool {
-		res, err := http.Get(endpoint + "/metrics")
-		if err != nil {
-			fmt.Println(err)
-			return false
-		}
-
-		readBytes, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			fmt.Println(err)
-			return false
-		}
-		m := make(metrics)
-		json.Unmarshal(readBytes, &m)
-
-		blockHeight := m["BlockStorage.BlockHeight"]["Value"].(float64)
-		return primitives.BlockHeight(blockHeight) >= targetBlockHeight
-	}
-}
-
 func testGammaWithJSONConfig(configJSON string) func(t *testing.T) {
 	return func(t *testing.T) {
 		randomPort := test.RandomPort()
-		runMain(t, randomPort, configJSON)
+		gamma.RunMain(t, randomPort, configJSON)
 		endpoint := fmt.Sprintf("http://0.0.0.0:%d", randomPort)
 
 		require.True(t, test.Eventually(WAIT_FOR_BLOCK_TIMEOUT, waitForBlock(endpoint, 1)))
@@ -73,18 +44,11 @@ func testGammaWithJSONConfig(configJSON string) func(t *testing.T) {
 func testGammaWithEmptyBlocks(configJSON string) func(t *testing.T) {
 	return func(t *testing.T) {
 		randomPort := test.RandomPort()
-		runMain(t, randomPort, configJSON)
+		gamma.RunMain(t, randomPort, configJSON)
 		endpoint := fmt.Sprintf("http://0.0.0.0:%d", randomPort)
 
 		require.True(t, test.Eventually(WAIT_FOR_BLOCK_TIMEOUT, waitForBlock(endpoint, 5)))
 	}
-}
-
-func runMain(t testing.TB, port int, overrideConfig string) {
-	require.NoError(t, flag.Set("override-config", overrideConfig))
-	require.NoError(t, flag.Set("port", strconv.Itoa(port)))
-
-	go Main()
 }
 
 func TestGamma(t *testing.T) {
@@ -107,7 +71,7 @@ func TestGammaWithEmptyBlocks(t *testing.T) {
 
 func TestGammaSetBlockTime(t *testing.T) {
 	randomPort := test.RandomPort()
-	runMain(t, randomPort, "")
+	gamma.RunMain(t, randomPort, "")
 	endpoint := fmt.Sprintf("http://0.0.0.0:%d", randomPort)
 
 	require.True(t, test.Eventually(WAIT_FOR_BLOCK_TIMEOUT, waitForBlock(endpoint, 1)))

--- a/bootstrap/gamma/e2e/harness.go
+++ b/bootstrap/gamma/e2e/harness.go
@@ -44,8 +44,9 @@ func waitForBlock(endpoint string, targetBlockHeight primitives.BlockHeight) fun
 func runGammaOnRandomPort(t testing.TB, overrideConfig string) string {
 	port := test.RandomPort()
 	endpoint := fmt.Sprintf("http://127.0.0.1:%d", port)
+	t.Log(t.Name(), "running Gamma at", endpoint)
 	gamma.RunMain(t, port, overrideConfig)
-	require.True(t, test.Eventually(WAIT_FOR_BLOCK_TIMEOUT, waitForBlock(endpoint, 1)))
+	require.True(t, test.Eventually(WAIT_FOR_BLOCK_TIMEOUT, waitForBlock(endpoint, 1)), "Gamma did not start ")
 
 	return endpoint
 }

--- a/bootstrap/gamma/e2e/harness.go
+++ b/bootstrap/gamma/e2e/harness.go
@@ -1,0 +1,67 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/orbs-network/orbs-client-sdk-go/codec"
+	orbsClient "github.com/orbs-network/orbs-client-sdk-go/orbs"
+	"github.com/orbs-network/orbs-spec/types/go/primitives"
+	"github.com/orbs-network/orbs-spec/types/go/protocol"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const WAIT_FOR_BLOCK_TIMEOUT = 10 * time.Second
+
+type metrics map[string]map[string]interface{}
+
+func waitForBlock(endpoint string, targetBlockHeight primitives.BlockHeight) func() bool {
+	return func() bool {
+		res, err := http.Get(endpoint + "/metrics")
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
+
+		readBytes, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
+		m := make(metrics)
+		json.Unmarshal(readBytes, &m)
+
+		blockHeight := m["BlockStorage.BlockHeight"]["Value"].(float64)
+		return primitives.BlockHeight(blockHeight) >= targetBlockHeight
+	}
+}
+
+func sendTransaction(t testing.TB, orbs *orbsClient.OrbsClient, sender *orbsClient.OrbsAccount, contractName string, method string, args ...interface{}) *codec.SendTransactionResponse {
+
+	tx, _, err := orbs.CreateTransaction(sender.PublicKey, sender.PrivateKey, contractName, method, args...)
+	require.NoError(t, err, "failed creating tx %s.%s", contractName, method)
+	res, err := orbs.SendTransaction(tx)
+	require.NoError(t, err, "failed sending tx %s.%s", contractName, method)
+	require.EqualValues(t, codec.TRANSACTION_STATUS_COMMITTED.String(), res.TransactionStatus.String(), "transaction to %s.%s not committed", contractName, method)
+	require.EqualValues(t, codec.EXECUTION_RESULT_SUCCESS.String(), res.ExecutionResult.String(), "transaction to %s.%s not successful", contractName, method)
+
+	return res
+}
+
+func deployContract(t *testing.T, orbs *orbsClient.OrbsClient, account *orbsClient.OrbsAccount, contractName string, code []byte) {
+	sendTransaction(t, orbs, account, "_Deployments", "deployService", "LogCalculator", uint32(protocol.PROCESSOR_TYPE_NATIVE), []byte(code))
+}
+
+func sendQuery(t testing.TB, orbs *orbsClient.OrbsClient, sender *orbsClient.OrbsAccount, contractName string, method string, args ...interface{}) *codec.RunQueryResponse {
+	q, err := orbs.CreateQuery(sender.PublicKey, contractName, method, args...)
+	require.NoError(t, err, "failed creating query %s.%s", contractName, method)
+	res, err := orbs.SendQuery(q)
+	require.NoError(t, err, "failed sending query %s.%s", contractName, method)
+	require.EqualValues(t, codec.REQUEST_STATUS_COMPLETED.String(), res.RequestStatus.String(), "failed calling %s.%s", contractName, method)
+	require.EqualValues(t, codec.EXECUTION_RESULT_SUCCESS.String(), res.ExecutionResult.String(), "failed calling %s.%s", contractName, method)
+
+	return res
+}

--- a/bootstrap/gamma/gamma_e2e_test.go
+++ b/bootstrap/gamma/gamma_e2e_test.go
@@ -120,11 +120,12 @@ func TestGammaSetBlockTime(t *testing.T) {
 	transferTo, _ := orbsClient.CreateAccount()
 	client := orbsClient.NewClient(endpoint, 42, codec.NETWORK_TYPE_TEST_NET)
 
+	desiredTime := time.Now().Add(10 * time.Second)
 	payload, _, err := client.CreateTransaction(sender.PublicKey, sender.PrivateKey, "BenchmarkToken", "transfer", uint64(671), transferTo.AddressAsBytes())
 	require.NoError(t, err)
 	response, err := client.SendTransaction(payload)
 	require.NoError(t, err)
 
 	require.Equal(t, codec.EXECUTION_RESULT_SUCCESS, response.ExecutionResult)
-	require.True(t, response.BlockTimestamp.After(time.Now().Add(10*time.Second)), "new block time did not reflect added seconds")
+	require.WithinDuration(t, desiredTime, response.BlockTimestamp, 1*time.Second, "new block time did not increase") // we check within a delta to prevent flakiness
 }

--- a/bootstrap/gamma/server_handlers.go
+++ b/bootstrap/gamma/server_handlers.go
@@ -7,6 +7,7 @@ import (
 
 func (s *GammaServer) addGammaHandlers(router *http.ServeMux) {
 	router.HandleFunc("/debug/gamma/shutdown", s.shutdownHandler)
+	router.HandleFunc("/debug/gamma/inc-time", s.incrementTime)
 }
 
 func (s *GammaServer) shutdownHandler(writer http.ResponseWriter, request *http.Request) {
@@ -18,4 +19,23 @@ func (s *GammaServer) shutdownHandler(writer http.ResponseWriter, request *http.
 	writer.Write([]byte(`{"status":"shutting down"}`))
 
 	s.GracefulShutdown(1 * time.Second)
+}
+
+func (s *GammaServer) incrementTime(writer http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodPost {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := request.ParseForm(); err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	seconds := request.Form.Get("seconds-to-add")
+	if seconds == "" {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 }

--- a/bootstrap/gamma/server_handlers.go
+++ b/bootstrap/gamma/server_handlers.go
@@ -2,6 +2,7 @@ package gamma
 
 import (
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -32,10 +33,18 @@ func (s *GammaServer) incrementTime(writer http.ResponseWriter, request *http.Re
 		return
 	}
 
-	seconds := request.Form.Get("seconds-to-add")
-	if seconds == "" {
+	secondsParam := request.Form.Get("seconds-to-add")
+	if secondsParam == "" {
 		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}
+
+	seconds, err := strconv.Atoi(secondsParam)
+	if err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	s.clock.AddSeconds(seconds)
 
 }

--- a/bootstrap/gamma/simple_transfer_test.go
+++ b/bootstrap/gamma/simple_transfer_test.go
@@ -21,7 +21,7 @@ import (
 func testSimpleTransfer(jsonConfig string) func(t *testing.T) {
 	return func(t *testing.T) {
 		test.WithContext(func(ctx context.Context) {
-			network := NewDevelopmentNetwork(ctx, log.DefaultTestingLogger(t), jsonConfig)
+			network := NewDevelopmentNetwork(ctx, log.DefaultTestingLogger(t), nil, jsonConfig)
 			contract := callcontract.NewContractClient(network)
 
 			t.Log("doing a simple transfer")

--- a/bootstrap/gamma/test_kit.go
+++ b/bootstrap/gamma/test_kit.go
@@ -1,0 +1,15 @@
+package gamma
+
+import (
+	"flag"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+)
+
+func RunMain(t testing.TB, port int, overrideConfig string) {
+	require.NoError(t, flag.Set("override-config", overrideConfig))
+	require.NoError(t, flag.Set("port", strconv.Itoa(port)))
+
+	go Main()
+}

--- a/bootstrap/node.go
+++ b/bootstrap/node.go
@@ -19,6 +19,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter/tcp"
 	nativeProcessorAdapter "github.com/orbs-network/orbs-network-go/services/processor/native/adapter"
 	stateStorageAdapter "github.com/orbs-network/orbs-network-go/services/statestorage/adapter/memory"
+	txPoolAdapter "github.com/orbs-network/orbs-network-go/services/transactionpool/adapter"
 	"github.com/orbs-network/scribe/log"
 )
 
@@ -54,7 +55,7 @@ func NewNode(nodeConfig config.NodeConfig, logger log.Logger) Node {
 	statePersistence := stateStorageAdapter.NewStatePersistence(metricRegistry)
 	ethereumConnection := ethereumAdapter.NewEthereumRpcConnection(nodeConfig, logger)
 	nativeCompiler := nativeProcessorAdapter.NewNativeCompiler(nodeConfig, nodeLogger, metricRegistry)
-	nodeLogic := NewNodeLogic(ctx, transport, blockPersistence, statePersistence, nil, nil, nativeCompiler, nodeLogger, metricRegistry, nodeConfig, ethereumConnection)
+	nodeLogic := NewNodeLogic(ctx, transport, blockPersistence, statePersistence, nil, nil, txPoolAdapter.NewSystemClock(), nativeCompiler, nodeLogger, metricRegistry, nodeConfig, ethereumConnection)
 	httpServer := httpserver.NewHttpServer(nodeConfig, nodeLogger, nodeLogic.PublicApi(), metricRegistry)
 
 	return &node{

--- a/bootstrap/node_logic.go
+++ b/bootstrap/node_logic.go
@@ -28,6 +28,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/services/statestorage"
 	stateStorageAdapter "github.com/orbs-network/orbs-network-go/services/statestorage/adapter"
 	"github.com/orbs-network/orbs-network-go/services/transactionpool"
+	txPoolAdapter "github.com/orbs-network/orbs-network-go/services/transactionpool/adapter"
 	"github.com/orbs-network/orbs-network-go/services/virtualmachine"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/services"
@@ -51,6 +52,7 @@ func NewNodeLogic(
 	statePersistence stateStorageAdapter.StatePersistence,
 	stateBlockHeightReporter stateStorageAdapter.BlockHeightReporter,
 	transactionPoolBlockHeightReporter transactionpool.BlockHeightReporter,
+	maybeClock txPoolAdapter.Clock,
 	nativeCompiler nativeProcessorAdapter.Compiler,
 	logger log.Logger,
 	metricRegistry metric.Registry,
@@ -74,7 +76,7 @@ func NewNodeLogic(
 	gossipService := gossip.NewGossip(ctx, gossipTransport, nodeConfig, logger, metricRegistry)
 	stateStorageService := statestorage.NewStateStorage(nodeConfig, statePersistence, stateBlockHeightReporter, logger, metricRegistry)
 	virtualMachineService := virtualmachine.NewVirtualMachine(stateStorageService, processors, crosschainConnectors, logger)
-	transactionPoolService := transactionpool.NewTransactionPool(ctx, gossipService, virtualMachineService, signer, transactionPoolBlockHeightReporter, nodeConfig, logger, metricRegistry)
+	transactionPoolService := transactionpool.NewTransactionPool(ctx, maybeClock, gossipService, virtualMachineService, signer, transactionPoolBlockHeightReporter, nodeConfig, logger, metricRegistry)
 	serviceSyncCommitters := []servicesync.BlockPairCommitter{servicesync.NewStateStorageCommitter(stateStorageService), servicesync.NewTxPoolCommitter(transactionPoolService)}
 	blockStorageService := blockstorage.NewBlockStorage(ctx, nodeConfig, blockPersistence, gossipService, logger, metricRegistry, serviceSyncCommitters)
 	publicApiService := publicapi.NewPublicApi(nodeConfig, transactionPoolService, virtualMachineService, blockStorageService, logger, metricRegistry)

--- a/config/system_factory_presets.go
+++ b/config/system_factory_presets.go
@@ -7,6 +7,7 @@
 package config
 
 import (
+	"fmt"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
 	"path/filepath"
@@ -247,5 +248,8 @@ func TemplateForGamma(
 	cfg.SetGenesisValidatorNodes(genesisValidatorNodes)
 	cfg.SetBenchmarkConsensusConstantLeader(constantConsensusLeader)
 	cfg.SetActiveConsensusAlgo(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS)
+
+	cfg.SetString(PROCESSOR_ARTIFACT_PATH, filepath.Join(GetProjectSourceTmpPath(), "processor-artifacts", fmt.Sprintf("%d", time.Now().Unix())))
+
 	return cfg
 }

--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   ganache:
     image: trufflesuite/ganache-cli
-    command: ganache-cli --gasLimit 90000000000 --gasPrice 1 -a 10 -m "vanish junk genuine web seminar cook absurd royal ability series taste method identify elevator liquid" -t $GANACHE_START_TIME
+    command: ganache-cli --gasLimit 90000000000 --gasPrice 1 -a 10 -m "vanish junk genuine web seminar cook absurd royal ability series taste method identify elevator liquid"
     networks:
       orbs-network:
         ipv4_address: 192.168.199.6

--- a/docker/test/test.sh
+++ b/docker/test/test.sh
@@ -19,5 +19,4 @@ cp ./test/e2e/_data/blocks _tmp/blocks/node3
 cp ./test/e2e/_data/blocks _tmp/blocks/node4
 
 # run docker-reliant tests
-export GANACHE_START_TIME=$(node -e "console.log(new Date(new Date() - 1000 * 60 * 25))")
 docker-compose -f ./docker/test/docker-compose.yml up --abort-on-container-exit --exit-code-from orbs-e2e

--- a/services/consensusalgo/leanhelixconsensus/election_trigger.go
+++ b/services/consensusalgo/leanhelixconsensus/election_trigger.go
@@ -45,7 +45,11 @@ func (e *exponentialBackoffElectionTrigger) RegisterOnElection(ctx context.Conte
 		e.view = view
 		e.blockHeight = blockHeight
 		e.Stop()
-		e.triggerTimer = time.AfterFunc(timeout, e.sendTrigger)
+		e.triggerTimer = time.AfterFunc(timeout, func() {
+			if ctx.Err() == nil { // only send trigger if system is not shutting down TODO delete this code when lean helix refactor is done
+				e.sendTrigger()
+			}
+		})
 		if e.view > 2 {
 			e.logger.Info("Started election trigger", log.Uint64("block-height", uint64(e.blockHeight)), log.Uint64("lh-view", uint64(e.view)), log.String("lh-election-timeout", timeout.String()))
 		}

--- a/services/crosschainconnector/ethereum/test/config.go
+++ b/services/crosschainconnector/ethereum/test/config.go
@@ -66,5 +66,5 @@ func ConfigForExternalRPCConnection() *ethereumConnectorConfigForTests {
 }
 
 func runningWithDocker() bool {
-	return os.Getenv("EXTERNAL_TEST") == "true"
+	return os.Getenv("ETHEREUM_ENDPOINT") != ""
 }

--- a/services/crosschainconnector/ethereum/test/external_block_timestamp_test.go
+++ b/services/crosschainconnector/ethereum/test/external_block_timestamp_test.go
@@ -33,8 +33,8 @@ func TestFullFlowWithVaryingTimestamps(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		h := newRpcEthereumConnectorHarness(t, ConfigForExternalRPCConnection())
 
-		// create first block in case we are running only this test (clean ganache, but no real hard in actual)
-		h.moveBlocksInGanache(t, 1, 1)
+		// pad Ganache nicely so that any previous test
+		h.moveBlocksInGanache(t, 100, 1)
 		blockAtStart, err := h.rpcAdapter.HeaderByNumber(ctx, nil)
 		require.NoError(t, err, "failed to get latest block in ganache")
 		t.Logf("block at start: %d | %d", blockAtStart.Number.Int64(), blockAtStart.Time.Int64())

--- a/services/crosschainconnector/ethereum/test/harness.go
+++ b/services/crosschainconnector/ethereum/test/harness.go
@@ -60,7 +60,7 @@ func (h *harness) deployRpcStorageContract(text string) (string, error) {
 	return hexutil.Encode(address[:]), nil
 }
 
-func (h *harness) moveBlocksInGanache(t *testing.T, count int, blockGapInSeconds int) error {
+func (h *harness) moveBlocksInGanache(t *testing.T, count int, blockGapInSeconds int) {
 	c, err := rpc.Dial(h.config.endpoint)
 	require.NoError(t, err, "failed creating Ethereum rpc client")
 	//start := time.Now()
@@ -69,7 +69,6 @@ func (h *harness) moveBlocksInGanache(t *testing.T, count int, blockGapInSeconds
 		require.NoError(t, c.Call(struct{}{}, "evm_mine"), "failed increasing time")
 	}
 
-	return nil
 }
 
 func newRpcEthereumConnectorHarness(tb testing.TB, cfg *ethereumConnectorConfigForTests) *harness {

--- a/services/crosschainconnector/ethereum/timestampfinder/finder_algo.go
+++ b/services/crosschainconnector/ethereum/timestampfinder/finder_algo.go
@@ -54,7 +54,7 @@ func algoExtendAbove(ctx context.Context, referenceTimestampNano primitives.Time
 		return nil, errors.New("ethereum timestamp finder received nil as latest block from getter")
 	}
 	if referenceTimestampNano >= latest.BlockTimeNano {
-		return nil, errors.Errorf("the latest ethereum block %d at %d is not newer than the reference timestamp %d", latest.BlockNumber, latest.BlockTimeNano, referenceTimestampNano)
+		return nil, errors.Errorf("the latest ethereum block %d at %d is not newer than the reference timestamp %d; delta is %d", latest.BlockNumber, latest.BlockTimeNano, referenceTimestampNano, referenceTimestampNano-latest.BlockTimeNano)
 	}
 	return latest, nil
 }

--- a/services/transactionpool/adapter/clock.go
+++ b/services/transactionpool/adapter/clock.go
@@ -1,0 +1,33 @@
+package adapter
+
+import "time"
+
+type Clock interface {
+	CurrentTime() time.Time
+}
+
+type systemClock struct{}
+
+func NewSystemClock() *systemClock {
+	return &systemClock{}
+}
+
+func (*systemClock) CurrentTime() time.Time {
+	return time.Now()
+}
+
+type AdjustableClock struct {
+	delta time.Duration
+}
+
+func (c *AdjustableClock) CurrentTime() time.Time {
+	return time.Now().Add(c.delta)
+}
+
+func (c *AdjustableClock) AddSeconds(delta int) {
+	c.delta += time.Duration(delta) * time.Second
+}
+
+func NewAdjustableClock() *AdjustableClock {
+	return &AdjustableClock{}
+}

--- a/services/transactionpool/get_transactions_for_ordering.go
+++ b/services/transactionpool/get_transactions_for_ordering.go
@@ -16,7 +16,6 @@ import (
 	"github.com/orbs-network/orbs-spec/types/go/services"
 	"github.com/orbs-network/scribe/log"
 	"github.com/pkg/errors"
-	"time"
 )
 
 type rejectedTransaction struct {
@@ -89,7 +88,7 @@ func (s *service) GetTransactionsForOrdering(ctx context.Context, input *service
 	if input.CurrentBlockHeight == 1 {
 		return &services.GetTransactionsForOrderingOutput{
 			SignedTransactions:     nil,
-			ProposedBlockTimestamp: proposeBlockTimestampWithCurrentTime(input.PrevBlockTimestamp),
+			ProposedBlockTimestamp: s.proposeBlockTimestampWithCurrentTime(input.PrevBlockTimestamp),
 		}, nil
 	}
 
@@ -118,14 +117,14 @@ func (s *service) GetTransactionsForOrdering(ctx context.Context, input *service
 		return batch, batch.runPreOrderValidations(ctx, pov, input.CurrentBlockHeight, proposedBlockTimestamp)
 	}
 
-	proposedBlockTimestamp := proposeBlockTimestampWithCurrentTime(input.PrevBlockTimestamp)
+	proposedBlockTimestamp := s.proposeBlockTimestampWithCurrentTime(input.PrevBlockTimestamp)
 	batch, err := runBatch(proposedBlockTimestamp)
 	for !batch.hasEnoughTransactions(1) && timeoutCtx.Err() == nil {
 		logger.Info("not enough transactions in batch, waiting for more")
 		if s.transactionWaiter.waitForIncomingTransaction(timeoutCtx) {
 			logger.Info("got a new transaction, re-running batch")
 			// propose a new time since we've been waiting
-			proposedBlockTimestamp = proposeBlockTimestampWithCurrentTime(input.PrevBlockTimestamp)
+			proposedBlockTimestamp = s.proposeBlockTimestampWithCurrentTime(input.PrevBlockTimestamp)
 			batch, err = runBatch(proposedBlockTimestamp)
 		}
 	}
@@ -141,8 +140,8 @@ func (s *service) GetTransactionsForOrdering(ctx context.Context, input *service
 	return out, err
 }
 
-func proposeBlockTimestampWithCurrentTime(prevBlockTimestamp primitives.TimestampNano) primitives.TimestampNano {
-	return digest.CalcNewBlockTimestamp(prevBlockTimestamp, primitives.TimestampNano(time.Now().UnixNano()))
+func (s *service) proposeBlockTimestampWithCurrentTime(prevBlockTimestamp primitives.TimestampNano) primitives.TimestampNano {
+	return digest.CalcNewBlockTimestamp(prevBlockTimestamp, primitives.TimestampNano(s.clock.CurrentTime().UnixNano()))
 }
 
 func (r *transactionBatch) filterInvalidTransactions(ctx context.Context, validator batchValidator, committedTransactions committedTransactionChecker, proposedBlockTimestamp primitives.TimestampNano) {

--- a/services/transactionpool/service.go
+++ b/services/transactionpool/service.go
@@ -9,6 +9,7 @@ package transactionpool
 import (
 	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
+	"github.com/orbs-network/orbs-network-go/services/transactionpool/adapter"
 	"github.com/orbs-network/orbs-network-go/synchronization"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/services"
@@ -25,6 +26,7 @@ type BlockHeightReporter interface {
 }
 
 type service struct {
+	clock                      adapter.Clock
 	gossip                     gossiptopics.TransactionRelay
 	virtualMachine             services.VirtualMachine
 	blockHeightReporter        BlockHeightReporter // used to allow test to wait for a block height to reach the transaction pool

--- a/services/transactionpool/test/harness.go
+++ b/services/transactionpool/test/harness.go
@@ -16,6 +16,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/crypto/signer"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	"github.com/orbs-network/orbs-network-go/services/transactionpool"
+	"github.com/orbs-network/orbs-network-go/services/transactionpool/adapter"
 	testKeys "github.com/orbs-network/orbs-network-go/test/crypto/keys"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol"
@@ -232,7 +233,7 @@ func (h *harness) getTxReceipt(ctx context.Context, tx *protocol.SignedTransacti
 }
 
 func (h *harness) start(ctx context.Context) *harness {
-	service := transactionpool.NewTransactionPool(ctx, h.gossip, h.vm, h.signer, nil, h.config, h.logger, metric.NewRegistry())
+	service := transactionpool.NewTransactionPool(ctx, adapter.NewSystemClock(), h.gossip, h.vm, h.signer, nil, h.config, h.logger, metric.NewRegistry())
 	service.RegisterTransactionResultsHandler(h.trh)
 	h.txpool = service
 	h.fastForwardTo(ctx, 1)

--- a/test.adapters.sh
+++ b/test.adapters.sh
@@ -1,13 +1,13 @@
 #!/bin/sh -xe
 
-for pkg in $(find . -type d -name e2e | grep -v vendor); do
+for pkg in $(find . -type d -name e2e | grep -v vendor | grep -v ".git"); do
     time go test $pkg -v
 done
 
-for pkg in $(find . -type d -name adapter | grep -v vendor); do
+for pkg in $(find . -type d -name adapter | grep -v vendor | grep -v ".git"); do
     time go test $pkg -v
 done
 
-for pkg in $(find . -type d -name ethereum | grep -v vendor); do
+for pkg in $(find . -type d -name ethereum | grep -v vendor | grep -v ".git"); do
     time go test "$pkg/..." -v
 done

--- a/test/acceptance/network_harness.go
+++ b/test/acceptance/network_harness.go
@@ -125,7 +125,7 @@ func newAcceptanceTestNetwork(ctx context.Context, testLogger log.Logger, consen
 	}
 
 	harness := &NetworkHarness{
-		Network:                            *inmemory.NewNetworkWithNumOfNodes(genesisValidatorNodes, nodeOrder, privateKeys, testLogger, cfgTemplate, sharedTamperingTransport, provider),
+		Network:                            *inmemory.NewNetworkWithNumOfNodes(genesisValidatorNodes, nodeOrder, privateKeys, testLogger, cfgTemplate, sharedTamperingTransport, nil, provider),
 		tamperingTransport:                 sharedTamperingTransport,
 		ethereumConnection:                 sharedEthereumSimulator,
 		fakeCompiler:                       sharedCompiler,


### PR DESCRIPTION
Added a new handler to gamma, `/debug/gamma/inc-time?seconds-to-add=n`, that adds a delta to the time of subsequent blocks.

This, on conjunction with Ganache's inc-time function, should allow us to not sleep in finality-sensitive integrative tests