### PR TITLE
Don't share blocks between in-memory persistence instances

### DIFF
--- a/services/gossip/service.go
+++ b/services/gossip/service.go
@@ -49,7 +49,7 @@ type Service struct {
 
 func NewGossip(ctx context.Context, transport adapter.Transport, config Config, parent log.Logger, metricRegistry metric.Registry) *Service {
 	logger := parent.WithTags(LogTag)
-	dispatcher := newMessageDispatcher(metricRegistry)
+	dispatcher := newMessageDispatcher(metricRegistry, logger)
 	s := &Service{
 		transport:       transport,
 		config:          config,
@@ -89,8 +89,7 @@ func (s *Service) OnTransportMessageReceived(ctx context.Context, payloads [][]b
 			return
 		}
 
-		logger.Info("transport message received", log.Stringable("header", header), log.String("gossip-topic", header.StringTopic()))
-		s.messageDispatcher.dispatch(logger, header, payloads[1:])
+		s.messageDispatcher.dispatch(ctx, logger, header, payloads[1:])
 	}
 }
 

--- a/test/acceptance/network_harness.go
+++ b/test/acceptance/network_harness.go
@@ -200,7 +200,7 @@ func (b *acceptanceNetworkHarness) makeLogger(testOutput *log.TestOutput, testId
 		log.String("_test", "acceptance"),
 		log.String("_test-id", testId)).
 		WithFilters(
-			log.IgnoreMessagesMatching("transport message received"),
+			//log.IgnoreMessagesMatching("transport message received"),
 			log.ExcludeField(memory.LogTag),
 		).
 		WithFilters(b.logFilters...)


### PR DESCRIPTION
- added topic size to "transport message received" message
- copying preloaded blocks on creation of memory persistence to avoid accidental sharing of blocks