### PR TITLE
Failing Tamperer Transport - error message not clear when failing Send() intentionally

### DIFF
--- a/services/gossip/adapter/testkit/tamperers.go
+++ b/services/gossip/adapter/testkit/tamperers.go
@@ -8,6 +8,7 @@ package testkit
 
 import (
 	"context"
+	"fmt"
 	"github.com/orbs-network/govnr"
 	"github.com/orbs-network/orbs-network-go/instrumentation/logfields"
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
@@ -21,9 +22,17 @@ type failingTamperer struct {
 	transport *TamperingTransport
 }
 
+type messageDroppedByTamperer struct {
+	Data *adapter.TransportData
+}
+
+func (e *messageDroppedByTamperer) Error() string {
+	return fmt.Sprintf("tampering transport intentionally failed to send: %v", e.Data)
+}
+
 func (o *failingTamperer) maybeTamper(ctx context.Context, data *adapter.TransportData) (err error, returnWithoutSending bool) {
 	if o.predicate(data) {
-		return &adapter.ErrTransportFailed{Data: data}, true
+		return &messageDroppedByTamperer{Data: data}, true
 	}
 
 	return nil, false

--- a/services/gossip/adapter/transport.go
+++ b/services/gossip/adapter/transport.go
@@ -34,21 +34,6 @@ type TransportListener interface {
 	OnTransportMessageReceived(ctx context.Context, payloads [][]byte)
 }
 
-type ErrCorruptData struct {
-}
-
-func (e *ErrCorruptData) Error() string {
-	return fmt.Sprintf("transport data is corrupt and missing required fields")
-}
-
-type ErrTransportFailed struct {
-	Data *TransportData
-}
-
-func (e *ErrTransportFailed) Error() string {
-	return fmt.Sprintf("transport failed to send: %v", e.Data)
-}
-
 func (d *TransportData) TotalSize() (res int) {
 	for _, payload := range d.Payloads {
 		res += len(payload)


### PR DESCRIPTION
Fixes #1357 

* Removed unused struct `ErrCorruptData`
* Renamed `ErrTransportFailed` to `messageDroppedByTamperer` and moved into tamperers.go
* Modified wording in `messageDroppedByTamperer.Error()`
