### PR TITLE
Serve HTTP requests early

### DIFF
--- a/bootstrap/gamma/server.go
+++ b/bootstrap/gamma/server.go
@@ -64,7 +64,8 @@ func StartGammaServer(config ServerConfig) *Server {
 	rootLogger.Info("finished creating development network")
 
 	httpServer := httpserver.NewHttpServer(httpserver.NewServerConfig(config.ServerAddress, config.Profiling),
-		rootLogger, network.PublicApi(0), network.MetricRegistry(0))
+		rootLogger, network.MetricRegistry(0))
+	httpServer.RegisterPublicApi(network.PublicApi(0))
 
 	s := &Server{
 		network:    network,

--- a/bootstrap/httpserver/server_handlers_test.go
+++ b/bootstrap/httpserver/server_handlers_test.go
@@ -27,244 +27,244 @@ import (
 
 func TestHttpServer_SendTransaction_Basic(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
+		withServerHarness(parent, func(h *harness) {
+			response := &client.SendTransactionResponseBuilder{
+				RequestResult:     aCompletedResult(),
+				TransactionStatus: protocol.TRANSACTION_STATUS_COMMITTED,
+			}
+			h.onSendTransaction().Return(&services.SendTransactionOutput{ClientResponse: response.Build()}, nil)
 
-		response := &client.SendTransactionResponseBuilder{
-			RequestResult:     aCompletedResult(),
-			TransactionStatus: protocol.TRANSACTION_STATUS_COMMITTED,
-		}
-		h.onSendTransaction().Return(&services.SendTransactionOutput{ClientResponse: response.Build()}, nil)
+			rec := h.sendTransaction(builders.TransferTransaction().Builder())
 
-		rec := h.sendTransaction(builders.TransferTransaction().Builder())
-
-		require.Equal(t, http.StatusOK, rec.Code, "should succeed")
+			require.Equal(t, http.StatusOK, rec.Code, "should succeed")
+		})
 	})
 }
 
 func TestHttpServer_SendTransaction_Error(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
+		withServerHarness(parent, func(h *harness) {
+			h.onSendTransaction().Return(nil, errors.Errorf("kaboom"))
 
-		h.onSendTransaction().Return(nil, errors.Errorf("kaboom"))
+			rec := h.sendTransaction(builders.TransferTransaction().Builder())
 
-		rec := h.sendTransaction(builders.TransferTransaction().Builder())
-
-		require.Equal(t, http.StatusInternalServerError, rec.Code, "should fail with 500")
+			require.Equal(t, http.StatusInternalServerError, rec.Code, "should fail with 500")
+		})
 	})
 }
 
 func TestHttpServer_SendTransactionAsync_Basic(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
+		withServerHarness(parent, func(h *harness) {
+			response := &client.SendTransactionResponseBuilder{
+				RequestResult: &client.RequestResultBuilder{
+					RequestStatus:  protocol.REQUEST_STATUS_IN_PROCESS,
+					BlockHeight:    1,
+					BlockTimestamp: primitives.TimestampNano(time.Now().UnixNano()),
+				},
+				TransactionStatus: protocol.TRANSACTION_STATUS_PENDING,
+			}
+			h.onSendTransactionAsync().Return(&services.SendTransactionOutput{ClientResponse: response.Build()})
 
-		response := &client.SendTransactionResponseBuilder{
-			RequestResult: &client.RequestResultBuilder{
-				RequestStatus:  protocol.REQUEST_STATUS_IN_PROCESS,
-				BlockHeight:    1,
-				BlockTimestamp: primitives.TimestampNano(time.Now().UnixNano()),
-			},
-			TransactionStatus: protocol.TRANSACTION_STATUS_PENDING,
-		}
-		h.onSendTransactionAsync().Return(&services.SendTransactionOutput{ClientResponse: response.Build()})
+			rec := h.sendTransactionAsync(builders.TransferTransaction().Builder())
 
-		rec := h.sendTransactionAsync(builders.TransferTransaction().Builder())
-
-		require.Equal(t, http.StatusAccepted, rec.Code, "should be accepted (202)")
+			require.Equal(t, http.StatusAccepted, rec.Code, "should be accepted (202)")
+		})
 	})
 }
 
 func TestHttpServer_RunQuery_Basic(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
-		response := &client.RunQueryResponseBuilder{
-			RequestResult: aCompletedResult(),
-			QueryResult: &protocol.QueryResultBuilder{
-				ExecutionResult: protocol.EXECUTION_RESULT_SUCCESS,
-			},
-		}
+		withServerHarness(parent, func(h *harness) {
+			response := &client.RunQueryResponseBuilder{
+				RequestResult: aCompletedResult(),
+				QueryResult: &protocol.QueryResultBuilder{
+					ExecutionResult: protocol.EXECUTION_RESULT_SUCCESS,
+				},
+			}
 
-		h.onRunQuery().Return(&services.RunQueryOutput{ClientResponse: response.Build()})
+			h.onRunQuery().Return(&services.RunQueryOutput{ClientResponse: response.Build()})
 
-		rec := h.runQuery()
+			rec := h.runQuery()
 
-		require.Equal(t, http.StatusOK, rec.Code, "should succeed")
-		// actual values are checked in the server_test.go as unit test of internal WriteMembuffResponse
+			require.Equal(t, http.StatusOK, rec.Code, "should succeed")
+			// actual values are checked in the server_test.go as unit test of internal WriteMembuffResponse
+		})
 	})
 }
 
 func TestHttpServer_RunQuery_Error(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
-		h.onRunQuery().Return(nil, errors.Errorf("kaboom"))
+		withServerHarness(parent, func(h *harness) {
+			h.onRunQuery().Return(nil, errors.Errorf("kaboom"))
 
-		rec := h.runQuery()
+			rec := h.runQuery()
 
-		require.Equal(t, http.StatusInternalServerError, rec.Code, "should fail with 500")
-		// actual values are checked in the server_test.go as unit test of internal writeErrorResponseAndLog
+			require.Equal(t, http.StatusInternalServerError, rec.Code, "should fail with 500")
+			// actual values are checked in the server_test.go as unit test of internal writeErrorResponseAndLog
+		})
 	})
 }
 
 func TestHttpServer_GetTransactionStatus_Basic(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
-		response := &client.GetTransactionStatusResponseBuilder{
-			RequestResult:     aCompletedResult(),
-			TransactionStatus: protocol.TRANSACTION_STATUS_COMMITTED,
-		}
+		withServerHarness(parent, func(h *harness) {
+			response := &client.GetTransactionStatusResponseBuilder{
+				RequestResult:     aCompletedResult(),
+				TransactionStatus: protocol.TRANSACTION_STATUS_COMMITTED,
+			}
 
-		h.onGetTransactionStatus().Return(&services.GetTransactionStatusOutput{ClientResponse: response.Build()})
+			h.onGetTransactionStatus().Return(&services.GetTransactionStatusOutput{ClientResponse: response.Build()})
 
-		rec := h.getTransactionStatus()
+			rec := h.getTransactionStatus()
 
-		require.Equal(t, http.StatusOK, rec.Code, "should succeed")
-		// actual values are checked in the server_test.go as unit test of internal WriteMembuffResponse
+			require.Equal(t, http.StatusOK, rec.Code, "should succeed")
+			// actual values are checked in the server_test.go as unit test of internal WriteMembuffResponse
+		})
 	})
 }
 
 func TestHttpServer_GetTransactionStatus_Error(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
-		h.onGetTransactionStatus().Return(nil, errors.Errorf("stam"))
+		withServerHarness(parent, func(h *harness) {
+			h.onGetTransactionStatus().Return(nil, errors.Errorf("stam"))
 
-		rec := h.getTransactionStatus()
+			rec := h.getTransactionStatus()
 
-		require.Equal(t, http.StatusInternalServerError, rec.Code, "should fail with 500")
-		// actual values are checked in the server_test.go as unit test of internal writeErrorResponseAndLog
+			require.Equal(t, http.StatusInternalServerError, rec.Code, "should fail with 500")
+			// actual values are checked in the server_test.go as unit test of internal writeErrorResponseAndLog
+		})
 	})
 }
 
 func TestHttpServer_GetTransactionReceiptProof_Basic(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
+		withServerHarness(parent, func(h *harness) {
+			response := &client.GetTransactionReceiptProofResponseBuilder{
+				RequestResult:     aCompletedResult(),
+				TransactionStatus: protocol.TRANSACTION_STATUS_COMMITTED,
+			}
+			h.onGetTransactionReceiptProof().Return(&services.GetTransactionReceiptProofOutput{ClientResponse: response.Build()})
 
-		response := &client.GetTransactionReceiptProofResponseBuilder{
-			RequestResult:     aCompletedResult(),
-			TransactionStatus: protocol.TRANSACTION_STATUS_COMMITTED,
-		}
-		h.onGetTransactionReceiptProof().Return(&services.GetTransactionReceiptProofOutput{ClientResponse: response.Build()})
+			rec := h.getTransactionReceiptProof()
 
-		rec := h.getTransactionReceiptProof()
-
-		require.Equal(t, http.StatusOK, rec.Code, "should succeed")
-		// actual values are checked in the server_test.go as unit test of internal WriteMembuffResponse
+			require.Equal(t, http.StatusOK, rec.Code, "should succeed")
+			// actual values are checked in the server_test.go as unit test of internal WriteMembuffResponse
+		})
 	})
 }
 
 func TestHttpServer_GetTransactionReceiptProof_Error(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
-		h.onGetTransactionReceiptProof().Return(nil, errors.Errorf("kaboom"))
+		withServerHarness(parent, func(h *harness) {
+			h.onGetTransactionReceiptProof().Return(nil, errors.Errorf("kaboom"))
 
-		rec := h.getTransactionReceiptProof()
+			rec := h.getTransactionReceiptProof()
 
-		require.Equal(t, http.StatusInternalServerError, rec.Code, "should fail with 500")
-		// actual values are checked in the server_test.go as unit test of internal writeErrorResponseAndLog
+			require.Equal(t, http.StatusInternalServerError, rec.Code, "should fail with 500")
+			// actual values are checked in the server_test.go as unit test of internal writeErrorResponseAndLog
+		})
 	})
 }
 
 func TestHttpServer_GetBlock_Basic(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
-		response := &client.GetBlockResponseBuilder{
-			RequestResult: aCompletedResult(),
-		}
+		withServerHarness(parent, func(h *harness) {
+			response := &client.GetBlockResponseBuilder{
+				RequestResult: aCompletedResult(),
+			}
 
-		h.onGetBlock().Return(&services.GetBlockOutput{ClientResponse: response.Build()})
+			h.onGetBlock().Return(&services.GetBlockOutput{ClientResponse: response.Build()})
 
-		rec := h.getBlock()
+			rec := h.getBlock()
 
-		require.Equal(t, http.StatusOK, rec.Code, "should succeed")
-		// actual values are checked in the server_test.go as unit test of internal WriteMembuffResponse
+			require.Equal(t, http.StatusOK, rec.Code, "should succeed")
+			// actual values are checked in the server_test.go as unit test of internal WriteMembuffResponse
+		})
 	})
 }
 
 func TestHttpServer_GetBlock_Error(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
-		h.onGetBlock().Return(nil, errors.Errorf("kaboom"))
+		withServerHarness(parent, func(h *harness) {
+			h.onGetBlock().Return(nil, errors.Errorf("kaboom"))
 
-		rec := h.getBlock()
+			rec := h.getBlock()
 
-		require.Equal(t, http.StatusInternalServerError, rec.Code, "should fail with 500")
-		// actual values are checked in the server_test.go as unit test of internal writeErrorResponseAndLog
+			require.Equal(t, http.StatusInternalServerError, rec.Code, "should fail with 500")
+			// actual values are checked in the server_test.go as unit test of internal writeErrorResponseAndLog
+		})
 	})
 }
 
 func TestHttpServer_Index(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
-		req, _ := http.NewRequest("GET", "/", nil)
-		rec := httptest.NewRecorder()
-		h.server.Index(rec, req)
+		withServerHarness(parent, func(h *harness) {
+			req, _ := http.NewRequest("GET", "/", nil)
+			rec := httptest.NewRecorder()
+			h.server.Index(rec, req)
 
-		require.Equal(t, http.StatusOK, rec.Code, "should return 200")
+			require.Equal(t, http.StatusOK, rec.Code, "should return 200")
 
-		reqNotFound, _ := http.NewRequest("GET", "/does-not-exist", nil)
-		recNotFound := httptest.NewRecorder()
-		h.server.Index(recNotFound, reqNotFound)
+			reqNotFound, _ := http.NewRequest("GET", "/does-not-exist", nil)
+			recNotFound := httptest.NewRecorder()
+			h.server.Index(recNotFound, reqNotFound)
 
-		require.Equal(t, http.StatusNotFound, recNotFound.Code, "should return 404")
+			require.Equal(t, http.StatusNotFound, recNotFound.Code, "should return 404")
+		})
 	})
 }
 
 func TestHttpServer_Robots(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
-		h := newHarness(parent)
+		withServerHarness(parent, func(h *harness) {
+			req, _ := http.NewRequest("Get", "/robots.txt", nil)
+			rec := httptest.NewRecorder()
+			h.server.robots(rec, req)
 
-		req, _ := http.NewRequest("Get", "/robots.txt", nil)
-		rec := httptest.NewRecorder()
-		h.server.robots(rec, req)
+			expectedResponse := "User-agent: *\nDisallow: /\n"
 
-		expectedResponse := "User-agent: *\nDisallow: /\n"
-
-		require.Equal(t, http.StatusOK, rec.Code, "should succeed")
-		require.Equal(t, "text/plain", rec.Header().Get("Content-Type"), "should have our content type")
-		require.Equal(t, expectedResponse, rec.Body.String(), "should have text value")
+			require.Equal(t, http.StatusOK, rec.Code, "should succeed")
+			require.Equal(t, "text/plain", rec.Header().Get("Content-Type"), "should have our content type")
+			require.Equal(t, expectedResponse, rec.Body.String(), "should have text value")
+		})
 	})
 }
 
 func TestPublicApiResponds503UntilPublicApiIsRegistered(t *testing.T) {
-	with.Logging(t, func(harness *with.LoggingHarness) {
-		h := newHarnessWithUnregisteredPublicApi(harness)
-		defer h.server.Shutdown()
-		port := h.server.Port()
+	with.Logging(t, func(parent *with.LoggingHarness) {
+		withUnregisteredPublicApiServerHarness(parent, func(h *harness) {
+			resp, err := h.GetBlockThroughHTTP()
+			require.NoError(t, err, "expected HTTP request to succeed")
+			defer resp.Body.Close()
 
-		request := (&client.GetBlockRequestBuilder{BlockHeight: 1}).Build()
-		req, _ := http.NewRequest("POST", fmt.Sprintf("http://127.0.0.1:%d/api/v1/get-block", port), bytes.NewReader(request.Raw()))
+			require.Equal(t, resp.StatusCode, 503, "expected publicapi endpoint to respond with HTTP 503")
 
-		//defer h.server.GracefulShutdown()
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err, "expected HTTP request to succeed")
-		defer resp.Body.Close()
+			response := &client.GetBlockResponseBuilder{
+				RequestResult: aCompletedResult(),
+			}
+			h.onGetBlock().Return(&services.GetBlockOutput{ClientResponse: response.Build()})
 
-		require.Equal(t, resp.StatusCode, 503, "expected publicapi endpoint to respond with HTTP 503")
+			h.server.RegisterPublicApi(h.publicApi)
 
-		response := &client.GetBlockResponseBuilder{
-			RequestResult: aCompletedResult(),
-		}
-		h.onGetBlock().Return(&services.GetBlockOutput{ClientResponse: response.Build()})
+			resp, err = h.GetBlockThroughHTTP()
+			require.NoError(t, err, "expected HTTP request to succeed")
+			defer resp.Body.Close()
 
-		h.server.RegisterPublicApi(h.publicApi)
-
-		resp, err = http.DefaultClient.Do(req)
-		require.NoError(t, err, "expected HTTP request to succeed")
-		defer resp.Body.Close()
-
-		require.Equal(t, resp.StatusCode, 200, "expected publicapi endpoint to respond with http 200")
+			require.Equal(t, resp.StatusCode, 200, "expected publicapi endpoint to respond with http 200")
+		})
 	})
 }
 
 func TestNonPublicApiIsAvailableImmediately(t *testing.T) {
-	with.Logging(t, func(harness *with.LoggingHarness) {
-		h := newHarnessWithUnregisteredPublicApi(harness)
-		defer h.server.Shutdown()
-		port := h.server.Port()
+	with.Logging(t, func(parent *with.LoggingHarness) {
+		withUnregisteredPublicApiServerHarness(parent, func(h *harness) {
+			resp, err := h.GetRobotsTxtThroughHTTP()
+			require.NoError(t, err, "expected HTTP request to succeed")
+			defer resp.Body.Close()
 
-		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/robots.txt", port))
-		require.NoError(t, err, "expected HTTP request to succeed")
-		defer resp.Body.Close()
-
-		require.Equal(t, resp.StatusCode, 200, "expected robots.txt endpoint to respond with HTTP 200")
+			require.Equal(t, resp.StatusCode, 200, "expected robots.txt endpoint to respond with HTTP 200")
+		})
 	})
 }
 
@@ -280,6 +280,14 @@ type harness struct {
 	*with.LoggingHarness
 	publicApi *services.MockPublicApi
 	server    *HttpServer
+}
+
+func (h *harness) shutdown() {
+	h.server.Shutdown()
+}
+
+func (h *harness) buildUrl(urlPath string) string {
+	return fmt.Sprintf("http://127.0.0.1:%d%s", h.server.port, urlPath)
 }
 
 func (h *harness) onSendTransaction() *mock.MockFunction {
@@ -366,17 +374,30 @@ func (h *harness) getBlock() *httptest.ResponseRecorder {
 	return rec
 }
 
-func newHarness(parent *with.LoggingHarness) *harness {
-	h := newHarnessWithUnregisteredPublicApi(parent)
-	h.server.RegisterPublicApi(h.publicApi)
-	return h
+func (h *harness) GetBlockThroughHTTP() (*http.Response, error) {
+	request := (&client.GetBlockRequestBuilder{BlockHeight: 1}).Build()
+	httpReq, _ := http.NewRequest("POST", h.buildUrl("/api/v1/get-block"), bytes.NewReader(request.Raw()))
+	return http.DefaultClient.Do(httpReq)
 }
 
-func newHarnessWithUnregisteredPublicApi(parent *with.LoggingHarness) *harness {
+func (h *harness) GetRobotsTxtThroughHTTP() (*http.Response, error) {
+	return http.Get(h.buildUrl("/robots.txt"))
+}
+
+func withUnregisteredPublicApiServerHarness(parent *with.LoggingHarness, f func(h *harness)) {
 	papiMock := &services.MockPublicApi{}
-	return &harness{
+	h := &harness{
 		LoggingHarness: parent,
 		publicApi:      papiMock,
 		server:         NewHttpServer(NewServerConfig(":0", false), parent.Logger, metric.NewRegistry()),
 	}
+	defer h.shutdown()
+	f(h)
+}
+
+func withServerHarness(parent *with.LoggingHarness, f func(h *harness)) {
+	withUnregisteredPublicApiServerHarness(parent, func(h *harness) {
+		h.server.RegisterPublicApi(h.publicApi)
+		f(h)
+	})
 }

--- a/bootstrap/httpserver/server_handlers_test.go
+++ b/bootstrap/httpserver/server_handlers_test.go
@@ -231,7 +231,7 @@ func TestHttpServer_Robots(t *testing.T) {
 	})
 }
 
-func TestPublicApiResponds503UntilPublicApiIsRegistered(t *testing.T) {
+func TestHttpServer_PublicApiResponds503UntilRegistered(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
 		withUnregisteredPublicApiServerHarness(parent, func(h *harness) {
 			resp, err := h.GetBlockThroughHTTP()
@@ -256,7 +256,7 @@ func TestPublicApiResponds503UntilPublicApiIsRegistered(t *testing.T) {
 	})
 }
 
-func TestNonPublicApiIsAvailableImmediately(t *testing.T) {
+func TestHttpServer_NonPublicApiIsAvailableImmediately(t *testing.T) {
 	with.Logging(t, func(parent *with.LoggingHarness) {
 		withUnregisteredPublicApiServerHarness(parent, func(h *harness) {
 			resp, err := h.GetRobotsTxtThroughHTTP()


### PR DESCRIPTION
fixes #1371 

This will make the HTTP server launch immediately and serve non public-api endpoints (metrics, robots.txt, etc) while the node is initializing. 