### PR TITLE
Add -race to the native compiler's build command when running with race

### DIFF
--- a/services/processor/native/adapter/native_compiler.go
+++ b/services/processor/native/adapter/native_compiler.go
@@ -178,7 +178,8 @@ func buildSharedObject(ctx context.Context, filenamePrefix string, sourceFilePat
 	}
 
 	// compile
-	args := append([]string{"build", "-buildmode=plugin", "-mod=readonly", "-o", soFilePath}, sourceFilePaths...)
+	args := append(addRaceFlagIfNeeded([]string{"build", "-buildmode=plugin", "-mod=readonly"}), "-o", soFilePath)
+	args = append(args, sourceFilePaths...)
 	out, err := runGoCommand(ctx, artifactsPath, args...)
 	if err != nil {
 		buildOutput := string(out)

--- a/services/processor/native/adapter/race_build_flag_norace.go
+++ b/services/processor/native/adapter/race_build_flag_norace.go
@@ -1,0 +1,7 @@
+//+build race
+
+package adapter
+
+func addRaceFlagIfNeeded(args []string) []string {
+	return append(args, "-race")
+}

--- a/services/processor/native/adapter/race_build_flag_withrace.go
+++ b/services/processor/native/adapter/race_build_flag_withrace.go
@@ -1,0 +1,7 @@
+//+build !race
+
+package adapter
+
+func addRaceFlagIfNeeded(args []string) []string {
+	return args
+}

--- a/test/e2e/deploy_experimental_test.go
+++ b/test/e2e/deploy_experimental_test.go
@@ -1,4 +1,3 @@
-//+build !race
 // Copyright 2019 the orbs-network-go authors
 // This file is part of the orbs-network-go library in the Orbs project.
 //

--- a/test/e2e/deploy_native_test.go
+++ b/test/e2e/deploy_native_test.go
@@ -1,4 +1,3 @@
-//+build !race
 // Copyright 2019 the orbs-network-go authors
 // This file is part of the orbs-network-go library in the Orbs project.
 //

--- a/test/e2e/deploy_native_whitelist_test.go
+++ b/test/e2e/deploy_native_whitelist_test.go
@@ -1,4 +1,3 @@
-//+build !race
 // Copyright 2019 the orbs-network-go authors
 // This file is part of the orbs-network-go library in the Orbs project.
 //


### PR DESCRIPTION
Fixes #1432 

To support running E2E tests with race detection.