### PR TITLE
TCP Transport - client-related code moved to own struct

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -233,6 +233,7 @@ type ValidatorNode interface {
 type GossipPeer interface {
 	GossipPort() int
 	GossipEndpoint() string
+	HexAddress() string
 }
 
 type HttpServerConfig interface {

--- a/config/config.go
+++ b/config/config.go
@@ -233,7 +233,7 @@ type ValidatorNode interface {
 type GossipPeer interface {
 	GossipPort() int
 	GossipEndpoint() string
-	HexAddress() string
+	HexOrbsAddress() string
 }
 
 type HttpServerConfig interface {

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -85,12 +85,7 @@ func parsePeers(value interface{}) (peers map[string]GossipPeer, err error) {
 				if i, err := parseUint32(kv["port"].(float64)); err != nil {
 					return peers, err
 				} else {
-					gossipPort := int(i)
-
-					peers[nodeAddress.KeyForMap()] = &hardCodedGossipPeer{
-						gossipEndpoint: kv["ip"].(string),
-						gossipPort:     gossipPort,
-					}
+					peers[nodeAddress.KeyForMap()] = NewHardCodedGossipPeer(int(i), kv["ip"].(string), hexAddress)
 				}
 			}
 		}

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -76,7 +76,8 @@ func parsePeers(value interface{}) (peers map[string]GossipPeer, err error) {
 		for _, item := range nodeList {
 			kv := item.(map[string]interface{})
 
-			if nodeAddress, err := hex.DecodeString(kv["address"].(string)); err != nil {
+			hexAddress := kv["address"].(string)
+			if nodeAddress, err := hex.DecodeString(hexAddress); err != nil {
 				return peers, err
 			} else {
 				nodeAddress := primitives.NodeAddress(nodeAddress)

--- a/config/file_config_test.go
+++ b/config/file_config_test.go
@@ -133,10 +133,7 @@ func TestSetGossipPeers(t *testing.T) {
 
 	keyPair := keys.EcdsaSecp256K1KeyPairForTests(0)
 
-	node1 := &hardCodedGossipPeer{
-		gossipEndpoint: "192.168.199.2",
-		gossipPort:     4400,
-	}
+	node1 := NewHardCodedGossipPeer(4400, "192.168.199.2", "a328846cd5b4979d68a8c58a9bdfeee657b34de7")
 
 	require.EqualValues(t, node1, cfg.GossipPeers()[keyPair.NodeAddress().KeyForMap()])
 }

--- a/config/hardcoded_config.go
+++ b/config/hardcoded_config.go
@@ -20,6 +20,7 @@ type hardCodedValidatorNode struct {
 type hardCodedGossipPeer struct {
 	gossipPort     int
 	gossipEndpoint string
+	hexAddress     string
 }
 
 type NodeConfigValue struct {
@@ -118,10 +119,11 @@ func NewHardCodedValidatorNode(nodeAddress primitives.NodeAddress) ValidatorNode
 	}
 }
 
-func NewHardCodedGossipPeer(gossipPort int, gossipEndpoint string) GossipPeer {
+func NewHardCodedGossipPeer(gossipPort int, gossipEndpoint string, hexAddress string) GossipPeer {
 	return &hardCodedGossipPeer{
 		gossipPort:     gossipPort,
 		gossipEndpoint: gossipEndpoint,
+		hexAddress:     hexAddress,
 	}
 }
 
@@ -190,6 +192,10 @@ func (c *hardCodedGossipPeer) GossipPort() int {
 
 func (c *hardCodedGossipPeer) GossipEndpoint() string {
 	return c.gossipEndpoint
+}
+
+func (c *hardCodedGossipPeer) HexAddress() string {
+	return c.hexAddress
 }
 
 func (c *config) NodeAddress() primitives.NodeAddress {

--- a/config/hardcoded_config.go
+++ b/config/hardcoded_config.go
@@ -20,7 +20,7 @@ type hardCodedValidatorNode struct {
 type hardCodedGossipPeer struct {
 	gossipPort     int
 	gossipEndpoint string
-	hexAddress     string
+	hexOrbsAddress string
 }
 
 type NodeConfigValue struct {
@@ -123,7 +123,7 @@ func NewHardCodedGossipPeer(gossipPort int, gossipEndpoint string, hexAddress st
 	return &hardCodedGossipPeer{
 		gossipPort:     gossipPort,
 		gossipEndpoint: gossipEndpoint,
-		hexAddress:     hexAddress,
+		hexOrbsAddress: hexAddress,
 	}
 }
 
@@ -194,8 +194,8 @@ func (c *hardCodedGossipPeer) GossipEndpoint() string {
 	return c.gossipEndpoint
 }
 
-func (c *hardCodedGossipPeer) HexAddress() string {
-	return c.hexAddress
+func (c *hardCodedGossipPeer) HexOrbsAddress() string {
+	return c.hexOrbsAddress
 }
 
 func (c *config) NodeAddress() primitives.NodeAddress {

--- a/services/gossip/adapter/tcp/direct_harness.go
+++ b/services/gossip/adapter/tcp/direct_harness.go
@@ -8,6 +8,7 @@ package tcp
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"github.com/orbs-network/go-mock"
 	"github.com/orbs-network/orbs-network-go/config"
@@ -120,7 +121,7 @@ func makePeers(t *testing.T) (map[string]config.GossipPeer, []net.Listener) {
 
 		peersListeners[i] = conn
 		port := conn.Addr().(*net.TCPAddr).Port
-		gossipPeers[nodeAddress.KeyForMap()] = config.NewHardCodedGossipPeer(port, "127.0.0.1")
+		gossipPeers[nodeAddress.KeyForMap()] = config.NewHardCodedGossipPeer(port, "127.0.0.1", hex.EncodeToString(nodeAddress))
 	}
 	return gossipPeers, peersListeners
 }

--- a/services/gossip/adapter/tcp/direct_outgoing.go
+++ b/services/gossip/adapter/tcp/direct_outgoing.go
@@ -39,19 +39,19 @@ type clientConnection struct {
 	sendQueueErrors *metric.Gauge
 }
 
-func newClientConnection(peerNodeAddress string, peer config.GossipPeer, parentLogger log.Logger, metricFactory metric.Registry, sharedMetrics *metrics, transportConfig config.GossipTransportConfig) *clientConnection {
+func newClientConnection(peerHexAddress string, peer config.GossipPeer, parentLogger log.Logger, metricFactory metric.Registry, sharedMetrics *metrics, transportConfig config.GossipTransportConfig) *clientConnection {
 	peerAddress := fmt.Sprintf("%s:%d", peer.GossipEndpoint(), peer.GossipPort())
-	queue := NewTransportQueue(SEND_QUEUE_MAX_BYTES, SEND_QUEUE_MAX_MESSAGES, metricFactory, peerNodeAddress)
+	queue := NewTransportQueue(SEND_QUEUE_MAX_BYTES, SEND_QUEUE_MAX_MESSAGES, metricFactory, peerHexAddress)
 	queue.networkAddress = peerAddress
 	queue.Disable() // until connection is established
 
 	client := &clientConnection{
-		logger:          parentLogger.WithTags(log.String("peer-node-address", peerNodeAddress), log.String("peer-network-address", peerAddress)),
+		logger:          parentLogger.WithTags(log.String("peer-node-address", peerHexAddress), log.String("peer-network-address", peerAddress)),
 		sharedMetrics:   sharedMetrics,
 		config:          transportConfig,
 		queue:           queue,
-		sendErrors:      metricFactory.NewGauge(fmt.Sprintf("Gossip.OutgoingConnection.SendError.%s.Count", peerNodeAddress)),
-		sendQueueErrors: metricFactory.NewGauge(fmt.Sprintf("Gossip.OutgoingConnection.EnqueueErrors.%s.Count", peerNodeAddress)),
+		sendErrors:      metricFactory.NewGauge(fmt.Sprintf("Gossip.OutgoingConnection.SendError.%s.Count", peerHexAddress)),
+		sendQueueErrors: metricFactory.NewGauge(fmt.Sprintf("Gossip.OutgoingConnection.EnqueueErrors.%s.Count", peerHexAddress)),
 	}
 
 	return client

--- a/services/gossip/adapter/tcp/direct_transport.go
+++ b/services/gossip/adapter/tcp/direct_transport.go
@@ -124,8 +124,8 @@ func (t *DirectTransport) connectForever(bgCtx context.Context, peerNodeAddress 
 	defer t.clientConnections.Unlock()
 
 	if peerNodeAddress != t.config.NodeAddress().KeyForMap() {
-
-		client := newClientConnection(peer.HexAddress()[:6], peer, t.logger, t.metricRegistry, t.metrics, t.config)
+		idForLogs := peer.HexOrbsAddress()[:6]
+		client := newClientConnection(idForLogs, peer, t.logger, t.metricRegistry, t.metrics, t.config)
 
 		t.clientConnections.peers[peerNodeAddress] = client
 

--- a/services/gossip/adapter/tcp/direct_transport.go
+++ b/services/gossip/adapter/tcp/direct_transport.go
@@ -125,7 +125,7 @@ func (t *DirectTransport) connectForever(bgCtx context.Context, peerNodeAddress 
 
 	if peerNodeAddress != t.config.NodeAddress().KeyForMap() {
 
-		client := newClientConnection(peerNodeAddress, peer, t.logger, t.metricRegistry, t.metrics, t.config)
+		client := newClientConnection(peer.HexAddress()[:6], peer, t.logger, t.metricRegistry, t.metrics, t.config)
 
 		t.clientConnections.peers[peerNodeAddress] = client
 

--- a/services/gossip/adapter/tcp/direct_transport.go
+++ b/services/gossip/adapter/tcp/direct_transport.go
@@ -8,7 +8,6 @@ package tcp
 
 import (
 	"context"
-	"fmt"
 	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
@@ -41,9 +40,9 @@ type metrics struct {
 	outgoingMessageSize *metric.Histogram
 }
 
-type lockableOutgoingQueues struct {
+type lockableClientConnections struct {
 	sync.RWMutex
-	peers map[string]*transportQueue
+	peers map[string]*clientConnection
 }
 
 type lockableTransportServer struct {
@@ -57,7 +56,7 @@ type DirectTransport struct {
 	config config.GossipTransportConfig
 	logger log.Logger
 
-	outgoingQueues *lockableOutgoingQueues
+	clientConnections *lockableClientConnections
 
 	server *lockableTransportServer
 
@@ -85,8 +84,8 @@ func NewDirectTransport(ctx context.Context, config config.GossipTransportConfig
 		logger:         logger.WithTags(LogTag),
 		metricRegistry: registry,
 
-		outgoingQueues: newLockableOutgoingQueues(),
-		server:         newDirectTransportServer(),
+		clientConnections: newLockableClientConnections(),
+		server:            newDirectTransportServer(),
 
 		metrics: getMetrics(registry),
 	}
@@ -112,31 +111,30 @@ func newDirectTransportServer() *lockableTransportServer {
 	}
 }
 
-func newLockableOutgoingQueues() *lockableOutgoingQueues {
-	return &lockableOutgoingQueues{
-		peers: make(map[string]*transportQueue),
+func newLockableClientConnections() *lockableClientConnections {
+	return &lockableClientConnections{
+		peers: make(map[string]*clientConnection),
 	}
 }
 
 // note that bgCtx MUST be a long-running background context - if it's a short lived context, the new connection will die as soon as
 // the context is done
 func (t *DirectTransport) connectForever(bgCtx context.Context, peerNodeAddress string, peer config.GossipPeer) {
-	t.outgoingQueues.Lock()
-	defer t.outgoingQueues.Unlock()
+	t.clientConnections.Lock()
+	defer t.clientConnections.Unlock()
 
 	if peerNodeAddress != t.config.NodeAddress().KeyForMap() {
 
-		newQueue := NewTransportQueue(SEND_QUEUE_MAX_BYTES, SEND_QUEUE_MAX_MESSAGES, t.metricRegistry, peerNodeAddress)
+		logger := t.logger.WithTags(log.String("peer-node-address", peerNodeAddress))
+		sharedMetrics := t.metrics
+		transportConfig := t.config
+		metricRegistry := t.metricRegistry
+		client := newClientConnection(peerNodeAddress, peer, logger, metricRegistry, sharedMetrics, transportConfig)
 
-		peerAddress := fmt.Sprintf("%s:%d", peer.GossipEndpoint(), peer.GossipPort())
-		newQueue.networkAddress = peerAddress
-		newQueue.Disable() // until connection is established
+		t.clientConnections.peers[peerNodeAddress] = client
 
-		t.outgoingQueues.peers[peerNodeAddress] = newQueue
+		client.connect(bgCtx)
 
-		supervised.GoForever(bgCtx, t.logger, func() {
-			t.clientMainLoop(bgCtx, newQueue) // avoid referencing queue map not under lock
-		})
 	}
 }
 
@@ -154,19 +152,19 @@ func (t *DirectTransport) RegisterListener(listener adapter.TransportListener, l
 
 // TODO(https://github.com/orbs-network/orbs-network-go/issues/182): we are not currently respecting any intents given in ctx (added in context refactor)
 func (t *DirectTransport) Send(ctx context.Context, data *adapter.TransportData) error {
-	t.outgoingQueues.RLock()
-	defer t.outgoingQueues.RUnlock()
+	t.clientConnections.RLock()
+	defer t.clientConnections.RUnlock()
 
 	switch data.RecipientMode {
 	case gossipmessages.RECIPIENT_LIST_MODE_BROADCAST:
-		for _, peerQueue := range t.outgoingQueues.peers {
-			t.addDataToOutgoingPeerQueue(data, peerQueue)
+		for _, client := range t.clientConnections.peers {
+			client.addDataToOutgoingPeerQueue(data)
 		}
 		return nil
 	case gossipmessages.RECIPIENT_LIST_MODE_LIST:
 		for _, recipientPublicKey := range data.RecipientNodeAddresses {
-			if peerQueue, found := t.outgoingQueues.peers[recipientPublicKey.KeyForMap()]; found {
-				t.addDataToOutgoingPeerQueue(data, peerQueue)
+			if client, found := t.clientConnections.peers[recipientPublicKey.KeyForMap()]; found {
+				client.addDataToOutgoingPeerQueue(data)
 			} else {
 				return errors.Errorf("unknown recipient public key: %s", recipientPublicKey.String())
 			}
@@ -193,11 +191,11 @@ func (t *DirectTransport) setServerPort(v int) {
 }
 
 func (t *DirectTransport) allOutgoingQueuesEnabled() bool {
-	t.outgoingQueues.RLock()
-	defer t.outgoingQueues.RUnlock()
+	t.clientConnections.RLock()
+	defer t.clientConnections.RUnlock()
 
-	for _, queue := range t.outgoingQueues.peers {
-		if queue.disabled {
+	for _, client := range t.clientConnections.peers {
+		if client.queue.disabled {
 			return false
 		}
 	}

--- a/services/gossip/adapter/tcp/direct_transport_test.go
+++ b/services/gossip/adapter/tcp/direct_transport_test.go
@@ -56,7 +56,7 @@ func TestDirectTransport_SupportsAddingPeersInRuntime(t *testing.T) {
 		node2.AddPeer(ctx, address1, config.NewHardCodedGossipPeer(node1.GetServerPort(), "127.0.0.1"))
 
 		require.True(t, test.Eventually(HARNESS_OUTGOING_CONNECTIONS_INIT_TIMEOUT, func() bool {
-			return len(node1.outgoingQueues.peers) > 0 && len(node2.outgoingQueues.peers) > 0
+			return len(node1.clientConnections.peers) > 0 && len(node2.clientConnections.peers) > 0
 		}), "expected all outgoing queues to become enabled after successfully connecting to added peers")
 
 		header := (&gossipmessages.HeaderBuilder{

--- a/services/gossip/adapter/tcp/direct_transport_test.go
+++ b/services/gossip/adapter/tcp/direct_transport_test.go
@@ -8,6 +8,7 @@ package tcp
 
 import (
 	"context"
+	"encoding/hex"
 	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
@@ -52,8 +53,8 @@ func TestDirectTransport_SupportsAddingPeersInRuntime(t *testing.T) {
 			return node1.IsServerListening() && node2.IsServerListening()
 		}), "server did not start")
 
-		node1.AddPeer(ctx, address2, config.NewHardCodedGossipPeer(node2.GetServerPort(), "127.0.0.1"))
-		node2.AddPeer(ctx, address1, config.NewHardCodedGossipPeer(node1.GetServerPort(), "127.0.0.1"))
+		node1.AddPeer(ctx, address2, config.NewHardCodedGossipPeer(node2.GetServerPort(), "127.0.0.1", hex.EncodeToString(address1)))
+		node2.AddPeer(ctx, address1, config.NewHardCodedGossipPeer(node1.GetServerPort(), "127.0.0.1", hex.EncodeToString(address2)))
 
 		require.True(t, test.Eventually(HARNESS_OUTGOING_CONNECTIONS_INIT_TIMEOUT, func() bool {
 			return len(node1.clientConnections.peers) > 0 && len(node2.clientConnections.peers) > 0
@@ -71,19 +72,22 @@ func TestDirectTransport_SupportsAddingPeersInRuntime(t *testing.T) {
 		payloads := [][]byte{header.Raw(), message.Content}
 
 		l2.ExpectReceive(payloads)
-		require.NoError(t, node1.Send(ctx, &adapter.TransportData{
-			SenderNodeAddress:      address1,
-			RecipientMode:          gossipmessages.RECIPIENT_LIST_MODE_LIST,
-			RecipientNodeAddresses: []primitives.NodeAddress{address2},
-			Payloads:               payloads,
-		}))
+		require.NoError(t, sendTo(ctx, node1, address1, address2, payloads))
 
 		l1.ExpectReceive(payloads)
-		require.NoError(t, node2.Send(ctx, &adapter.TransportData{
-			SenderNodeAddress:      address2,
-			RecipientMode:          gossipmessages.RECIPIENT_LIST_MODE_LIST,
-			RecipientNodeAddresses: []primitives.NodeAddress{address1},
-			Payloads:               payloads,
-		}))
+		require.NoError(t, sendTo(ctx, node2, address2, address1, payloads))
 	})
+}
+
+func sendTo(ctx context.Context, node *DirectTransport, from primitives.NodeAddress, to primitives.NodeAddress, payloads [][]byte) error {
+	return node.Send(ctx, &adapter.TransportData{
+		SenderNodeAddress:      from,
+		RecipientMode:          gossipmessages.RECIPIENT_LIST_MODE_LIST,
+		RecipientNodeAddresses: []primitives.NodeAddress{to},
+		Payloads:               payloads,
+	})
+}
+
+func TestDirectTransport_SupportsTopologyChangeInRuntime(t *testing.T) {
+
 }

--- a/services/gossip/adapter/tcp/queue.go
+++ b/services/gossip/adapter/tcp/queue.go
@@ -91,6 +91,11 @@ func (q *transportQueue) Enable() {
 	q.disabled = false
 }
 
+func (q *transportQueue) OnNewConnection(ctx context.Context) {
+	q.Clear(ctx)
+	q.Enable()
+}
+
 func (q *transportQueue) consumeBytes(data *adapter.TransportData) error {
 	q.protected.Lock()
 	defer q.protected.Unlock()

--- a/services/gossip/adapter/tcp/queue.go
+++ b/services/gossip/adapter/tcp/queue.go
@@ -27,8 +27,6 @@ type transportQueue struct {
 		bytesLeft int
 	}
 	usagePercentageMetric *metric.Gauge
-	sendErrors            *metric.Gauge
-	sendQueueErrors       *metric.Gauge
 }
 
 func NewTransportQueue(maxSizeBytes int, maxSizeMessages int, metricFactory metric.Factory, peerNodeAddress string) *transportQueue {
@@ -40,8 +38,6 @@ func NewTransportQueue(maxSizeBytes int, maxSizeMessages int, metricFactory metr
 	q.protected.bytesLeft = maxSizeBytes
 
 	q.usagePercentageMetric = metricFactory.NewGauge(fmt.Sprintf("Gossip.OutgoingConnection.Queue.Usage.%s.Percent", peerNodeAddress))
-	q.sendErrors = metricFactory.NewGauge(fmt.Sprintf("Gossip.OutgoingConnection.SendError.%s.Count", peerNodeAddress))
-	q.sendQueueErrors = metricFactory.NewGauge(fmt.Sprintf("Gossip.OutgoingConnection.EnqueueErrors.%s.Count", peerNodeAddress))
 
 	return q
 }

--- a/services/gossip/adapter/test/transport_contract_test.go
+++ b/services/gossip/adapter/test/transport_contract_test.go
@@ -8,6 +8,7 @@ package test
 
 import (
 	"context"
+	"encoding/hex"
 	"github.com/orbs-network/orbs-network-go/config"
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
@@ -154,7 +155,7 @@ func aDirectTransport(ctx context.Context, tb testing.TB) *transportContractCont
 	for _, t1 := range transports {
 		for i, t2 := range transports {
 			if t1 != t2 {
-				t1.AddPeer(ctx, res.nodeAddresses[i], config.NewHardCodedGossipPeer(t2.GetServerPort(), "127.0.0.1"))
+				t1.AddPeer(ctx, res.nodeAddresses[i], config.NewHardCodedGossipPeer(t2.GetServerPort(), "127.0.0.1", hex.EncodeToString(res.nodeAddresses[i])))
 			}
 		}
 	}

--- a/test/e2e/network.go
+++ b/test/e2e/network.go
@@ -7,6 +7,7 @@
 package e2e
 
 import (
+	"encoding/hex"
 	"fmt"
 	"github.com/orbs-network/orbs-network-go/bootstrap"
 	"github.com/orbs-network/orbs-network-go/config"
@@ -53,7 +54,7 @@ func bootstrapE2ENetwork() (nodes []bootstrap.Node) {
 		gossipPortByNodeIndex = append(gossipPortByNodeIndex, test.RandomPort())
 		nodeAddress := keys.EcdsaSecp256K1KeyPairForTests(i).NodeAddress()
 		genesisValidatorNodes[nodeAddress.KeyForMap()] = config.NewHardCodedValidatorNode(nodeAddress)
-		gossipPeers[nodeAddress.KeyForMap()] = config.NewHardCodedGossipPeer(gossipPortByNodeIndex[i], "127.0.0.1")
+		gossipPeers[nodeAddress.KeyForMap()] = config.NewHardCodedGossipPeer(gossipPortByNodeIndex[i], "127.0.0.1", hex.EncodeToString(nodeAddress))
 	}
 
 	ethereumEndpoint := os.Getenv("ETHEREUM_ENDPOINT") //TODO v1 unite how this config is fetched


### PR DESCRIPTION
This PR moves all code that deals with a single client connection within `DirectTransport` to a new struct, `clientConnection`. This is in preparation for a future PR to allow updating peer topology in runtime.