### PR TITLE
Speed up block indexing by buffering reads

### DIFF
--- a/services/blockstorage/adapter/filesystem/codec.go
+++ b/services/blockstorage/adapter/filesystem/codec.go
@@ -291,6 +291,8 @@ func (c *codec) writeDynamicBlockSectionWithChecksum(w io.Writer, messages []mem
 }
 
 // TODO V1 see https://tree.taiga.io/project/orbs-network/us/681
+// TODO in case of a truncated file, the error could be either EOF or ErrUnexpectedEOF - consider changing
+//  this behaviour
 func (c *codec) decode(r io.Reader) (*protocol.BlockPairContainer, int, error) {
 	checkSum := crc32.New(crc32.MakeTable(crc32.Castagnoli))
 	tr := io.TeeReader(r, checkSum)
@@ -521,9 +523,6 @@ func readChunk(reader io.Reader, budget *readingBudget) ([]byte, error) {
 	n, err := io.ReadFull(reader, chunk)
 	if err != nil {
 		return nil, err
-	}
-	if n != len(chunk) {
-		return nil, fmt.Errorf("read %d bytes in block chuck while expecting %d", n, len(chunk))
 	}
 
 	budget.bytesRead += n

--- a/services/blockstorage/adapter/filesystem/codec.go
+++ b/services/blockstorage/adapter/filesystem/codec.go
@@ -518,7 +518,7 @@ func readChunk(reader io.Reader, budget *readingBudget) ([]byte, error) {
 	}
 
 	chunk := make([]byte, chunkLength)
-	n, err := reader.Read(chunk)
+	n, err := io.ReadFull(reader, chunk)
 	if err != nil {
 		return nil, err
 	}

--- a/services/blockstorage/adapter/filesystem/construct_index_test.go
+++ b/services/blockstorage/adapter/filesystem/construct_index_test.go
@@ -7,7 +7,6 @@
 package filesystem
 
 import (
-	"bufio"
 	"bytes"
 	"github.com/orbs-network/go-mock"
 	"github.com/orbs-network/orbs-network-go/test"
@@ -53,8 +52,8 @@ func TestConstructIndexFromReader(t *testing.T) {
 
 }
 
-func newBlockFileReadStream(t *testing.T, ctrlRand *rand.ControlledRand, numBlocks int32, codec *codec) (io.Reader, chan int) {
-	blocksQueue := builders.RandomizedBlockChain(numBlocks, ctrlRand)
+func newBlockFileReadStream(t *testing.T, ctrlRand *rand.ControlledRand, numBlocks int32, maxTransactions uint32, maxStateDiffs uint32, codec *codec) (io.Reader, chan int) {
+	blocksQueue := builders.RandomizedBlockChainWithLimit(numBlocks, ctrlRand, maxTransactions, maxStateDiffs)
 
 	pr, pw := io.Pipe()
 
@@ -71,13 +70,44 @@ func newBlockFileReadStream(t *testing.T, ctrlRand *rand.ControlledRand, numBloc
 	return pr, done
 }
 
+func OneByteAtATimeReader(t *testing.T, r io.Reader) (io.Reader, chan int) {
+	pr, pw := io.Pipe()
+
+	done := make(chan int)
+	go func() {
+		defer pw.Close()
+		defer close(done)
+
+		b := make([]byte, 1)
+
+		var err error
+		var n int
+		for err == nil {
+			n, err = io.ReadFull(r, b)
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err, "expected a byte from the stream or EOF")
+			require.Equal(t, 1, n, "expected exactly one byte from the stream")
+
+			n, err = pw.Write(b)
+			require.NoError(t, err, "Expected a successful write")
+			require.Equal(t, 1, n, "expected exactly one byte to be written")
+		}
+	}()
+
+	return pr, done
+}
+
 func TestBuildIndexSucceedsIndexingFromReader(t *testing.T) {
 	with.Logging(t, func(harness *with.LoggingHarness) {
 		const numBlocks = 17
+		const maxTransactions = 200
+		const maxStateDiffs = 200
 
 		ctrlRand := rand.NewControlledRand(t)
 		codec := newCodec(1024 * 1024)
-		r, done := newBlockFileReadStream(t, ctrlRand, numBlocks, codec)
+		r, done := newBlockFileReadStream(t, ctrlRand, numBlocks, maxTransactions, maxStateDiffs, codec)
 
 		bhIndex, err := buildIndex(r, 0, harness.Logger, codec)
 
@@ -88,21 +118,29 @@ func TestBuildIndexSucceedsIndexingFromReader(t *testing.T) {
 	})
 }
 
-func TestBuildIndexHandlesSmallBufferedReader(t *testing.T) {
+// The purpose of this test is to assure that buildIndex handles the case where a reader returns less bytes than
+// requested, even when more will be available in a subsequent read.
+// (this is the behaviour of the buffered reader we use for reading the block file)
+// To test this, we wrap the file reader with a reader that only returns one byte at a time.
+func TestBuildIndexHandlesPartialReads(t *testing.T) {
 	with.Logging(t, func(harness *with.LoggingHarness) {
-		const numBlocks = 17
+		// This test reads the file one byte at a time which is slow, so we use a small chain
+		const numBlocks = 2
+		const maxTransactions = 30
+		const maxStateDiffs = 30
 
 		ctrlRand := rand.NewControlledRand(t)
 		codec := newCodec(1024 * 1024)
-		r, done := newBlockFileReadStream(t, ctrlRand, numBlocks, codec)
+		r, done := newBlockFileReadStream(t, ctrlRand, numBlocks, maxTransactions, maxStateDiffs, codec)
 
-		rBuffered := bufio.NewReaderSize(r, 1)
+		rBuffered, done2 := OneByteAtATimeReader(t, r)
 		bhIndex, err := buildIndex(rBuffered, 0, harness.Logger, codec)
 
 		require.NoError(t, err, "expected buildIndex to succeed with a buffered reader")
 		require.Equal(t, bhIndex.topBlockHeight, primitives.BlockHeight(numBlocks), "expected block height to match the encoded block count")
 
 		<-done
+		<-done2
 	})
 }
 

--- a/services/blockstorage/adapter/filesystem/file_system_persistence.go
+++ b/services/blockstorage/adapter/filesystem/file_system_persistence.go
@@ -7,6 +7,7 @@
 package filesystem
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -213,6 +214,7 @@ func newFileBlockWriter(file *os.File, codec blockCodec, nextBlockOffset int64) 
 }
 
 func buildIndex(r io.Reader, firstBlockOffset int64, logger log.Logger, c blockCodec) (*blockHeightIndex, error) {
+	r = bufio.NewReaderSize(r, 1024*1024)
 	bhIndex := newBlockHeightIndex(logger, firstBlockOffset)
 	offset := int64(firstBlockOffset)
 	for {

--- a/test/builders/random_blocks.go
+++ b/test/builders/random_blocks.go
@@ -13,11 +13,15 @@ import (
 )
 
 func RandomizedBlockChain(numBlocks int32, ctrlRand *rand.ControlledRand) []*protocol.BlockPairContainer {
+	return RandomizedBlockChainWithLimit(numBlocks, ctrlRand, 200, 200)
+}
+
+func RandomizedBlockChainWithLimit(numBlocks int32, ctrlRand *rand.ControlledRand, maxTransactions uint32, maxStateDiffs uint32) []*protocol.BlockPairContainer {
 	blocks := make([]*protocol.BlockPairContainer, 0, numBlocks)
 
 	var prev *protocol.BlockPairContainer
 	for bi := 1; bi <= cap(blocks); bi++ {
-		newBlock := RandomizedBlock(primitives.BlockHeight(bi), ctrlRand, prev)
+		newBlock := RandomizedBlockWithLimit(primitives.BlockHeight(bi), ctrlRand, prev, maxTransactions, maxStateDiffs)
 		blocks = append(blocks, newBlock)
 		prev = newBlock
 	}
@@ -25,10 +29,14 @@ func RandomizedBlockChain(numBlocks int32, ctrlRand *rand.ControlledRand) []*pro
 }
 
 func RandomizedBlock(h primitives.BlockHeight, ctrlRand *rand.ControlledRand, prev *protocol.BlockPairContainer) *protocol.BlockPairContainer {
+	return RandomizedBlockWithLimit(h, ctrlRand, prev, 200, 200)
+}
+
+func RandomizedBlockWithLimit(h primitives.BlockHeight, ctrlRand *rand.ControlledRand, prev *protocol.BlockPairContainer, maxTransactions uint32, maxStateDiffs uint32) *protocol.BlockPairContainer {
 	builder := BlockPair().
 		WithHeight(h).
-		WithTransactions(ctrlRand.Uint32() % 200).
-		WithStateDiffs(ctrlRand.Uint32() % 200).
+		WithTransactions(ctrlRand.Uint32() % maxTransactions).
+		WithStateDiffs(ctrlRand.Uint32() % maxStateDiffs).
 		WithReceiptsForTransactions().
 		WithEmptyLeanHelixBlockProof()
 	if prev != nil {


### PR DESCRIPTION
This uses a buffered reader for more efficient reading of blocks from the disk.
Currently the buffer size is 1MB, which on my machine decreased the block indexing time for the 5GB block file from production from ~75 seconds to ~10 seconds.

also, resolved #1385