### PR TITLE
Fix race with query immediately following contract deployment

### DIFF
--- a/test/e2e/deploy_experimental_test.go
+++ b/test/e2e/deploy_experimental_test.go
@@ -51,7 +51,7 @@ func TestContractExperimentalLibraries(t *testing.T) {
 		require.NoError(t, err, "add transaction should not return error")
 		requireSuccessful(t, addResponse)
 
-		queryResponse, err := h.EventuallyRunQueryWithoutError(5*time.Second, OwnerOfAllSupply.PublicKey(), contractName, "get", uint64(0))
+		queryResponse, err := h.runQueryAtBlockHeight(5*time.Second, addResponse.BlockHeight, OwnerOfAllSupply.PublicKey(), contractName, "get", uint64(0))
 		require.NoError(t, err)
 		require.EqualValues(t, "Diamond Dogs", queryResponse.OutputArguments[0])
 

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -70,12 +70,16 @@ func NewAppHarness() *Harness {
 	}
 }
 
+func isNotHttp202Error(err error) bool {
+	return !strings.Contains(err.Error(), "http status 202 Accepted")
+}
+
 func (h *Harness) DeployContract(from *keys.Ed25519KeyPair, contractName string, processorType orbsClient.ProcessorType, code ...[]byte) (*codec.TransactionResponse, error) {
 	timeoutDuration := 15 * time.Second
 	beginTime := time.Now()
 
 	txOut, txId, err := h.SendDeployTransaction(from.PublicKey(), from.PrivateKey(), contractName, processorType, code...)
-	if err != nil && !strings.Contains(err.Error(), "http status 202 Accepted") { // TODO the SDK treats HTTP 202 as an error
+	if err != nil && isNotHttp202Error(err) { // TODO the SDK treats HTTP 202 as an error
 		return nil, errors.Wrap(err, "failed to deploy native contract")
 	}
 

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -115,14 +115,6 @@ func (h *Harness) SendDeployTransaction(senderPublicKey []byte, senderPrivateKey
 	return out.TransactionResponse, txId, err
 }
 
-func (h *Harness) EventuallyRunQueryWithoutError(timeout time.Duration, senderPublicKey []byte, contractName string, methodName string, args ...interface{}) (response *codec.RunQueryResponse, err error) {
-	test.Eventually(timeout, func() bool {
-		response, err = h.RunQuery(senderPublicKey, contractName, methodName, args...)
-		return err == nil
-	})
-	return response, err
-}
-
 func (h *Harness) runQueryAtBlockHeight(timeout time.Duration, expectedBlockHeight uint64, senderPublicKey []byte, contractName string, methodName string, args ...interface{}) (*codec.RunQueryResponse, error) {
 	var lastErr error
 	var response *codec.RunQueryResponse

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -75,7 +75,7 @@ func (h *Harness) DeployContract(from *keys.Ed25519KeyPair, contractName string,
 	beginTime := time.Now()
 
 	txOut, txId, err := h.SendDeployTransaction(from.PublicKey(), from.PrivateKey(), contractName, processorType, code...)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "http status 202 Accepted") { // TODO the SDK treats HTTP 202 as an error
 		return nil, errors.Wrap(err, "failed to deploy native contract")
 	}
 


### PR DESCRIPTION
RunQuery returns an error when the contract is not deployed. This will suppress the error when polling for the correct block height. If polling is unsuccessful the last error will be returned.

Another related fix - when submitting a transaction synchronously, the SDK treats HTTP 202 (indicating the transaction is still pending) as an error. Added this as an exception in the test flow.