### PR TITLE
disable ./git-submodule-checkout.sh in githooks

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -5,4 +5,5 @@
 # and a flag indicating whether the checkout was a branch checkout (changing branches, flag=1) or a file checkout
 # (retrieving a file from the index, flag=0). This hook cannot affect the outcome of git checkout.
 
-./git-submodule-checkout.sh
+# enable if rolling back from go-modules to vendoring with git-sub-modules
+# ./git-submodule-checkout.sh

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -5,4 +5,5 @@
 # This hook cannot affect the outcome of git merge and is not executed, if the merge failed due to conflicts.
 #
 
-./git-submodule-checkout.sh
+# enable if rolling back from go-modules to vendoring with git-sub-modules
+# ./git-submodule-checkout.sh


### PR DESCRIPTION
the hooks has some flaws. and occasionally when failures occurred it left the folders in a messed up state. which is why I'm removing it now that we require it's use less frequently - since the transition to go modules