### PR TITLE
Gossip topic ignore overflowing messages 

### DIFF
--- a/services/gossip/service.go
+++ b/services/gossip/service.go
@@ -69,28 +69,27 @@ func NewGossip(ctx context.Context, transport adapter.Transport, config Config, 
 }
 
 func (s *Service) OnTransportMessageReceived(ctx context.Context, payloads [][]byte) {
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return
-	default:
-		logger := s.logger.WithTags(trace.LogFieldFrom(ctx))
-		if len(payloads) == 0 {
-			logger.Error("transport did not receive any payloads, header missing")
-			return
-		}
-		header := gossipmessages.HeaderReader(payloads[0])
-		if !header.IsValid() {
-			logger.Error("transport header is corrupt", log.Bytes("header", payloads[0]))
-			return
-		}
-
-		if err := s.headerValidator.validateMessageHeader(header); err != nil {
-			logger.Error("dropping a received message that isn't valid", log.Error(err), log.Stringable("message-header", header))
-			return
-		}
-
-		s.messageDispatcher.dispatch(ctx, logger, header, payloads[1:])
 	}
+
+	logger := s.logger.WithTags(trace.LogFieldFrom(ctx))
+	if len(payloads) == 0 {
+		logger.Error("transport did not receive any payloads, header missing")
+		return
+	}
+	header := gossipmessages.HeaderReader(payloads[0])
+	if !header.IsValid() {
+		logger.Error("transport header is corrupt", log.Bytes("header", payloads[0]))
+		return
+	}
+
+	if err := s.headerValidator.validateMessageHeader(header); err != nil {
+		logger.Error("dropping a received message that isn't valid", log.Error(err), log.Stringable("message-header", header))
+		return
+	}
+
+	s.messageDispatcher.dispatch(ctx, logger, header, payloads[1:])
 }
 
 func (s *Service) String() string {


### PR DESCRIPTION
Dispatcher thread is blocked when waiting for topic buffer to empty out,
this leads to deadlocks when topic A consumer thread is waiting for a gossip message to arrive on another topic B. the dispatcher is not dispatching because it's waiting for consumer of topic A to read the next message and clear the buffer, but this will never happen because topic B is now frozen since the dispatcher is deadlocked.