### PR TITLE
Resolve flakiness in trigger_test.go

### DIFF
--- a/synchronization/trigger_test.go
+++ b/synchronization/trigger_test.go
@@ -139,9 +139,11 @@ func TestPeriodicalTriggerKeepsGoingOnPanic(t *testing.T) {
 		}, nil)
 
 		// a second invocation of the handler means the trigger recovered from the first panic
+		var lastObservedInvocationCount uint32
 		require.True(t, test.Eventually(1*time.Second, func() bool {
-			return atomic.LoadUint32(&handlerInvocationCount) >= 2
-		}), "expected trigger to have ticked more than once (even though it panics) but it ticked %d", atomic.LoadUint32(&handlerInvocationCount))
+			lastObservedInvocationCount = atomic.LoadUint32(&handlerInvocationCount)
+			return lastObservedInvocationCount >= 2
+		}), "expected trigger to have ticked more than once (even though it panics) but it ticked %d", lastObservedInvocationCount)
 
 		p.Stop()
 	})

--- a/synchronization/trigger_test.go
+++ b/synchronization/trigger_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/orbs-network/orbs-network-go/test"
 	"github.com/orbs-network/scribe/log"
 	"github.com/stretchr/testify/require"
-	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -99,7 +98,6 @@ func TestPeriodicalTriggerStopOnContextCancelWithStopAction(t *testing.T) {
 		p := synchronization.NewPeriodicalTrigger(ctx, "a periodical trigger", time.Millisecond*2, harness.Logger, func() {}, func() { close(ch) })
 		harness.Supervise(p)
 		cancel()
-		runtime.Gosched() // yield
 		_, ok := <-ch
 		require.False(t, ok, "expected trigger stop action to close the channel")
 


### PR DESCRIPTION
See #1339 for flakiness in `TestPeriodicalTriggerKeepsGoingOnPanic` 
additionally noticed similar flakiness in `TestPeriodicalTriggerStartsOk`.

This PR addresses both issues