### PR TITLE
prefetch contract compiler dependencies and prevent go.mod changes

### DIFF
--- a/docker/build/Dockerfile.export
+++ b/docker/build/Dockerfile.export
@@ -5,7 +5,7 @@ RUN apt-get install -y git
 RUN mkdir -p /src/_tmp/processor-artifacts/native-src/
 COPY ./_dockerbuild/go.mod.template /src/_tmp/processor-artifacts/native-src/go.mod
 
-RUN cd /src/_tmp/processor-artifacts/native-src/ && go mod download && echo "Downloaded dependencies:" && go mod graph
+RUN cd /src/_tmp/processor-artifacts/native-src/ && go mod download && echo "Downloaded dependencies:" && go list -f '{{.ImportPath}} --> {{.Dir}}' all
 
 ADD ./_bin/orbs-node /opt/orbs/
 

--- a/docker/build/Dockerfile.export
+++ b/docker/build/Dockerfile.export
@@ -2,10 +2,10 @@ FROM golang:1.12.9
 
 RUN apt-get install -y git
 
-RUN mkdir -p /src/_tmp/processor-artifacts/native-src/
-COPY ./_dockerbuild/go.mod.template /src/_tmp/processor-artifacts/native-src/go.mod
+RUN mkdir -p /src/_tmp/processor-artifacts/
+COPY ./_dockerbuild/go.mod.template /src/_tmp/processor-artifacts/go.mod
 
-RUN cd /src/_tmp/processor-artifacts/native-src/ && go mod download && echo "Downloaded dependencies:" && go list -m all
+RUN cd /src/_tmp/processor-artifacts/ && go mod download && echo "Downloaded dependencies:" && go list -m all
 
 ADD ./_bin/orbs-node /opt/orbs/
 

--- a/docker/build/Dockerfile.export
+++ b/docker/build/Dockerfile.export
@@ -5,7 +5,7 @@ RUN apt-get install -y git
 RUN mkdir -p /src/_tmp/processor-artifacts/native-src/
 COPY ./_dockerbuild/go.mod.template /src/_tmp/processor-artifacts/native-src/go.mod
 
-RUN cd /src/_tmp/processor-artifacts/native-src/ && go mod download && echo "Downloaded dependencies:" && go list -m -f '{{.ImportPath}} --> {{.Dir}}' all
+RUN cd /src/_tmp/processor-artifacts/native-src/ && go mod download && echo "Downloaded dependencies:" && go list -m all
 
 ADD ./_bin/orbs-node /opt/orbs/
 

--- a/docker/build/Dockerfile.export
+++ b/docker/build/Dockerfile.export
@@ -5,6 +5,8 @@ RUN apt-get install -y git
 RUN mkdir -p /src/_tmp/processor-artifacts/native-src/
 COPY ./_dockerbuild/go.mod.template /src/_tmp/processor-artifacts/native-src/go.mod
 
+RUN cd /src/_tmp/processor-artifacts/native-src/ && go mod download && echo "Downloaded dependencies:" && go mod graph
+
 ADD ./_bin/orbs-node /opt/orbs/
 
 VOLUME /usr/local/var/orbs/

--- a/docker/build/Dockerfile.export
+++ b/docker/build/Dockerfile.export
@@ -5,7 +5,7 @@ RUN apt-get install -y git
 RUN mkdir -p /src/_tmp/processor-artifacts/native-src/
 COPY ./_dockerbuild/go.mod.template /src/_tmp/processor-artifacts/native-src/go.mod
 
-RUN cd /src/_tmp/processor-artifacts/native-src/ && go mod download && echo "Downloaded dependencies:" && go list -f '{{.ImportPath}} --> {{.Dir}}' all
+RUN cd /src/_tmp/processor-artifacts/native-src/ && go mod download && echo "Downloaded dependencies:" && go list -m -f '{{.ImportPath}} --> {{.Dir}}' all
 
 ADD ./_bin/orbs-node /opt/orbs/
 

--- a/docker/build/Dockerfile.export
+++ b/docker/build/Dockerfile.export
@@ -5,7 +5,7 @@ RUN apt-get install -y git
 RUN mkdir -p /src/_tmp/processor-artifacts/
 COPY ./_dockerbuild/go.mod.template /src/_tmp/processor-artifacts/go.mod
 
