### PR TITLE
Increase test timeout for message receival 

### DIFF
--- a/services/blockstorage/internodesync/harness.go
+++ b/services/blockstorage/internodesync/harness.go
@@ -180,7 +180,7 @@ func (h *blockSyncHarness) expectBroadcastOfBlockAvailabilityRequest() {
 }
 
 func (h *blockSyncHarness) verifyBroadcastOfBlockAvailabilityRequest(t *testing.T) {
-	require.NoError(t, test.EventuallyVerify(10*time.Millisecond, h.gossip), "broadcast should be sent")
+	require.NoError(t, test.EventuallyVerify(50*time.Millisecond, h.gossip), "broadcast should be sent")
 }
 
 func (h *blockSyncHarness) expectBlockValidationQueriesFromStorage(numExpectedBlocks int) {


### PR DESCRIPTION
Fixes: #1332 

Increase EventuallyVerify test timeout for message receival from 10m to 50ms (possible cause of flakiness)