### PR TITLE
Issue 1454: Update marvin dependencies in CircleCI; change its timing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,6 @@ workflows:
             tags:
               only: /^v.*/
       - races
-      - call_marvin
       - memory_leaks
       - deploy_new_chain_pr_only:
           requires:
@@ -240,6 +239,9 @@ workflows:
       - e2e_testnet_leanhelix:
           requires:
             - deploy_testnet
+      - call_marvin:
+          requires:
+            - e2e_testnet_leanhelix
       - release:
           requires:
             - tests

--- a/.circleci/marvin-stress.sh
+++ b/.circleci/marvin-stress.sh
@@ -3,8 +3,7 @@
 echo "Launching Marvin stress test"
 
 URI="ec2-34-222-245-15.us-west-2.compute.amazonaws.com:4567/jobs/start"
-
-curl -d '{"tpm":10, "duration_sec":300}' -H "Content-Type: application/json" -X POST ${URI}
+curl -d '{"tpm":60, "duration_sec":720, "client_timeout_sec": 180}' -H "Content-Type: application/json" -X POST ${URI}
 echo
 echo "Started Marvin test. Results will be posted to Slack channel #marvin-results."
 echo


### PR DESCRIPTION
- [ ] CircleCI: Run marvin test only after successful e2e (which itself executes only after deployment of new version to testnet).

- [ ] Fix timings to 60tpm, 720s test duration, 180s max client duration (so total of 3 client cycles and slack notifications during test)