### PR TITLE
Fix benchmark consensus sync race

### DIFF
--- a/services/consensusalgo/benchmarkconsensus/non_leader.go
+++ b/services/consensusalgo/benchmarkconsensus/non_leader.go
@@ -70,9 +70,9 @@ func (s *Service) nonLeaderCommitAndReply(ctx context.Context, blockPair *protoc
 
 	// remember the block in our last committed state variable
 	if blockPair.TransactionsBlock.Header.BlockHeight() == lastCommittedBlockHeight+1 {
-		err = s.setLastCommittedBlock(blockPair, lastCommittedBlock)
-		if err != nil {
-			return err
+		updated := s.setLastCommittedBlockIfPreviousBlockMatches(blockPair, lastCommittedBlock)
+		if !updated {
+			return nil // Updated concurrently
 		}
 		// don't forget to update internal vars too since they may be used later on in the function
 		lastCommittedBlock = blockPair


### PR DESCRIPTION
There is a race when a node is updated with a new block concurrently through block sync and consensus. The consensus block sync handler will attempt to update the last committed block, but will find that the it doesn't match the current block and return with an error. Block sync in return will output an error to the log, and tests fail.

The solution suggested here is to not treat this as an error - it is a valid flow. Instead, add an info log and ignore.