### PR TITLE
Refactor/Rename DirectTransport mutexes

### DIFF
--- a/services/gossip/adapter/tcp/direct_harness.go
+++ b/services/gossip/adapter/tcp/direct_harness.go
@@ -60,7 +60,7 @@ func newDirectHarnessWithConnectedPeersWithTimeouts(t *testing.T, ctx context.Co
 	transport := makeTransport(ctx, t, cfg)                                               // step 3: create the transport; it will attempt to establish connections with the peer servers repeatedly until they start accepting connections
 	// end of section where order matters
 
-	peerTalkerConnection := establishPeerClient(t, transport.serverPort)           // establish connection from test to server port ( test harness ==> SUT )
+	peerTalkerConnection := establishPeerClient(t, transport.GetServerPort())      // establish connection from test to server port ( test harness ==> SUT )
 	peersListenersConnections := establishPeerServerConnections(t, peersListeners) // establish connection from transport clients to peer servers ( SUT ==> test harness)
 
 	h := &directHarness{
@@ -187,15 +187,7 @@ func (h *directHarness) verifyTransportListenerNotCalled(t *testing.T) {
 }
 
 func (h *directHarness) allOutgoingQueuesEnabled() bool {
-	h.transport.mutex.RLock()
-	defer h.transport.mutex.RUnlock()
-
-	for _, queue := range h.transport.outgoingPeerQueues {
-		if queue.disabled {
-			return false
-		}
-	}
-	return true
+	return h.transport.allOutgoingQueuesEnabled()
 }
 
 func concatSlices(slices ...[]byte) []byte {

--- a/services/gossip/adapter/tcp/direct_incoming_test.go
+++ b/services/gossip/adapter/tcp/direct_incoming_test.go
@@ -19,7 +19,7 @@ func TestDirectIncoming_ConnectionsAreListenedToWhileContextIsLive(t *testing.T)
 	ctx, cancel := context.WithCancel(context.Background())
 	h := newDirectHarnessWithConnectedPeers(t, ctx)
 
-	connection, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", h.transport.serverPort))
+	connection, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", h.transport.GetServerPort()))
 	require.NoError(t, err, "test peer should be able connect to local transport")
 	defer connection.Close()
 
@@ -31,7 +31,7 @@ func TestDirectIncoming_ConnectionsAreListenedToWhileContextIsLive(t *testing.T)
 	require.Error(t, err, "test peer should disconnect from local transport")
 
 	eventuallyFailsConnecting := test.Eventually(test.EVENTUALLY_ADAPTER_TIMEOUT, func() bool {
-		connection, err = net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", h.transport.serverPort))
+		connection, err = net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", h.transport.GetServerPort()))
 		if err != nil {
 			return true
 		} else {

--- a/services/gossip/adapter/tcp/direct_transport_test.go
+++ b/services/gossip/adapter/tcp/direct_transport_test.go
@@ -52,11 +52,11 @@ func TestDirectTransport_SupportsAddingPeersInRuntime(t *testing.T) {
 			return node1.IsServerListening() && node2.IsServerListening()
 		}), "server did not start")
 
-		node1.AddPeer(ctx, address2, config.NewHardCodedGossipPeer(node2.serverPort, "127.0.0.1"))
-		node2.AddPeer(ctx, address1, config.NewHardCodedGossipPeer(node1.serverPort, "127.0.0.1"))
+		node1.AddPeer(ctx, address2, config.NewHardCodedGossipPeer(node2.GetServerPort(), "127.0.0.1"))
+		node2.AddPeer(ctx, address1, config.NewHardCodedGossipPeer(node1.GetServerPort(), "127.0.0.1"))
 
 		require.True(t, test.Eventually(HARNESS_OUTGOING_CONNECTIONS_INIT_TIMEOUT, func() bool {
-			return node1.safeLenOfOutgoingPeerQueues() > 0 && node2.safeLenOfOutgoingPeerQueues() > 0
+			return len(node1.outgoingQueues.peers) > 0 && len(node2.outgoingQueues.peers) > 0
 		}), "expected all outgoing queues to become enabled after successfully connecting to added peers")
 
 		header := (&gossipmessages.HeaderBuilder{

--- a/services/gossip/adapter/test/transport_contract_test.go
+++ b/services/gossip/adapter/test/transport_contract_test.go
@@ -155,7 +155,7 @@ func aDirectTransport(ctx context.Context, tb testing.TB) *transportContractCont
 	for _, t1 := range transports {
 		for i, t2 := range transports {
 			if t1 != t2 {
-				t1.AddPeer(ctx, res.nodeAddresses[i], config.NewHardCodedGossipPeer(t2.Port(), "127.0.0.1"))
+				t1.AddPeer(ctx, res.nodeAddresses[i], config.NewHardCodedGossipPeer(t2.GetServerPort(), "127.0.0.1"))
 			}
 		}
 	}


### PR DESCRIPTION
## Description

A previous PR (#1232) expanded the scope of DirectTransport mutex to protect against concurrent access to the outgoing message queue by peer map (`outgoingPeerQueues`).

The current PR adds a dedicated mutex for controlling access to outgoing queues map, and re-organizes the items under each mutex in a separate struct type. the new types are `lockableOutgoingQueues` and `lockableTransportServer`.

In addition to some renaming I also removed the locking of the server mutex in some cases where I coulf not find a good reason for the lock. for instance, around calls to `connect()` (not renamed to `connectForever()` to expose the fact that it launches a listener using `GoForever()`)   

Points to notice in review:
1. Cases where I removed locking of `mutex` without replacing it with any other lock
1. `connectForever()`'s anonymous client-main-loop function is now not accessing the outgoing queues map anymore. This is done to avoid the need to obtain a lock inside the anonymous function every time it is launched. which means that if the queue object is ever changed the client loop will never pick up on it. 