### PR TITLE
Adding tac-like functionality for Mac OS based system so that test.sh would work

### DIFF
--- a/test.common.sh
+++ b/test.common.sh
@@ -3,6 +3,13 @@
 NIGHTLY=0
 mkdir -p _out
 
+OS=$(uname -s)
+if [ $OS == "Darwin" ]; then
+    tac () {
+        tail -r -- "$@";
+    }
+fi
+
 check_exit_code_and_report () {
     if [ $EXIT_CODE != 0 ]; then
         grep -B 150 -A 15 -- "FAIL:" ./$OUT_DUR/test.out > ./$OUT_DUR/fail.out


### PR DESCRIPTION
running test.sh locally would not bring meaningful output due to missing tac command on Darwin based systems. 

BSD-style system have most functionality of `tac` covered by `tail -r`

This PR deals with checking whether we are running on a Mac OS system and if so sets up a local function inside our test.common bash library for testing so that the system can have access to a similar `tac` functionality.