### PR TITLE
Fix flakiness of TestReadFromEthereumLogsTakingFinalityIntoAccount

### DIFF
--- a/bootstrap/gamma/ethereum/ethereum_finality_test.go
+++ b/bootstrap/gamma/ethereum/ethereum_finality_test.go
@@ -117,9 +117,9 @@ func TestReadFromEthereumLogsTakingFinalityIntoAccount(t *testing.T) {
 
 		ensureFinalityInGanacheAndGamma(t, gammaEndpoint, ethRpc)
 
-		gamma.SendTransaction(t, orbs, contractOwner, "LogCalculator", "bind", loggerContractAddress.Bytes(), []byte(eth.LoggerABI)) // this happens AFTER moving time forwards so that a block with the new time is closed
+		res := gamma.SendTransaction(t, orbs, contractOwner, "LogCalculator", "bind", loggerContractAddress.Bytes(), []byte(eth.LoggerABI)) // this happens AFTER moving time forwards so that a block with the new time is closed
 
-		queryRes := gamma.SendQuery(t, orbs, contractOwner, "LogCalculator", "sum", strings.Join(txHashes, ","))
+		queryRes := gamma.SendQuery(t, orbs, contractOwner, res.BlockHeight, "LogCalculator", "sum", strings.Join(txHashes, ","))
 
 		require.EqualValues(t, 325, queryRes.OutputArguments[0], "did not get expected logs from Ethereum")
 	})

--- a/bootstrap/gamma/harness.go
+++ b/bootstrap/gamma/harness.go
@@ -73,12 +73,12 @@ func SendQuery(t testing.TB, orbs *orbsClient.OrbsClient, sender *orbsClient.Orb
 	q, err := orbs.CreateQuery(sender.PublicKey, contractName, method, args...)
 	require.NoError(t, err, "failed creating query %s.%s", contractName, method)
 
-	// Allow no more than 10 seconds for the network to sync
+	// Allow no more than 10 seconds for state storage to process previous blocks
 	var res *codec.RunQueryResponse
 	require.True(t, test.Eventually(10*time.Second, func() bool {
 		res, err = orbs.SendQuery(q)
 		return err != nil || res.BlockHeight >= minBlockHeight
-	}), "network did not sync - unable to obtain response for a lower bound block height")
+	}), "state storage is out of sync")
 
 	require.NoError(t, err, "failed sending query %s.%s", contractName, method)
 	require.EqualValues(t, codec.REQUEST_STATUS_COMPLETED.String(), res.RequestStatus.String(), "failed calling %s.%s", contractName, method)


### PR DESCRIPTION
At some point there is a query immediately following a transaction. In one of my executions the query failed because it ran on a node that wasn't synced with the transaction.
This will poll on the query result to assure that the block height is at least as high as that of the transaction.
Will poll for no longer than 10 seconds.