### PR TITLE
Fix state storage memory leak

### DIFF
--- a/services/statestorage/adapter/memory/memory_persistence.go
+++ b/services/statestorage/adapter/memory/memory_persistence.go
@@ -50,7 +50,7 @@ func NewStatePersistence(metricFactory metric.Factory) *InMemoryStatePersistence
 		fullState:  adapter.ChainState{},
 		height:     0,
 		ts:         0,
-		proposer:    []byte{},
+		proposer:   []byte{},
 		merkleRoot: merkleRoot,
 	}
 }

--- a/services/statestorage/service.go
+++ b/services/statestorage/service.go
@@ -196,7 +196,13 @@ func inflateChainState(csd []*protocol.ContractStateDiff) adapter.ChainState {
 		}
 		for i := stateDiffs.StateDiffsIterator(); i.HasNext(); {
 			r := i.NextStateDiffs()
-			contractMap[string(r.Key())] = r
+
+			// copying here is very important to free up the underlying structures
+			rCopy := make([]byte, len(r.Raw()))
+			copy(rCopy, r.Raw())
+
+			diffToApply := protocol.StateRecordReader(rCopy)
+			contractMap[string(diffToApply.Key())] = diffToApply
 		}
 	}
 	return result

--- a/services/statestorage/service.go
+++ b/services/statestorage/service.go
@@ -188,7 +188,8 @@ func (s *service) GetStateHash(ctx context.Context, input *services.GetStateHash
 func inflateChainState(csd []*protocol.ContractStateDiff) adapter.ChainState {
 	result := make(adapter.ChainState)
 	for _, stateDiffs := range csd {
-		contract := stateDiffs.ContractName()
+		// copying here is very important to free up the underlying structures
+		contract := primitives.ContractName(stateDiffs.ContractName().String())
 		contractMap, ok := result[contract]
 		if !ok {
 			contractMap = make(map[string]*protocol.StateRecord)

--- a/services/statestorage/service.go
+++ b/services/statestorage/service.go
@@ -198,10 +198,10 @@ func inflateChainState(csd []*protocol.ContractStateDiff) adapter.ChainState {
 			r := i.NextStateDiffs()
 
 			// copying here is very important to free up the underlying structures
-			rCopy := make([]byte, len(r.Raw()))
-			copy(rCopy, r.Raw())
+			detachedBuffer := make([]byte, len(r.Raw()))
+			copy(detachedBuffer, r.Raw())
 
-			diffToApply := protocol.StateRecordReader(rCopy)
+			diffToApply := protocol.StateRecordReader(detachedBuffer)
 			contractMap[string(diffToApply.Key())] = diffToApply
 		}
 	}

--- a/services/statestorage/service_test.go
+++ b/services/statestorage/service_test.go
@@ -23,6 +23,8 @@ func Test_inflateChainState(t *testing.T) {
 
 	chainState := inflateChainState(diffs)
 	singleDiff.StateDiffsIterator().NextStateDiffs().MutateValue([]byte("Station of Station"))
+	singleDiff.MutateContractName("Album1")
 
+	require.NotNil(t, chainState["Albums"])
 	require.EqualValues(t, []byte("Station to Station"), chainState["Albums"]["David Bowie"].Value(), "the underlying buffer was not copied")
 }

--- a/services/statestorage/service_test.go
+++ b/services/statestorage/service_test.go
@@ -1,0 +1,28 @@
+package statestorage
+
+import (
+	"github.com/orbs-network/orbs-spec/types/go/protocol"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_inflateChainState(t *testing.T) {
+	singleDiff := (&protocol.ContractStateDiffBuilder{
+		ContractName: "Albums",
+		StateDiffs: []*protocol.StateRecordBuilder{
+			{
+				Key:   []byte("David Bowie"),
+				Value: []byte("Station to Station"),
+			},
+		},
+	}).Build()
+
+	diffs := []*protocol.ContractStateDiff{
+		singleDiff,
+	}
+
+	chainState := inflateChainState(diffs)
+	singleDiff.StateDiffsIterator().NextStateDiffs().MutateValue([]byte("Station of Station"))
+
+	require.EqualValues(t, []byte("Station to Station"), chainState["Albums"]["David Bowie"].Value(), "the underlying buffer was not copied")
+}


### PR DESCRIPTION
The nature of the leak is that any block that contained the state diff was held up in memory because the state diffs were referencing the underlying byte array.

After applying the fix, testing on 3.9Gb blocks file for vchain 1960000 revealed that allocated memory after starting up went down from `878mb` to `478mb` which is `45.5%` improvement.

This PR partially resolves #1520 