### PR TITLE
Fix flakiness of TestFullFlowWithVaryingTimestamps

### DIFF
--- a/services/crosschainconnector/ethereum/test/external_block_timestamp_test.go
+++ b/services/crosschainconnector/ethereum/test/external_block_timestamp_test.go
@@ -53,8 +53,11 @@ func TestFullFlowWithVaryingTimestamps(t *testing.T) {
 			t.Logf("block at deploy: %d | %d", blockAtDeploy.BlockNumber, blockAtDeploy.TimeInSeconds)
 
 			t.Logf("finality is %f seconds, %d blocks", h.config.finalityTimeComponent.Seconds(), h.config.finalityBlocksComponent)
-			h.moveBlocksInGanache(t, ctx, int(h.config.finalityBlocksComponent+1), 1)                                                                                      // finality blocks + block we will request below of because of the finder algo
-			referenceTime := time.Unix(blockAtStart.TimeInSeconds, 0).Add(+h.config.finalityTimeComponent + time.Duration(h.config.finalityBlocksComponent+1)*time.Second) // we need time.Now()-finality to be: [ . . we-want-to-be-here . . lastBlock . . t.N()]
+			h.moveBlocksInGanache(t, ctx, int(h.config.finalityBlocksComponent+1), 1) // finality blocks + block we will request below of because of the finder algo
+
+			blockAfterPad, err := h.rpcAdapter.HeaderByNumber(ctx, nil)
+			require.NoError(t, err, "failed to get latest block in ganache")
+			referenceTime := time.Unix(blockAfterPad.TimeInSeconds, 0)
 
 			methodToCall := "getValues"
 			parsedABI, err := abi.JSON(strings.NewReader(contract.SimpleStorageABI))

--- a/services/crosschainconnector/ethereum/test/get_transaction_logs_test.go
+++ b/services/crosschainconnector/ethereum/test/get_transaction_logs_test.go
@@ -57,8 +57,12 @@ func TestEthereumConnector_GetTransactionLogs_ParsesASBEvent(t *testing.T) {
 			t.Logf("block after emit: %s", blockAfterEmit)
 
 			t.Logf("finality is %f seconds, %d blocks", h.config.finalityTimeComponent.Seconds(), h.config.finalityBlocksComponent)
-			h.moveBlocksInGanache(t, ctx, int(h.config.finalityBlocksComponent*2), 1)                                                                                     // finality blocks + block we will request below of because of the finder algo
-			referenceTime := time.Unix(blockAtDeploy.TimeInSeconds, 0).Add(+h.config.finalityTimeComponent + time.Duration(h.config.finalityBlocksComponent)*time.Second) // we need time.Now()-finality to be: [ . . we-want-to-be-here . . lastBlock . . t.N()]
+			h.moveBlocksInGanache(t, ctx, int(h.config.finalityBlocksComponent*2), 1) // finality blocks + block we will request below of because of the finder algo
+
+			blockAfterPad, err := h.rpcAdapter.HeaderByNumber(ctx, nil)
+			require.NoError(t, err, "failed to get latest block in ganache")
+			referenceTime := time.Unix(blockAfterPad.TimeInSeconds, 0)
+
 			t.Logf("reference time: %d", referenceTime.UnixNano())
 
 			out, err := h.connector.EthereumGetTransactionLogs(ctx, &services.EthereumGetTransactionLogsInput{

--- a/services/crosschainconnector/ethereum/test/get_transaction_logs_test.go
+++ b/services/crosschainconnector/ethereum/test/get_transaction_logs_test.go
@@ -118,8 +118,12 @@ func TestEthereumConnector_GetTransactionLogs_ParsesEventsWithAddressArray(t *te
 			require.NoError(t, err, "failed emitting event")
 
 			t.Logf("finality is %f seconds, %d blocks", h.config.finalityTimeComponent.Seconds(), h.config.finalityBlocksComponent)
-			h.moveBlocksInGanache(t, ctx, int(h.config.finalityBlocksComponent*2), 1)                                                                                     // finality blocks + block we will request below of because of the finder algo
-			referenceTime := time.Unix(blockAtDeploy.TimeInSeconds, 0).Add(+h.config.finalityTimeComponent + time.Duration(h.config.finalityBlocksComponent)*time.Second) // we need time.Now()-finality to be: [ . . we-want-to-be-here . . lastBlock . . t.N()]
+			h.moveBlocksInGanache(t, ctx, int(h.config.finalityBlocksComponent*2), 1) // finality blocks + block we will request below of because of the finder algo
+
+			blockAfterPad, err := h.rpcAdapter.HeaderByNumber(ctx, nil)
+			require.NoError(t, err, "failed to get latest block in ganache")
+			referenceTime := time.Unix(blockAfterPad.TimeInSeconds, 0)
+
 			t.Logf("reference time: %d", referenceTime.UnixNano())
 
 			out, err := h.connector.EthereumGetTransactionLogs(ctx, &services.EthereumGetTransactionLogsInput{


### PR DESCRIPTION
An unexpected delay between contract deployment and padding with blocks for finality can cause a failure:

```
Blk# | Time
369  | 66      start                <-   returned block - too early
370  | 67      deploy               <-   block at augmented reference
     | 68      (unexpceted delay)   <-   augmented reference
371  | 69      pad                  <-   reference = startTime + 3
372  | 70      pad

```
This changes the reference time to that of the most recent padding block.