-RUN cd /src/_tmp/processor-artifacts/ && go mod download && echo "Downloaded dependencies:" && go list -m all
+RUN cd /src/_tmp/processor-artifacts/ && go mod download
 
 ADD ./_bin/orbs-node /opt/orbs/
 

--- a/docker/build/go.mod.template
+++ b/docker/build/go.mod.template
@@ -7,6 +7,6 @@ go 1.12
 // so that built contracts won't break the system.
 
 require (
-    github.com/orbs-network/orbs-contract-sdk v1.1.0
+    github.com/orbs-network/orbs-contract-sdk v1.2.0
     golang.org/x/crypto c126467
 )

--- a/docker/build/go.mod.template
+++ b/docker/build/go.mod.template
@@ -7,6 +7,6 @@ go 1.12
 // so that built contracts won't break the system.
 
 require (
-    github.com/orbs-network/orbs-contract-sdk v1.2.0
-    golang.org/x/crypto c126467
+	github.com/orbs-network/orbs-contract-sdk v1.2.0
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 )

--- a/services/processor/native/adapter/native_compiler.go
+++ b/services/processor/native/adapter/native_compiler.go
@@ -119,11 +119,15 @@ func (c *nativeCompiler) Compile(ctx context.Context, code ...string) (*sdkConte
 	if err != nil {
 
 		// add all available modules to error output for troubleshooting
-		cmd := exec.Command("go", "list", "-m", "all")
+		cmd := exec.Command("go", "list", "-m")
 		out, _ := cmd.CombinedOutput()
 		dep := string(out)
 
-		return nil, errors.Wrap(err, fmt.Sprintf("could not build a shared object:\n%s", dep))
+		cmd = exec.Command("pwd")
+		out, _ = cmd.CombinedOutput()
+		pwd := string(out)
+
+		return nil, errors.Wrap(err, fmt.Sprintf("could not build a shared object module %s at %s", dep, pwd))
 	}
 
 	logger.Info("loading shared object", log.String("so-path", soFilePath))
@@ -194,7 +198,7 @@ func buildSharedObject(ctx context.Context, filenamePrefix string, sourceFilePat
 		"GOPATH=" + getGOPATH(),
 		"PATH=" + os.Getenv("PATH"),
 		"GOCACHE=" + filepath.Join(artifactsPath, GC_CACHE_PATH),
-		//"GO111MODULE=on",
+		"GO111MODULE=on",
 		// "GOGC=off", (this improves compilation time by a small factor)
 	}
 	out, err := cmd.CombinedOutput()

--- a/services/processor/native/adapter/native_compiler.go
+++ b/services/processor/native/adapter/native_compiler.go
@@ -193,8 +193,8 @@ func buildSharedObject(ctx context.Context, filenamePrefix string, sourceFilePat
 	cmd.Env = []string{
 		"GOPATH=" + getGOPATH(),
 		"PATH=" + os.Getenv("PATH"),
-		"GO111MODULE=on",
 		"GOCACHE=" + filepath.Join(artifactsPath, GC_CACHE_PATH),
+		//"GO111MODULE=on",
 		// "GOGC=off", (this improves compilation time by a small factor)
 	}
 	out, err := cmd.CombinedOutput()

--- a/services/processor/native/adapter/native_compiler.go
+++ b/services/processor/native/adapter/native_compiler.go
@@ -179,7 +179,7 @@ func buildSharedObject(ctx context.Context, filenamePrefix string, sourceFilePat
 
 	// compile
 	goCmd := path.Join(runtime.GOROOT(), "bin", "go")
-	cmdArgs := []string{"build", "-buildmode=plugin", "-o", soFilePath}
+	cmdArgs := []string{"build", "-buildmode=plugin", "-mod=readonly", "-o", soFilePath}
 	cmdArgs = append(cmdArgs, sourceFilePaths...)
 
 	cmd := exec.CommandContext(ctx, goCmd, cmdArgs...)

--- a/services/processor/native/adapter/native_compiler.go
+++ b/services/processor/native/adapter/native_compiler.go
@@ -117,12 +117,7 @@ func (c *nativeCompiler) Compile(ctx context.Context, code ...string) (*sdkConte
 	soFilePath, err := buildSharedObject(ctx, hashOfCode, sourceCodeFilePaths, artifactsPath)
 	c.metrics.buildTime.RecordSince(buildTime)
 	if err != nil {
-
-		// add all available modules to error output for troubleshooting
-		out, _ := runGoCommand(ctx, artifactsPath, "list", "-m")
-		dep := string(out)
-
-		return nil, errors.Wrap(err, fmt.Sprintf("could not build a shared object. module %s at %s", dep, artifactsPath))
+		return nil, errors.Wrap(err, "could not build a shared object")
 	}
 
 	logger.Info("loading shared object", log.String("so-path", soFilePath))

--- a/services/processor/native/adapter/native_compiler.go
+++ b/services/processor/native/adapter/native_compiler.go
@@ -119,7 +119,7 @@ func (c *nativeCompiler) Compile(ctx context.Context, code ...string) (*sdkConte
 	if err != nil {
 
 		// add all available modules to error output for troubleshooting
-		cmd := exec.Command("go", "list", "-m", "-f", "'{{.ImportPath}} --> {{.Dir}}'", "all")
+		cmd := exec.Command("go", "list", "-m", "all")
 		out, _ := cmd.CombinedOutput()
 		dep := string(out)
 

--- a/test/e2e/file_utils.go
+++ b/test/e2e/file_utils.go
@@ -49,7 +49,7 @@ func getVirtualChainDataDir(virtualChainId primitives.VirtualChainId) string {
 }
 
 func getProcessorArtifactPath(virtualChainId primitives.VirtualChainId) (string, string) {
-	dir := filepath.Join(config.GetCurrentSourceFileDirPath(), "_tmp", vChainPathComponent(virtualChainId))
+	dir := filepath.Join(os.TempDir(), "orbs", "processorArtifacts", vChainPathComponent(virtualChainId))
 	return filepath.Join(dir, "processor-artifacts"), dir
 }
 
@@ -80,4 +80,23 @@ func deployBlockStorageFiles(targetDir string, logger log.Logger) {
 
 func vChainPathComponent(virtualChainId primitives.VirtualChainId) string {
 	return fmt.Sprintf("vcid_%d", virtualChainId)
+}
+
+func setUpProcessorArtifactPath(virtualChainId primitives.VirtualChainId) string {
+	processorArtifactPath, _ := getProcessorArtifactPath(virtualChainId)
+
+	// copy go.mod file:
+	err := os.MkdirAll(processorArtifactPath, 0755)
+	//exec.Command("mkdir", "-p", targetGoModPath).Run()
+	if err != nil {
+		panic(fmt.Sprintf("failed to make dir: %s", err.Error()))
+	}
+
+	sourceGoModPath := filepath.Join(config.GetCurrentSourceFileDirPath(), "..", "..", "docker/build", "go.mod.template")
+	targetGoModPath := filepath.Join(processorArtifactPath, "go.mod")
+	err = CopyFile(sourceGoModPath, targetGoModPath)
+	if err != nil {
+		panic(fmt.Sprintf("failed to copy go.mod file: %s", err.Error()))
+	}
+	return processorArtifactPath
 }

--- a/test/e2e/file_utils.go
+++ b/test/e2e/file_utils.go
@@ -87,7 +87,6 @@ func setUpProcessorArtifactPath(virtualChainId primitives.VirtualChainId) string
 
 	// copy go.mod file:
 	err := os.MkdirAll(processorArtifactPath, 0755)
-	//exec.Command("mkdir", "-p", targetGoModPath).Run()
 	if err != nil {
 		panic(fmt.Sprintf("failed to make dir: %s", err.Error()))
 	}

--- a/test/e2e/network.go
+++ b/test/e2e/network.go
@@ -95,7 +95,7 @@ func bootstrapE2ENetwork(portOffset int, logFilePrefix string, virtualChainId pr
 		}
 
 		nodeLogger := logger.WithOutput(console, log.NewFormattingOutput(logFile, log.NewJsonFormatter()))
-		processorArtifactPath, _ := getProcessorArtifactPath(virtualChainId)
+		processorArtifactPath := setUpProcessorArtifactPath(virtualChainId)
 
 		cfg := config.
 			ForE2E(


### PR DESCRIPTION
To reduce compilation time we download all dependencies of the contract compiler (contract sdk) when building the docker image. 

in addition, when invoking the compiler, disallow making any changes to go.mod file. if changes are required the compilation fails