### PR TITLE
fix bug. get block by time dont use getfinality 

### DIFF
--- a/services/crosschainconnector/ethereum/service.go
+++ b/services/crosschainconnector/ethereum/service.go
@@ -190,7 +190,7 @@ func (s *service) EthereumGetBlockNumber(ctx context.Context, input *services.Et
 }
 
 func (s *service) EthereumGetBlockNumberByTime(ctx context.Context, input *services.EthereumGetBlockNumberByTimeInput) (*services.EthereumGetBlockNumberByTimeOutput, error) {
-	blockNumberAndTime, err := s.getFinalitySafeBlockNumber(ctx, input.EthereumTimestamp)
+	blockNumberAndTime, err := s.timestampFinder.FindBlockByTimestamp(ctx, input.EthereumTimestamp)
 	if err != nil {
 		return nil, err
 	}

--- a/services/crosschainconnector/ethereum/test/config.go
+++ b/services/crosschainconnector/ethereum/test/config.go
@@ -43,8 +43,8 @@ func (c *ethereumConnectorConfigForTests) GetAuthFromConfig() (*bind.TransactOpt
 
 func ConfigForSimulatorConnection() *ethereumConnectorConfigForTests {
 	return &ethereumConnectorConfigForTests{
-		finalityTimeComponent:   0 * time.Millisecond,
-		finalityBlocksComponent: 0,
+		finalityTimeComponent:   100 * time.Millisecond,
+		finalityBlocksComponent: 3,
 	}
 }
 

--- a/services/crosschainconnector/ethereum/test/harness.go
+++ b/services/crosschainconnector/ethereum/test/harness.go
@@ -109,25 +109,3 @@ func (h *harness) packInputArgumentsForSampleStorage(method string, args []inter
 		return ethereum.ABIPackFunctionInputArguments(parsedABI, method, args)
 	}
 }
-
-//type mockFinality struct {
-//	mock.Mock
-//}
-//
-//func (s *mockFinality) GetFinalitySafeBlockNumber(ctx context.Context, referenceTimestampNano primitives.TimestampNano) (*timestampfinder.BlockNumberAndTime, error) {
-//	ret := s.Called(ctx, referenceTimestampNano)
-//	if out := ret.Get(0); out != nil {
-//		return out.(*timestampfinder.BlockNumberAndTime), ret.Error(1)
-//	} else {
-//		return nil, ret.Error(1)
-//	}
-//}
-//
-//func (s *mockFinality) VerifyBlockNumberIsFinalitySafe(ctx context.Context, blockNumber uint64, referenceTimestamp primitives.TimestampNano) error {
-//	ret := s.Called(ctx, blockNumber, referenceTimestamp)
-//	if out := ret.Get(0); out != nil {
-//		return ret.Error(1)
-//	} else {
-//		return ret.Error(1)
-//	}
-//}


### PR DESCRIPTION
## Description
fix issue with getblocknumberbytime -> it should not used getfinality to find block number.
used the getbytimestamp
then just verifies that the found block is past finality.
