### PR TITLE
Mitigate nightly (hopefully related)

### DIFF
--- a/test.flakiness.sh
+++ b/test.flakiness.sh
@@ -13,8 +13,8 @@ if [[ "${LAST_COMMIT_MESSAGE}" == *"#extraflaky"* ]]; then
     FAILFAST=""
     TIMEOUT_ACCEPTANCE="500m"
     TIMEOUT_REST="500m"
-    COUNT_ACCEPTANCE=50
-    COUNT_REST=50
+    COUNT_ACCEPTANCE=30
+    COUNT_REST=30
 fi
 
 if [[ $1 == "NIGHTLY" ]]; then
@@ -28,8 +28,8 @@ if [[ $1 == "NIGHTLY" ]]; then
     TIMEOUT_ACCEPTANCE="500m"
     TIMEOUT_REST="500m"
     # The number here have been reduced since we use paralleism 6 to run 500 tests in 6 different processes
-    COUNT_ACCEPTANCE=50
-    COUNT_REST=50
+    COUNT_ACCEPTANCE=30
+    COUNT_REST=30
 fi
 
 if [ "$CIRCLE_NODE_INDEX" == 0 ] || [ "$CIRCLE_NODE_INDEX" == 1 ] || [ "$CIRCLE_NODE_INDEX" == 2 ] || [ "$CIRCLE_NODE_INDEX" == 3 ] || [ -z "$CIRCLE_NODE_INDEX" ]; then


### PR DESCRIPTION
We have opened a ticket with CircleCI to try and address the `Killed...` signal we are getting for our `go test` within the nightly build.
Since we have no other data to act upon at this stage, I'm proposing a reduction in go's concurrent tests iterations from 50 to a value of 30.