### PR TITLE
manual memory leak test - fixed

### DIFF
--- a/test/acceptance/api_responses_test.go
+++ b/test/acceptance/api_responses_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestResponseForTransactionOnValidContract(t *testing.T) {
-	newHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
+	NewHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
 		ctx, cancel := context.WithTimeout(parent, 1*time.Second)
 		defer cancel()
 
@@ -31,7 +31,7 @@ func TestResponseForTransactionOnValidContract(t *testing.T) {
 }
 
 func TestResponseForTransactionOnContractNotDeployed(t *testing.T) {
-	newHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
+	NewHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
 		ctx, cancel := context.WithTimeout(parent, 1*time.Second)
 		defer cancel()
 
@@ -44,7 +44,7 @@ func TestResponseForTransactionOnContractNotDeployed(t *testing.T) {
 }
 
 func TestResponseForTransactionOnContractWithBadInput(t *testing.T) {
-	newHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
+	NewHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
 		ctx, cancel := context.WithTimeout(parent, 1*time.Second)
 		defer cancel()
 
@@ -57,7 +57,7 @@ func TestResponseForTransactionOnContractWithBadInput(t *testing.T) {
 }
 
 func TestResponseForTransactionOnFailingContract(t *testing.T) {
-	newHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
+	NewHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
 		ctx, cancel := context.WithTimeout(parent, 1*time.Second)
 		defer cancel()
 
@@ -70,7 +70,7 @@ func TestResponseForTransactionOnFailingContract(t *testing.T) {
 }
 
 func TestResponseForTransactionWithInvalidProtocolVersion(t *testing.T) {
-	newHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
+	NewHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
 		ctx, cancel := context.WithTimeout(parent, 1*time.Second)
 		defer cancel()
 
@@ -83,7 +83,7 @@ func TestResponseForTransactionWithInvalidProtocolVersion(t *testing.T) {
 }
 
 func TestResponseForTransactionWithBadSignature(t *testing.T) {
-	newHarness().
+	NewHarness().
 		AllowingErrors("error validating transaction for preorder").
 		Start(t, func(t testing.TB, parent context.Context, network *Network) {
 			ctx, cancel := context.WithTimeout(parent, 1*time.Second)

--- a/test/acceptance/committee_election_test.go
+++ b/test/acceptance/committee_election_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestLeanHelix_CommitTransactionToElected(t *testing.T) {
-	newHarness().
+	NewHarness().
 		WithNumNodes(6).
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX).
 		Start(t, func(t testing.TB, ctx context.Context, network *Network) {
@@ -66,7 +66,7 @@ func TestLeanHelix_CommitTransactionToElected(t *testing.T) {
 }
 
 func TestLeanHelix_MultipleReElections(t *testing.T) {
-	newHarness().
+	NewHarness().
 		WithNumNodes(6).
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX).
 		Start(t, func(t testing.TB, ctx context.Context, network *Network) {
@@ -102,7 +102,7 @@ func TestLeanHelix_MultipleReElections(t *testing.T) {
 }
 
 func TestLeanHelix_AllNodesLoseElectionButReturn(t *testing.T) {
-	newHarness().
+	NewHarness().
 		WithEmptyBlockTime(100*time.Millisecond).
 		WithNumNodes(8).
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX).
@@ -152,7 +152,7 @@ func TestLeanHelix_AllNodesLoseElectionButReturn(t *testing.T) {
 }
 
 func TestLeanHelix_GrowingElectedAmount(t *testing.T) {
-	newHarness().
+	NewHarness().
 		WithNumNodes(7).
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX).
 		Start(t, func(t testing.TB, ctx context.Context, network *Network) {
@@ -191,7 +191,7 @@ func TestLeanHelix_GrowingElectedAmount(t *testing.T) {
 }
 
 func TestLeanHelix_CommitTransactionWithCommitteeContractTurnedOff(t *testing.T) {
-	newHarness().WithConfigOverride(func(cfg config.OverridableConfig) config.OverridableConfig {
+	NewHarness().WithConfigOverride(func(cfg config.OverridableConfig) config.OverridableConfig {
 		c, err := cfg.MergeWithFileConfig(`{"consensus-context-committee-using-contract": false}`)
 		require.NoError(t, err)
 		return c
@@ -218,7 +218,6 @@ func TestLeanHelix_CommitTransactionWithCommitteeContractTurnedOff(t *testing.T)
 
 		})
 }
-
 
 func verifyTxSignersAreFromGroup(t testing.TB, ctx context.Context, api callcontract.CallContractAPI, txHash primitives.Sha256, nodeIndex int, allowedIndexes []int) {
 	response := api.GetTransactionReceiptProof(ctx, txHash, nodeIndex)

--- a/test/acceptance/consensus_test.go
+++ b/test/acceptance/consensus_test.go
@@ -21,7 +21,7 @@ import (
 // TODO: add similar test for lean helix
 
 func TestBenchmarkConsensus_LeaderGetsVotesBeforeNextBlock(t *testing.T) {
-	newHarness().
+	NewHarness().
 		WithLogFilters(log.ExcludeField(internodesync.LogTag), log.ExcludeEntryPoint("BlockSync")).
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS). // override default consensus algo
 		WithMaxTxPerBlock(1).

--- a/test/acceptance/deploy_native_test.go
+++ b/test/acceptance/deploy_native_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestDeployNativeContract(t *testing.T) {
-	newHarness().Start(t, func(t testing.TB, ctx context.Context, network *Network) {
+	NewHarness().Start(t, func(t testing.TB, ctx context.Context, network *Network) {
 
 		counterStart := contracts.MOCK_COUNTER_CONTRACT_START_FROM
 		network.MockContract(contracts.MockForCounter(), string(contracts.NativeSourceCodeForCounter(counterStart)))
@@ -46,7 +46,7 @@ func TestDeployNativeContract(t *testing.T) {
 }
 
 func TestLockNativeDeployment(t *testing.T) {
-	newHarness().Start(t, func(t testing.TB, ctx context.Context, network *Network) {
+	NewHarness().Start(t, func(t testing.TB, ctx context.Context, network *Network) {
 
 		counterStart := contracts.MOCK_COUNTER_CONTRACT_START_FROM
 		network.MockContract(contracts.MockForCounter(), string(contracts.NativeSourceCodeForCounter(counterStart)))

--- a/test/acceptance/duplicate_tx_test.go
+++ b/test/acceptance/duplicate_tx_test.go
@@ -23,7 +23,7 @@ var STATUS_DUPLICATE = []TransactionStatus{TRANSACTION_STATUS_DUPLICATE_TRANSACT
 
 // LH: Use ControlledRandom (ctrlrnd.go) (in acceptance harness) to generate the initial RandomSeed and put it in LeanHelix's config
 func TestSendSameTransactionFastToTwoNodes(t *testing.T) {
-	newHarness().AllowingErrors(
+	NewHarness().AllowingErrors(
 		"error adding transaction to pending pool",
 		"error adding forwarded transaction to pending pool",
 		"error sending transaction",
@@ -61,7 +61,7 @@ func TestSendSameTransactionFastToTwoNodes(t *testing.T) {
 
 // LH: Use ControlledRandom (ctrlrnd.go) (in acceptance harness) to generate the initial RandomSeed and put it in LeanHelix's config
 func TestSendSameTransactionFastTwiceToSameNode(t *testing.T) {
-	newHarness().AllowingErrors(
+	NewHarness().AllowingErrors(
 		"error adding transaction to pending pool",
 		"error adding forwarded transaction to pending pool",
 		"error sending transaction",
@@ -123,7 +123,7 @@ func requireTxCommittedOnce(ctx context.Context, t testing.TB, network *Network,
 }
 
 func TestBlockTrackerAndScanBlocksStayInSync(t *testing.T) {
-	newHarness().AllowingErrors(
+	NewHarness().AllowingErrors(
 		"error adding transaction to pending pool",
 		"error adding forwarded transaction to pending pool",
 		"error sending transaction",

--- a/test/acceptance/empty_block_time_test.go
+++ b/test/acceptance/empty_block_time_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestIncomingTransactionTriggersExactlyOneBlock(t *testing.T) {
-	newHarness().
+	NewHarness().
 		WithEmptyBlockTime(1*time.Second).
 		Start(t, func(tb testing.TB, ctx context.Context, network *Network) {
 			contract := callcontract.NewContractClient(network)
@@ -34,7 +34,7 @@ func TestIncomingTransactionTriggersExactlyOneBlock(t *testing.T) {
 }
 
 func TestIncomingTransactionTriggersImmediateBlockClosure(t *testing.T) {
-	newHarness().
+	NewHarness().
 		WithEmptyBlockTime(1*time.Hour).
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX).
 		WithLogFilters(log.ExcludeEntryPoint("BlockSync")).

--- a/test/acceptance/lean_helix_recovers_from_disk_error_test.go
+++ b/test/acceptance/lean_helix_recovers_from_disk_error_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestLeanHelix_RecoversFromDiskWriteError(t *testing.T) {
-	newHarness().
+	NewHarness().
 		// TODO - reduce sync timeout to speed up test
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX).
 		AllowingErrors(

--- a/test/acceptance/network_benchmark_test.go
+++ b/test/acceptance/network_benchmark_test.go
@@ -21,7 +21,7 @@ func BenchmarkInMemoryNetwork(b *testing.B) {
 	limiter := rate.NewLimiter(1000, 100)
 	ctrlRand := rand.NewControlledRand(b)
 
-	newHarness().
+	NewHarness().
 		WithLogFilters(log.DiscardAll()).
 		WithNumNodes(4).Start(b, func(t testing.TB, ctx context.Context, network *Network) {
 

--- a/test/acceptance/network_harness.go
+++ b/test/acceptance/network_harness.go
@@ -53,7 +53,7 @@ type networkHarness struct {
 	testTimeout              time.Duration
 }
 
-func newHarness() *networkHarness {
+func NewHarness() *networkHarness {
 	n := &networkHarness{maxTxPerBlock: DEFAULT_ACCEPTANCE_MAX_TX_PER_BLOCK, requiredQuorumPercentage: DEFAULT_ACCEPTANCE_REQUIRED_QUORUM_PERCENTAGE}
 
 	var algos []consensus.ConsensusAlgoType

--- a/test/acceptance/node_sync_test.go
+++ b/test/acceptance/node_sync_test.go
@@ -21,7 +21,7 @@ import (
 // Either test with Benchmark Consensus which is makes it easier to generate fake proofs, or use real recorded Lean Helix blocks
 func TestInterNodeBlockSync_WithBenchmarkConsensusBlocks(t *testing.T) {
 
-	newHarness().
+	NewHarness().
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS).
 		//WithLogFilters(log.ExcludeEntryPoint("BenchmarkConsensus.Tick")).
 		//AllowingErrors().

--- a/test/acceptance/quorum_size_test.go
+++ b/test/acceptance/quorum_size_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestNetworkStartedWithEnoughNodes_SucceedsClosingBlocks_BenchmarkConsensus(t *testing.T) {
-	newHarness().
+	NewHarness().
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS).
 		WithNumNodes(6).
 		WithNumRunningNodes(4).

--- a/test/acceptance/sanity_test.go
+++ b/test/acceptance/sanity_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSanity(t *testing.T) {
 	t.Skip("on purpose - this test is here to help us migrate acceptance network to ConcurrencyHarness")
-	newHarness().
+	NewHarness().
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS).
 		Start(t, func(t testing.TB, ctx context.Context, network *Network) {
 			t.Fatalf("Intentional error")

--- a/test/acceptance/service_sync_test.go
+++ b/test/acceptance/service_sync_test.go
@@ -29,30 +29,30 @@ func TestServiceBlockSync_TransactionPool(t *testing.T) {
 
 	blocks := createInitialBlocks(t, txBuilders)
 
-	newHarness().
+	NewHarness().
 		WithInitialBlocks(blocks).
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS). // this test only runs with BenchmarkConsensus since we only create blocks compatible with that algo
 		//AllowingErrors().
 		Start(t, func(t testing.TB, ctx context.Context, network *Network) {
 
-		topBlockHeight := blocks[len(blocks)-1].ResultsBlock.Header.BlockHeight()
+			topBlockHeight := blocks[len(blocks)-1].ResultsBlock.Header.BlockHeight()
 
-		_ = network.GetTransactionPoolBlockHeightTracker(0).WaitForBlock(ctx, topBlockHeight)
-		_ = network.GetTransactionPoolBlockHeightTracker(1).WaitForBlock(ctx, topBlockHeight)
+			_ = network.GetTransactionPoolBlockHeightTracker(0).WaitForBlock(ctx, topBlockHeight)
+			_ = network.GetTransactionPoolBlockHeightTracker(1).WaitForBlock(ctx, topBlockHeight)
 
-		// this is required because GlobalPreOrder contract relies on state (Approve method), and if state storage is too far behind, GlobalPreOrder will fail on gap
-		require.NoError(t, network.stateBlockHeightTrackers[0].WaitForBlock(ctx, topBlockHeight))
-		require.NoError(t, network.stateBlockHeightTrackers[1].WaitForBlock(ctx, topBlockHeight))
+			// this is required because GlobalPreOrder contract relies on state (Approve method), and if state storage is too far behind, GlobalPreOrder will fail on gap
+			require.NoError(t, network.stateBlockHeightTrackers[0].WaitForBlock(ctx, topBlockHeight))
+			require.NoError(t, network.stateBlockHeightTrackers[1].WaitForBlock(ctx, topBlockHeight))
 
-		// Resend an already committed transaction to Leader
-		leaderTxResponse, _ := network.SendTransaction(ctx, txBuilders[0].Builder(), 0)
-		nonLeaderTxResponse, _ := network.SendTransaction(ctx, txBuilders[0].Builder(), 1)
+			// Resend an already committed transaction to Leader
+			leaderTxResponse, _ := network.SendTransaction(ctx, txBuilders[0].Builder(), 0)
+			nonLeaderTxResponse, _ := network.SendTransaction(ctx, txBuilders[0].Builder(), 1)
 
-		require.Equal(t, protocol.TRANSACTION_STATUS_DUPLICATE_TRANSACTION_ALREADY_COMMITTED.String(), leaderTxResponse.TransactionStatus().String(),
-			"expected a tx that is committed prior to restart and sent again to leader to be rejected")
-		require.Equal(t, protocol.TRANSACTION_STATUS_DUPLICATE_TRANSACTION_ALREADY_COMMITTED.String(), nonLeaderTxResponse.TransactionStatus().String(),
-			"expected a tx that is committed prior to restart and sent again to non leader to be rejected")
-	})
+			require.Equal(t, protocol.TRANSACTION_STATUS_DUPLICATE_TRANSACTION_ALREADY_COMMITTED.String(), leaderTxResponse.TransactionStatus().String(),
+				"expected a tx that is committed prior to restart and sent again to leader to be rejected")
+			require.Equal(t, protocol.TRANSACTION_STATUS_DUPLICATE_TRANSACTION_ALREADY_COMMITTED.String(), nonLeaderTxResponse.TransactionStatus().String(),
+				"expected a tx that is committed prior to restart and sent again to non leader to be rejected")
+		})
 }
 
 func createInitialBlocks(t testing.TB, txBuilders []*builders.TransactionBuilder) (blocks []*protocol.BlockPairContainer) {
@@ -78,7 +78,7 @@ func TestServiceBlockSync_StateStorage(t *testing.T) {
 
 	blocks, txHashes := createTransferBlocks(t, transfers, transferAmount)
 
-	newHarness().
+	NewHarness().
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS). // this test only runs with BenchmarkConsensus since we only create blocks compatible with that algo
 		WithInitialBlocks(blocks).
 		WithLogFilters(log.ExcludeField(gossip.LogTag),

--- a/test/acceptance/simple_transfer_test.go
+++ b/test/acceptance/simple_transfer_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestLeanHelix_CommitTransaction(t *testing.T) {
-	newHarness().
+	NewHarness().
 		WithNumNodes(4).
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_LEAN_HELIX).
 		Start(t, func(t testing.TB, ctx context.Context, network *Network) {
@@ -51,7 +51,7 @@ func TestLeanHelix_CommitTransaction(t *testing.T) {
 }
 
 func TestLeaderCommitsTransactionsAndSkipsInvalidOnes(t *testing.T) {
-	newHarness().
+	NewHarness().
 		Start(t, func(t testing.TB, parent context.Context, network *Network) {
 			ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 			defer cancel()
@@ -82,7 +82,7 @@ func TestLeaderCommitsTransactionsAndSkipsInvalidOnes(t *testing.T) {
 }
 
 func TestNonLeaderPropagatesTransactionsToLeader(t *testing.T) {
-	newHarness().
+	NewHarness().
 		WithConsensusAlgos(consensus.CONSENSUS_ALGO_TYPE_BENCHMARK_CONSENSUS).
 		Start(t, func(t testing.TB, parent context.Context, network *Network) {
 			ctx, cancel := context.WithTimeout(parent, 1*time.Second)
@@ -111,7 +111,7 @@ func TestNonLeaderPropagatesTransactionsToLeader(t *testing.T) {
 }
 
 func TestLeaderCommitsTwoTransactionsInOneBlock(t *testing.T) {
-	newHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
+	NewHarness().Start(t, func(t testing.TB, parent context.Context, network *Network) {
 		ctx, cancel := context.WithTimeout(parent, 1*time.Second)
 		defer cancel()
 

--- a/test/acceptance/stress_benchmark_test.go
+++ b/test/acceptance/stress_benchmark_test.go
@@ -14,7 +14,7 @@ func BenchmarkHappyFlow1k(b *testing.B) {
 	numTransactions := 1000
 
 	rnd := rand.NewControlledRand(b)
-	newHarness().Start(b, func(t testing.TB, ctx context.Context, network *Network) {
+	NewHarness().Start(b, func(t testing.TB, ctx context.Context, network *Network) {
 		for n := 0; n < b.N; n++ {
 			b.StartTimer()
 			transferDuration, waitDuration := sendTransfersAndAssertTotalBalance(ctx, network, t, numTransactions, rnd)
@@ -79,7 +79,7 @@ func BenchmarkHappyFlow1kWithOverrides(b *testing.B) {
 	numTransactions := 1000
 
 	rnd := rand.NewControlledRand(b)
-	newHarness().WithConfigOverride(func(cfg config.OverridableConfig) config.OverridableConfig {
+	NewHarness().WithConfigOverride(func(cfg config.OverridableConfig) config.OverridableConfig {
 		c, err := cfg.MergeWithFileConfig(`{
 	"consensus-context-maximum-transactions-in-block": 70,
 	"transaction-pool-propagation-batch-size": 100

--- a/test/acceptance/stress_test.go
+++ b/test/acceptance/stress_test.go
@@ -21,7 +21,7 @@ import (
 // Control group - if this fails, there are bugs unrelated to message tampering
 func TestGazillionTxHappyFlow(t *testing.T) {
 	rnd := rand.NewControlledRand(t)
-	newHarness().
+	NewHarness().
 		Start(t, func(t testing.TB, ctx context.Context, network *Network) {
 			sendTransfersAndAssertTotalBalance(ctx, network, t, 200, rnd)
 		})
@@ -70,7 +70,7 @@ func TestGazillionTxWhileDelayingMessages(t *testing.T) {
 func TestGazillionTxWhileCorruptingMessages(t *testing.T) {
 	t.Skip("This should work - fix and remove Skip")
 	rnd := rand.NewControlledRand(t)
-	newHarness().
+	NewHarness().
 		AllowingErrors(
 			"transport header is corrupt", // because we corrupt messages
 		).

--- a/test/acceptance/stress_test_harness_all.go
+++ b/test/acceptance/stress_test_harness_all.go
@@ -11,5 +11,5 @@ package acceptance
 // as we are using a build flag, and we want to avoid logging in the stress test
 // as the harness will cache them because of t.Log, we have this conditional compilation for creating the harness
 func getStressTestHarness() *networkHarness {
-	return newHarness()
+	return NewHarness()
 }

--- a/test/acceptance/stress_test_harness_memoryleak.go
+++ b/test/acceptance/stress_test_harness_memoryleak.go
@@ -15,5 +15,5 @@ import (
 // as we are using a build flag, and we want to avoid logging in the stress test
 // as the harness will cache them because of t.Log, we have this conditional compilation for creating the harness
 func getStressTestHarness() *networkHarness {
-	return newHarness().WithLogFilters(log.DiscardAll())
+	return NewHarness().WithLogFilters(log.DiscardAll())
 }

--- a/test/acceptance/subscription_state_test.go
+++ b/test/acceptance/subscription_state_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestSubscriptionProblemThanBecomesOkAgain(t *testing.T) {
-	newHarness().
+	NewHarness().
 		AllowingErrors("error validating transaction for preorder").
 		Start(t, func(t testing.TB, ctx context.Context, network *Network) {
 			contract := callcontract.NewContractClient(network)

--- a/test/acceptance/trigger_test.go
+++ b/test/acceptance/trigger_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTriggers_ABlockContainsATriggerTransaction(t *testing.T) {
-	newHarness().
+	NewHarness().
 		Start(t, func(t testing.TB, ctx context.Context, network *Network) {
 
 			blockHeight := primitives.BlockHeight(1)


### PR DESCRIPTION
resolves #549 

An old bug dealing with manual tests failing compilation and execution - caused by tests marked to be excluded from compilation, and then a commit that broke them caused the IDE to never parse this file. Over time the harness was refactored and the distance between the code and framework gradually grew.

The tests pass now and hopefully IDE will include the file in future refactoring so the compilation will not break again. Consider removing the `_` from the folder name `_manual` and adding `t.Skip()` commands to ensure compilation and no execution when running `go test ...` @electricmonk  what do you think?