### PR TITLE
sanitization of contract names 

### DIFF
--- a/bootstrap/gamma/deploy_native_test.go
+++ b/bootstrap/gamma/deploy_native_test.go
@@ -10,9 +10,13 @@ package gamma
 import (
 	"context"
 	"fmt"
+	"github.com/orbs-network/orbs-network-go/services/processor/native/repository/_Elections"
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/orbs-network-go/test/acceptance/callcontract"
+	"github.com/orbs-network/orbs-network-go/test/builders"
 	"github.com/orbs-network/orbs-network-go/test/contracts"
+	"github.com/orbs-network/orbs-network-go/test/crypto/keys"
+	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/consensus"
 	"github.com/orbs-network/scribe/log"
 	"github.com/stretchr/testify/require"
@@ -57,4 +61,28 @@ func TestNonLeaderDeploysNativeContract(t *testing.T) {
 
 	t.Run("Benchmark", testDeployNativeContractWithConfig(""))
 	t.Run("LeanHelix", testDeployNativeContractWithConfig(fmt.Sprintf(`{"active-consensus-algo":%d}`, consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX)))
+}
+
+func TestDeployNativeContractFailsWhenUsingSystemContractName(t *testing.T) {
+	test.WithContext(func(ctx context.Context) {
+		network := NewDevelopmentNetwork(ctx, log.DefaultTestingLogger(t), nil, "")
+
+		tx := builders.Transaction().
+			WithVirtualChainId(network.VirtualChainId).
+			WithMethod("_Deployments", "deployService").
+			WithArgs(elections_systemcontract.CONTRACT_NAME,
+				uint32(protocol.PROCESSOR_TYPE_NATIVE),
+				[]byte(contracts.NativeSourceCodeForCounter(0)),
+			).
+			WithEd25519Signer(keys.Ed25519KeyPairForTests(0)).
+			Builder()
+
+		txResponse, _ := network.SendTransaction(ctx, tx, 0)
+		require.EqualValues(t, protocol.REQUEST_STATUS_COMPLETED, txResponse.RequestResult().RequestStatus())
+		require.EqualValues(t, protocol.TRANSACTION_STATUS_COMMITTED, txResponse.TransactionStatus())
+		require.EqualValues(t, protocol.EXECUTION_RESULT_ERROR_SMART_CONTRACT, txResponse.TransactionReceipt().ExecutionResult())
+		textValue := builders.PackedArgumentArrayDecode(txResponse.TransactionReceipt().RawOutputArgumentArrayWithHeader()).ArgumentsIterator().NextArguments().StringValue()
+		require.EqualValues(t, "a contract with this name exists", textValue)
+	})
+	time.Sleep(5 * time.Millisecond) // give context dependent goroutines 5 ms to terminate gracefully
 }

--- a/services/processor/native/repository/_Deployments/deploy.go
+++ b/services/processor/native/repository/_Deployments/deploy.go
@@ -18,7 +18,7 @@ import (
 )
 
 func getInfo(serviceName string) uint32 {
-	if _isImplicitlyDeployed(serviceName) {
+	if IsImplicitlyDeployed(serviceName) {
 		return uint32(protocol.PROCESSOR_TYPE_NATIVE)
 	}
 
@@ -55,8 +55,11 @@ func deployService(serviceName string, processorType uint32, code ...[]byte) {
 		_validateNativeDeploymentLock()
 	}
 
-	// TODO(https://github.com/orbs-network/orbs-network-go/issues/571): sanitize serviceName
+	_validateServiceName(serviceName)
 
+	_addServiceName(serviceName)
+
+	// this read is for backwards compatibility if someone deployed a contract before service name sanitization was added
 	existingProcessorType := _readProcessor(serviceName)
 	if existingProcessorType != 0 {
 		panic("contract already deployed")
@@ -74,7 +77,8 @@ func deployService(serviceName string, processorType uint32, code ...[]byte) {
 	service.CallMethod(serviceName, "_init")
 }
 
-func _isImplicitlyDeployed(serviceName string) bool {
+// Function was made go "public" to allow testing, it is not public in the contract.
+func IsImplicitlyDeployed(serviceName string) bool {
 	switch serviceName {
 	case
 		CONTRACT_NAME,

--- a/services/processor/native/repository/_Deployments/service_name.go
+++ b/services/processor/native/repository/_Deployments/service_name.go
@@ -1,0 +1,62 @@
+package deployments_systemcontract
+
+import (
+	"fmt"
+	"github.com/orbs-network/orbs-contract-sdk/go/sdk/v1/state"
+	"regexp"
+	"strings"
+)
+
+func _validateServiceName(serviceName string) {
+	if IsImplicitlyDeployed(serviceName) {
+		panic("a contract with this name exists")
+	}
+	if matched, err := regexp.MatchString("^[a-zA-Z0-9]+$", serviceName); err != nil || !matched {
+		panic("contract name must be non empty and contain alpha-numeric characters only")
+	}
+	if _isServiceNameUsed(serviceName) {
+		panic("a contract with same name (case insensitive) already exists")
+	}
+}
+
+func _isServiceNameUsed(serviceName string) bool {
+	numOfServices := _getNumberOfServices()
+	serviceName = strings.ToLower(serviceName)
+	for i := 0; i < numOfServices; i++ {
+		if serviceName == _getServiceAtIndex(i) {
+			return true
+		}
+	}
+	return false
+}
+
+func _addServiceName(serviceName string) {
+	numOfServices := _getNumberOfServices()
+	_setServiceAtIndex(numOfServices, serviceName)
+	numOfServices++
+	_setNumberOfServices(numOfServices)
+}
+
+func _formatNumberOfDeployedServices() []byte {
+	return []byte("Service_Count")
+}
+
+func _getNumberOfServices() int {
+	return int(state.ReadUint32(_formatNumberOfDeployedServices()))
+}
+
+func _setNumberOfServices(numberOfServices int) {
+	state.WriteUint32(_formatNumberOfDeployedServices(), uint32(numberOfServices))
+}
+
+func _formatServiceIterator(num int) []byte {
+	return []byte(fmt.Sprintf("Service_At_%d", num))
+}
+
+func _getServiceAtIndex(index int) string {
+	return state.ReadString(_formatServiceIterator(index))
+}
+
+func _setServiceAtIndex(index int, serviceName string) {
+	state.WriteString(_formatServiceIterator(index), strings.ToLower(serviceName))
+}

--- a/services/processor/native/repository/_Deployments/service_name_test.go
+++ b/services/processor/native/repository/_Deployments/service_name_test.go
@@ -1,0 +1,36 @@
+package deployments_systemcontract
+
+import (
+	. "github.com/orbs-network/orbs-contract-sdk/go/testing/unit"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestOrbsDeployContract_isServiceNameValid(t *testing.T) {
+	contractAlreadyDeployedName := "someName"
+	InServiceScope(nil, nil, func(m Mockery) {
+		_addServiceName(contractAlreadyDeployedName)
+		tests := []struct {
+			name         string
+			contractName string
+			shouldPanic  bool
+		}{
+			{"ok Name", "randomName", false},
+			{"empty contract name", "", true},
+			{"using system contract name", "_Elections", true},
+			{"space at end", "randomName ", true},
+			{"space in middle", "random Name", true},
+			{"space in begin", " randomName", true},
+			{"other non alpha", "random%Name", true},
+			{"exact name again", contractAlreadyDeployedName, true},
+			{"same name again but different lower/upper", "somename", true},
+		}
+		for _, tt := range tests {
+			if tt.shouldPanic {
+				require.Panics(t, func() { _validateServiceName(tt.contractName) }, "should panic when %s", tt.name)
+			} else {
+				require.NotPanics(t, func() { _validateServiceName(tt.contractName) }, "should not panic when %s", tt.name)
+			}
+		}
+	})
+}

--- a/services/processor/native/repository/all_system_contracts_declared_test.go
+++ b/services/processor/native/repository/all_system_contracts_declared_test.go
@@ -1,0 +1,19 @@
+package repository
+
+import (
+	"github.com/orbs-network/orbs-network-go/services/processor/native/repository/BenchmarkContract"
+	"github.com/orbs-network/orbs-network-go/services/processor/native/repository/BenchmarkToken"
+	"github.com/orbs-network/orbs-network-go/services/processor/native/repository/_Deployments"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// Important this is a safety test that makes sure new system contracts are added to the deploy contract as system contract to avoid attempt at re-deploy.
+func TestOrbsDeployContract_AreAllSystemContracts(t *testing.T) {
+	for contractName, _ := range PreBuiltContracts {
+		if contractName == benchmarkcontract.CONTRACT_NAME || contractName == benchmarktoken.CONTRACT_NAME {
+			continue // Important these two contracts are in the pre-build for acceptance and e2e tests but are not actually system
+		}
+		require.True(t, deployments_systemcontract.IsImplicitlyDeployed(contractName), "deploy.go func _isImplicitlyDeployed is missing system contract with name %s", contractName)
+	}
+}


### PR DESCRIPTION
## Description

sanitization of contract names :
contract names checked before deploy that they are not system and are alphanumeric only.
also for deploy contract name is case insensitive. HOWEVER contract name is case sensitive for reading/accessing.
(example can deploy "randomName", then access it only as "randomName", but can't deploy "RANDOMNAME" as a new contract.

also added test to check all system contracts are checked as such for proper deploy

fixes #1067
fixes #571 
