### PR TITLE
Fix passing empty array of variable length to a contract

### DIFF
--- a/services/processor/native/call.go
+++ b/services/processor/native/call.go
@@ -136,7 +136,14 @@ func (s *service) prepareMethodInputArgsForCall(methodInstance types.MethodInsta
 	}
 
 	if i < methodType.NumIn() {
+		if methodType.NumIn()-1 == i { // missing a single argument
+			if k := methodType.In(methodType.NumIn() - 1).Kind(); k == reflect.Slice {
+				return res, nil
+			}
+		}
+
 		return nil, errors.Errorf("method '%s' takes %d args but received less", functionNameForErrors, methodType.NumIn())
+
 	}
 
 	return res, nil

--- a/services/processor/native/call.go
+++ b/services/processor/native/call.go
@@ -107,16 +107,29 @@ func (s *service) prepareMethodInputArgsForCall(methodInstance types.MethodInsta
 		case reflect.Slice:
 			switch methodTypeIn.Elem().Kind() {
 			case reflect.Uint8:
+				if !arg.IsTypeBytesValue() {
+					return nil, errors.Errorf("method '%s' expects arg %d to be []byte but it has %s", functionNameForErrors, i, arg.StringType())
+				}
 				res = append(res, reflect.ValueOf(arg.BytesValue()))
 			case reflect.String:
-				res = append(res, reflect.ValueOf(arg.StringStringValue()))
+				if methodType.IsVariadic() && !arg.IsTypeStringValue() {
+					return nil, errors.Errorf("method '%s' expects arg %d to be string but it has %s", functionNameForErrors, i, arg.StringType())
+				}
+				res = append(res, reflect.ValueOf(arg.StringValue()))
 			case reflect.Uint32:
+				if methodType.IsVariadic() && !arg.IsTypeUint32Value() {
+					return nil, errors.Errorf("method '%s' expects arg %d to be uint32 but it has %s", functionNameForErrors, i, arg.StringType())
+				}
 				res = append(res, reflect.ValueOf(arg.Uint32Value()))
 			case reflect.Uint64:
+				if methodType.IsVariadic() && !arg.IsTypeUint64Value() {
+					return nil, errors.Errorf("method '%s' expects arg %d to be uint64 but it has %s", functionNameForErrors, i, arg.StringType())
+				}
 				res = append(res, reflect.ValueOf(arg.Uint64Value()))
 			case reflect.Slice:
-				if !arg.IsTypeBytesValue() {
-					return nil, errors.Errorf("method '%s' expects arg %d to be bytes but it has %s", functionNameForErrors, i, arg.StringType())
+				if methodType.IsVariadic() && (!arg.IsTypeBytesValue() ||
+					(methodTypeIn.Elem().Elem().Kind() != reflect.Uint8)) { // check that element of slice-of-slice is defined as byte
+					return nil, errors.Errorf("method '%s' expects arg %d to be [][]byte but it has %s", functionNameForErrors, i, arg.StringType())
 				}
 				res = append(res, reflect.ValueOf(arg.BytesValue()))
 			default:
@@ -128,22 +141,12 @@ func (s *service) prepareMethodInputArgsForCall(methodInstance types.MethodInsta
 
 	}
 
-	// Handle case of overflow unless the last argument was an array (supposedly of variable length)
-	if i > methodType.NumIn() && methodType.NumIn() > 0 {
-		if k := methodType.In(methodType.NumIn() - 1).Kind(); k != reflect.Slice {
-			return nil, errors.Errorf("method '%s' takes %d args but received more", functionNameForErrors, methodType.NumIn())
-		}
-	}
-
-	if i < methodType.NumIn() {
-		if methodType.NumIn()-1 == i { // missing a single argument
-			if k := methodType.In(methodType.NumIn() - 1).Kind(); k == reflect.Slice {
-				return res, nil
-			}
-		}
-
+	if methodType.IsVariadic() { // determine dangling array
+		return res, nil
+	} else if i < methodType.NumIn() {
 		return nil, errors.Errorf("method '%s' takes %d args but received less", functionNameForErrors, methodType.NumIn())
-
+	} else if i > methodType.NumIn() {
+		return nil, errors.Errorf("method '%s' takes %d args but received more", functionNameForErrors, methodType.NumIn())
 	}
 
 	return res, nil

--- a/services/processor/native/call_test.go
+++ b/services/processor/native/call_test.go
@@ -70,6 +70,32 @@ func TestPrepareMethodArgumentsForCallWithArrayOfVariableLengthPassingNoArgument
 	require.EqualValues(t, []string{}, outValues[0].Interface().([]string))
 }
 
+func TestPrepareMethodArgumentsForCallWithArrayOfVariableLengthPassingArgumentsOfDifferentType(t *testing.T) {
+	s := &service{}
+
+	methodInstance := func(a uint32, b ...string) []string {
+		return b
+	}
+
+	args := argsToArgumentArray(uint32(1), "hello", uint32(2))
+
+	_, err := s.prepareMethodInputArgsForCall(methodInstance, args, "funcName")
+	require.EqualError(t, err, "method 'funcName' expects arg 2 to be string but it has (Uint32Value)2")
+}
+
+func TestPrepareMethodArgumentsForCallWithArrayOfVariableLengthSkippingByteArrayArgument(t *testing.T) {
+	s := &service{}
+
+	methodInstance := func(a uint32, b []byte) []byte {
+		return b
+	}
+
+	args := argsToArgumentArray(uint32(1))
+
+	_, err := s.prepareMethodInputArgsForCall(methodInstance, args, "funcName")
+	require.EqualError(t, err, "method 'funcName' takes 2 args but received less")
+}
+
 func TestPrepareMethodArgumentsForCallWithArrayOfByteArrays(t *testing.T) {
 	s := &service{}
 
@@ -84,6 +110,19 @@ func TestPrepareMethodArgumentsForCallWithArrayOfByteArrays(t *testing.T) {
 
 	outValues := reflect.ValueOf(methodInstance).Call(inValues)
 	require.EqualValues(t, [][]byte{[]byte("one"), []byte("two")}, outValues[0].Interface())
+}
+
+func TestPrepareMethodArgumentsForCallWithArrayOfArraysOfStringsPassingTwoByteArrays(t *testing.T) {
+	s := &service{}
+
+	methodInstance := func(a ...[]string) [][]string {
+		return a
+	}
+
+	args := argsToArgumentArray([]byte("one"), []byte("two"))
+
+	_, err := s.prepareMethodInputArgsForCall(methodInstance, args, "funcName")
+	require.EqualError(t, err, "method 'funcName' expects arg 0 to be [][]byte but it has (BytesValue)6f6e65")
 }
 
 func TestPrepareMethodArgumentsForCallWithTwoByteArrays(t *testing.T) {

--- a/services/processor/native/call_test.go
+++ b/services/processor/native/call_test.go
@@ -54,6 +54,22 @@ func TestPrepareMethodArgumentsForCallWithArrayOfVariableLength(t *testing.T) {
 	require.EqualValues(t, []string{"one", "two"}, outValues[0].Interface().([]string))
 }
 
+func TestPrepareMethodArgumentsForCallWithArrayOfVariableLengthPassingNoArguments(t *testing.T) {
+	s := &service{}
+
+	methodInstance := func(a ...string) []string {
+		return a
+	}
+
+	args := argsToArgumentArray()
+
+	inValues, err := s.prepareMethodInputArgsForCall(methodInstance, args, "funcName")
+	require.NoError(t, err)
+
+	outValues := reflect.ValueOf(methodInstance).Call(inValues)
+	require.EqualValues(t, []string{}, outValues[0].Interface().([]string))
+}
+
 func TestPrepareMethodArgumentsForCallWithArrayOfByteArrays(t *testing.T) {
 	s := &service{}
 


### PR DESCRIPTION
Fixes the bug when `f(1)` would fail if it was defined in the smart contract.

```golang
package main

import "fmt"

func f(a int, bs...uint) {
	fmt.Println(a, bs)
}

func main() {
	f(1)
}
```