### PR TITLE
Added new metrics per outgoing TCP connection

### DIFF
--- a/instrumentation/metric/registry.go
+++ b/instrumentation/metric/registry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/synchronization"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/scribe/log"
+	"github.com/pkg/errors"
 	"strconv"
 	"strings"
 	"sync"
@@ -76,6 +77,13 @@ type inMemoryRegistry struct {
 func (r *inMemoryRegistry) register(m metric) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	for _, existing := range r.mu.metrics {
+		if existing.Name() == m.Name() {
+			err := errors.Errorf("a metric with name %s is already registered", m.Name())
+			panic(err)
+		}
+	}
+
 	r.mu.metrics = append(r.mu.metrics, m)
 }
 

--- a/services/crosschainconnector/ethereum/timestampfinder/timestamp_finder_test.go
+++ b/services/crosschainconnector/ethereum/timestampfinder/timestamp_finder_test.go
@@ -19,23 +19,20 @@ import (
 )
 
 type harness struct {
-	btg     BlockTimeGetter
-	logger  log.Logger
-	metrics metric.Factory
-	finder  *finder
+	btg    BlockTimeGetter
+	logger log.Logger
+	finder *finder
 }
 
 func NewTestHarness(t testing.TB) *harness {
 	logger := log.DefaultTestingLogger(t)
 	btg := NewFakeBlockTimeGetter(logger)
-	metricFactory := metric.NewRegistry()
-	finder := NewTimestampFinder(btg, logger, metricFactory)
+	finder := NewTimestampFinder(btg, logger, metric.NewRegistry())
 
 	h := &harness{
-		btg:     btg,
-		finder:  finder,
-		logger:  logger,
-		metrics: metricFactory,
+		btg:    btg,
+		finder: finder,
+		logger: logger,
 	}
 
 	return h
@@ -48,7 +45,7 @@ func (h *harness) GetBtgAsFake() *FakeBlockTimeGetter {
 
 func (h *harness) WithBtg(btg BlockTimeGetter) *harness {
 	h.btg = btg
-	finder := NewTimestampFinder(btg, h.logger, h.metrics)
+	finder := NewTimestampFinder(btg, h.logger, metric.NewRegistry())
 	h.finder = finder
 	return h
 }

--- a/services/gossip/adapter/tcp/direct_outgoing.go
+++ b/services/gossip/adapter/tcp/direct_outgoing.go
@@ -57,7 +57,8 @@ func (t *DirectTransport) clientHandleOutgoingConnection(ctx context.Context, co
 			// meaning do a regular send (we have data)
 			err := t.sendTransportData(ctx, conn, data)
 			if err != nil {
-				t.metrics.outgoingConnectionSendErrors.Inc()
+				t.metrics.outgoingConnectionSendErrors.Inc() //TODO remove, replaced by following metric
+				queue.sendErrors.Inc()
 				t.logger.Info("failed sending transport data, reconnecting", log.Error(err), log.String("peer", queue.networkAddress), trace.LogFieldFrom(ctx))
 				conn.Close()
 				return true
@@ -93,7 +94,8 @@ func (t *DirectTransport) clientHandleOutgoingConnection(ctx context.Context, co
 func (t *DirectTransport) addDataToOutgoingPeerQueue(data *adapter.TransportData, outgoingQueue *transportQueue) {
 	err := outgoingQueue.Push(data)
 	if err != nil {
-		t.metrics.outgoingConnectionSendQueueErrors.Inc()
+		t.metrics.outgoingConnectionSendQueueErrors.Inc() //TODO remove, replaced by following metric
+		outgoingQueue.sendQueueErrors.Inc()
 		t.logger.Info("direct transport send queue error", log.Error(err), log.String("peer", outgoingQueue.networkAddress))
 	}
 	t.metrics.outgoingMessageSize.Record(int64(data.TotalSize()))

--- a/services/gossip/adapter/tcp/direct_transport.go
+++ b/services/gossip/adapter/tcp/direct_transport.go
@@ -126,7 +126,7 @@ func (t *DirectTransport) connectForever(bgCtx context.Context, peerNodeAddress 
 
 	if peerNodeAddress != t.config.NodeAddress().KeyForMap() {
 
-		newQueue := NewTransportQueue(SEND_QUEUE_MAX_BYTES, SEND_QUEUE_MAX_MESSAGES, t.metricRegistry)
+		newQueue := NewTransportQueue(SEND_QUEUE_MAX_BYTES, SEND_QUEUE_MAX_MESSAGES, t.metricRegistry, peerNodeAddress)
 
 		peerAddress := fmt.Sprintf("%s:%d", peer.GossipEndpoint(), peer.GossipPort())
 		newQueue.networkAddress = peerAddress

--- a/services/gossip/adapter/tcp/queue_test.go
+++ b/services/gossip/adapter/tcp/queue_test.go
@@ -16,9 +16,11 @@ import (
 	"time"
 )
 
+const someAddress = ""
+
 func TestQueue_PushAndPopMultiple(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		q := NewTransportQueue(1000, 1000, metric.NewRegistry())
+		q := NewTransportQueue(1000, 1000, metric.NewRegistry(), someAddress)
 
 		err := q.Push(&adapter.TransportData{SenderNodeAddress: []byte{0x01}})
 		require.NoError(t, err)
@@ -42,7 +44,7 @@ func TestQueue_PushAndPopMultiple(t *testing.T) {
 
 func TestQueue_CannotPushMoreThanMaxMessages(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		q := NewTransportQueue(1000, 2, metric.NewRegistry())
+		q := NewTransportQueue(1000, 2, metric.NewRegistry(), someAddress)
 
 		err := q.Push(&adapter.TransportData{SenderNodeAddress: []byte{0x01}})
 		require.NoError(t, err)
@@ -66,7 +68,7 @@ func TestQueue_CannotPushMoreThanMaxMessages(t *testing.T) {
 
 func TestQueue_PopWhenEmptyWaitsUntilPush(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		q := NewTransportQueue(1000, 1000, metric.NewRegistry())
+		q := NewTransportQueue(1000, 1000, metric.NewRegistry(), someAddress)
 
 		go func() {
 			time.Sleep(10 * time.Millisecond)
@@ -81,7 +83,7 @@ func TestQueue_PopWhenEmptyWaitsUntilPush(t *testing.T) {
 
 func TestQueue_PopWhenEmptyCancelsWithContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	q := NewTransportQueue(1000, 1000, metric.NewRegistry())
+	q := NewTransportQueue(1000, 1000, metric.NewRegistry(), someAddress)
 
 	go func() {
 		time.Sleep(10 * time.Millisecond)
@@ -94,7 +96,7 @@ func TestQueue_PopWhenEmptyCancelsWithContext(t *testing.T) {
 
 func TestQueue_CannotPushMoreThanMaxBytes(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		q := NewTransportQueue(10, 1000, metric.NewRegistry())
+		q := NewTransportQueue(10, 1000, metric.NewRegistry(), someAddress)
 
 		err := q.Push(&adapter.TransportData{SenderNodeAddress: []byte{0x01}, Payloads: [][]byte{buf(3), buf(4)}})
 		require.NoError(t, err)
@@ -118,7 +120,7 @@ func TestQueue_CannotPushMoreThanMaxBytes(t *testing.T) {
 
 func TestQueue_ClearEmptiesTheQueue(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		q := NewTransportQueue(1000, 3, metric.NewRegistry())
+		q := NewTransportQueue(1000, 3, metric.NewRegistry(), someAddress)
 
 		q.Clear(ctx)
 
@@ -146,7 +148,7 @@ func TestQueue_ClearEmptiesTheQueue(t *testing.T) {
 
 func TestQueue_DisableThenEnable(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		q := NewTransportQueue(1000, 2, metric.NewRegistry())
+		q := NewTransportQueue(1000, 2, metric.NewRegistry(), someAddress)
 
 		q.Disable()
 

--- a/services/gossip/adapter/test/transport_contract_test.go
+++ b/services/gossip/adapter/test/transport_contract_test.go
@@ -128,13 +128,12 @@ func aDirectTransport(ctx context.Context, tb testing.TB) *transportContractCont
 	}
 
 	logger := log.DefaultTestingLogger(tb)
-	registry := metric.NewRegistry()
 
 	transports := []*tcp.DirectTransport{
-		tcp.NewDirectTransport(ctx, configs[0], logger, registry),
-		tcp.NewDirectTransport(ctx, configs[1], logger, registry),
-		tcp.NewDirectTransport(ctx, configs[2], logger, registry),
-		tcp.NewDirectTransport(ctx, configs[3], logger, registry),
+		tcp.NewDirectTransport(ctx, configs[0], logger, metric.NewRegistry()),
+		tcp.NewDirectTransport(ctx, configs[1], logger, metric.NewRegistry()),
+		tcp.NewDirectTransport(ctx, configs[2], logger, metric.NewRegistry()),
+		tcp.NewDirectTransport(ctx, configs[3], logger, metric.NewRegistry()),
 	}
 
 	test.Eventually(1*time.Second, func() bool {


### PR DESCRIPTION
Due to a bug in the `MetricRegistry` we missed the fact that only a single connection's outgoing metrics where being reported - because of a name collision.

This PR adds a `panic` when attempting to register a metric with a name that already exists, as well as introducing new metrics per client:
`Gossip.OutgoingConnection.Queue.Usage.[NodeAddress].Percent`
`Gossip.OutgoingConnection.SendError.[NodeAddress].Count`
`Gossip.OutgoingConnection.EnqueueErrors.[NodeAddress].Count`

where `NodeAddress` stands for a hex-encoded representation of the Node's Orbs address