### PR TITLE
Skip a flaky test for Lean Helix's Leader Election Trigger

### DIFF
--- a/services/consensusalgo/leanhelixconsensus/election_trigger_test.go
+++ b/services/consensusalgo/leanhelixconsensus/election_trigger_test.go
@@ -66,6 +66,7 @@ func TestCallbackTriggerOnce(t *testing.T) {
 }
 
 func TestCallbackTriggerTwiceInARow(t *testing.T) {
+	t.Skip("Remove this entirely, when all code copied to LH. This code+tests are redundant")
 	test.WithContext(func(ctx context.Context) {
 		et := buildElectionTrigger(ctx, t, time.Millisecond)
 


### PR DESCRIPTION
## Description

Code for Lean Helix's Leader Election Trigger will soon be moved from `orbs-network-go` into `lean-helix-go`, along with its tests.
The specific test that is being skipped now is flaky because it uses timers. In addition it tests code that is obsolete and planned to be deleted once the new goroutine model in Lean Helix will be used by orbs-network-go.
 
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

