### PR TITLE
System contract retries - log warning instead of error

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,7 @@ github.com/orbs-network/pbparser v0.3.0/go.mod h1:WSzcxgH5xzywQm0YSASbD7RcdxBXZg
 github.com/orbs-network/scribe v0.1.0/go.mod h1:FmGcbukz5eolO+mqzxwmuy4RF4UEoLfGJIeEDAoGsBU=
 github.com/orbs-network/scribe v0.2.2 h1:PJeMsUp9/TU6NmBGmJkgeeWVppoMl2IiUiqZVtq28xQ=
 github.com/orbs-network/scribe v0.2.2/go.mod h1:FmGcbukz5eolO+mqzxwmuy4RF4UEoLfGJIeEDAoGsBU=
+github.com/orbs-network/scribe v0.2.3 h1:9WxpS5gBAHhJ93sX/mNBj5LXtrob1kM8STQnJHO3kvg=
 github.com/orbs-network/scribe v0.2.3/go.mod h1:FmGcbukz5eolO+mqzxwmuy4RF4UEoLfGJIeEDAoGsBU=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/go.sum
+++ b/go.sum
@@ -208,7 +208,6 @@ github.com/orbs-network/pbparser v0.3.0/go.mod h1:WSzcxgH5xzywQm0YSASbD7RcdxBXZg
 github.com/orbs-network/scribe v0.1.0/go.mod h1:FmGcbukz5eolO+mqzxwmuy4RF4UEoLfGJIeEDAoGsBU=
 github.com/orbs-network/scribe v0.2.2 h1:PJeMsUp9/TU6NmBGmJkgeeWVppoMl2IiUiqZVtq28xQ=
 github.com/orbs-network/scribe v0.2.2/go.mod h1:FmGcbukz5eolO+mqzxwmuy4RF4UEoLfGJIeEDAoGsBU=
-github.com/orbs-network/scribe v0.2.3 h1:9WxpS5gBAHhJ93sX/mNBj5LXtrob1kM8STQnJHO3kvg=
 github.com/orbs-network/scribe v0.2.3/go.mod h1:FmGcbukz5eolO+mqzxwmuy4RF4UEoLfGJIeEDAoGsBU=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/services/consensuscontext/call_contract_elected_validators.go
+++ b/services/consensuscontext/call_contract_elected_validators.go
@@ -68,7 +68,7 @@ func (s *service) callElectionsSystemContractUntilSuccess(ctx context.Context, b
 		// log every 500 failures
 		if attempts%500 == 1 {
 			if ctx.Err() == nil { // this may fail rightfully on graceful shutdown (ctx.Done), we don't want to report an error in this case
-				s.logger.Error("cannot get elected validators from system contract", log.Error(err), logfields.BlockHeight(blockHeight), log.Int("attempts", attempts))
+				s.logger.Info("cannot get elected validators from system contract", log.Error(err), logfields.BlockHeight(blockHeight), log.Int("attempts", attempts))
 			}
 		}
 

--- a/services/consensuscontext/call_contract_ordered_committee.go
+++ b/services/consensuscontext/call_contract_ordered_committee.go
@@ -63,7 +63,7 @@ func (s *service) callGetOrderedCommitteeSystemContractUntilSuccess(ctx context.
 		// log every 500 failures
 		if attempts%500 == 1 {
 			if ctx.Err() == nil { // this may fail rightfully on graceful shutdown (ctx.Done), we don't want to report an error in this case
-				s.logger.Error("cannot get ordered committee from system contract", log.Error(err), logfields.BlockHeight(blockHeight), log.Int("attempts", attempts))
+				s.logger.Info("cannot get ordered committee from system contract", log.Error(err), logfields.BlockHeight(blockHeight), log.Int("attempts", attempts))
 			}
 		}
 
@@ -139,7 +139,7 @@ func (s *service) callGetOrderedCommitteeForAddressesSystemContractUntilSuccess(
 		// log every 500 failures
 		if attempts%500 == 1 {
 			if ctx.Err() == nil { // this may fail rightfully on graceful shutdown (ctx.Done), we don't want to report an error in this case
-				s.logger.Error("cannot get ordered committee for addresses", log.Error(err), logfields.BlockHeight(blockHeight), log.Int("attempts", attempts))
+				s.logger.Info("cannot get ordered committee for addresses", log.Error(err), logfields.BlockHeight(blockHeight), log.Int("attempts", attempts))
 			}
 		}
 


### PR DESCRIPTION
Some system contract calls retry until success, and report every 500th failure (including the first) by logging an error. 
There is a reoccurring CircleCI issue (#1443) where test containers freeze for a period of 300ms-1s, causing the first attempt to fail on "timeout". The error log then fails the tests. 
Since this issue only manifests itself this way, switching from error log to warning (info-error) seems like a decent workaround.
The info-error logs are still shipped to logzio, but will not fail tests.