### PR TITLE
Removing extra structs/pointers from state storage

### DIFF
--- a/services/statestorage/adapter/memory/memory_persistence.go
+++ b/services/statestorage/adapter/memory/memory_persistence.go
@@ -13,7 +13,6 @@ import (
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	"github.com/orbs-network/orbs-network-go/services/statestorage/adapter"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
-	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"sort"
 	"strings"
 	"sync"
@@ -76,28 +75,28 @@ func (sp *InMemoryStatePersistence) Write(height primitives.BlockHeight, ts prim
 	sp.merkleRoot = root
 
 	for contract, records := range diff {
-		for _, record := range records {
-			sp._writeOneRecord(primitives.ContractName(contract), record)
+		for key, value := range records {
+			sp._writeOneRecord(primitives.ContractName(contract), key, value)
 		}
 	}
 	sp.reportSize()
 	return nil
 }
 
-func (sp *InMemoryStatePersistence) _writeOneRecord(c primitives.ContractName, r *protocol.StateRecord) {
+func (sp *InMemoryStatePersistence) _writeOneRecord(c primitives.ContractName, key string, value []byte) {
 	if _, ok := sp.fullState[c]; !ok {
-		sp.fullState[c] = map[string]*protocol.StateRecord{}
+		sp.fullState[c] = map[string][]byte{}
 	}
 
-	if isZeroValue(r.Value()) {
-		delete(sp.fullState[c], string(r.Key()))
+	if isZeroValue(value) {
+		delete(sp.fullState[c], key)
 		return
 	}
 
-	sp.fullState[c][string(r.Key())] = r
+	sp.fullState[c][key] = value
 }
 
-func (sp *InMemoryStatePersistence) Read(contract primitives.ContractName, key string) (*protocol.StateRecord, bool, error) {
+func (sp *InMemoryStatePersistence) Read(contract primitives.ContractName, key string) ([]byte, bool, error) {
 	sp.mutex.RLock()
 	defer sp.mutex.RUnlock()
 
@@ -133,9 +132,9 @@ func (sp *InMemoryStatePersistence) Dump() string {
 
 		output.WriteString(string(currentContract) + ":{")
 		for _, k := range keys {
-			output.WriteString(sp.fullState[currentContract][k].StringKey())
+			output.WriteString(k)
 			output.WriteString(":")
-			output.WriteString(sp.fullState[currentContract][k].StringValue())
+			output.WriteString(string(sp.fullState[currentContract][k]))
 			output.WriteString(",")
 		}
 		output.WriteString("},")

--- a/services/statestorage/adapter/memory/memory_persistence_test.go
+++ b/services/statestorage/adapter/memory/memory_persistence_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
 	"github.com/orbs-network/orbs-network-go/services/statestorage/adapter"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
-	"github.com/orbs-network/orbs-spec/types/go/protocol"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -29,8 +28,8 @@ func TestWriteStateAddAndRemoveKeyFromPersistentStorage(t *testing.T) {
 	record, ok, err := d.Read("foo", "foo")
 	require.NoError(t, err, "unexpected error")
 	require.EqualValues(t, true, ok, "after writing a key it should exist")
-	require.EqualValues(t, "foo", record.Key(), "after writing a key/value it should be returned")
-	require.EqualValues(t, "bar", record.Value(), "after writing a key/value it should be returned")
+	// require.EqualValues(t, "foo", "foo"), "after writing a key/value it should be returned")
+	require.EqualValues(t, "bar", record, "after writing a key/value it should be returned")
 
 	d.writeSingleValueBlock(1, "foo", "foo", "")
 
@@ -50,7 +49,6 @@ func newDriver() *driver {
 }
 
 func (d *driver) writeSingleValueBlock(h primitives.BlockHeight, c, k, v string) error {
-	record := (&protocol.StateRecordBuilder{Key: []byte(k), Value: []byte(v)}).Build()
-	diff := adapter.ChainState{primitives.ContractName(c): {k: record}}
+	diff := adapter.ChainState{primitives.ContractName(c): {k: []byte(v)}}
 	return d.InMemoryStatePersistence.Write(h, 0, []byte{}, []byte{}, diff)
 }

--- a/services/statestorage/adapter/persistence.go
+++ b/services/statestorage/adapter/persistence.go
@@ -8,14 +8,14 @@ package adapter
 
 import (
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
-	"github.com/orbs-network/orbs-spec/types/go/protocol"
 )
 
-type ContractState map[string]*protocol.StateRecord
+// ContractState is a state.key->state.value
+type ContractState map[string][]byte
 type ChainState map[primitives.ContractName]ContractState
 
 type StatePersistence interface {
 	Write(height primitives.BlockHeight, ts primitives.TimestampNano, proposer primitives.NodeAddress, root primitives.Sha256, diff ChainState) error
-	Read(contract primitives.ContractName, key string) (*protocol.StateRecord, bool, error)
+	Read(contract primitives.ContractName, key string) ([]byte, bool, error)
 	ReadMetadata() (primitives.BlockHeight, primitives.TimestampNano, primitives.NodeAddress, primitives.Sha256, error)
 }

--- a/services/statestorage/service.go
+++ b/services/statestorage/service.go
@@ -203,7 +203,7 @@ func inflateChainState(csd []*protocol.ContractStateDiff) adapter.ChainState {
 			copy(detachedBuffer, r.Raw())
 
 			diffToApply := protocol.StateRecordReader(detachedBuffer)
-			contractMap[string(diffToApply.Key())] = diffToApply.Value()
+			contractMap[string(diffToApply.Key())] = append([]byte{}, diffToApply.Value()...)
 		}
 	}
 	return result

--- a/services/statestorage/service.go
+++ b/services/statestorage/service.go
@@ -133,7 +133,7 @@ func (s *service) ReadKeys(ctx context.Context, input *services.ReadKeysInput) (
 			return nil, errors.Wrap(err, "persistence layer error")
 		}
 		if ok {
-			records = append(records, record)
+			records = append(records, (&protocol.StateRecordBuilder{Key: key, Value: record}).Build())
 		} else { // implicitly return the zero value if key is missing in db
 			records = append(records, (&protocol.StateRecordBuilder{Key: key, Value: newZeroValue()}).Build())
 		}
@@ -192,7 +192,7 @@ func inflateChainState(csd []*protocol.ContractStateDiff) adapter.ChainState {
 		contract := primitives.ContractName(stateDiffs.ContractName().String())
 		contractMap, ok := result[contract]
 		if !ok {
-			contractMap = make(map[string]*protocol.StateRecord)
+			contractMap = make(map[string][]byte)
 			result[contract] = contractMap
 		}
 		for i := stateDiffs.StateDiffsIterator(); i.HasNext(); {
@@ -203,7 +203,7 @@ func inflateChainState(csd []*protocol.ContractStateDiff) adapter.ChainState {
 			copy(detachedBuffer, r.Raw())
 
 			diffToApply := protocol.StateRecordReader(detachedBuffer)
-			contractMap[string(diffToApply.Key())] = diffToApply
+			contractMap[string(diffToApply.Key())] = diffToApply.Value()
 		}
 	}
 	return result

--- a/services/statestorage/service_test.go
+++ b/services/statestorage/service_test.go
@@ -26,5 +26,5 @@ func Test_inflateChainState(t *testing.T) {
 	singleDiff.MutateContractName("Album1")
 
 	require.NotNil(t, chainState["Albums"])
-	require.EqualValues(t, []byte("Station to Station"), chainState["Albums"]["David Bowie"].Value(), "the underlying buffer was not copied")
+	require.EqualValues(t, []byte("Station to Station"), chainState["Albums"]["David Bowie"], "the underlying buffer was not copied")
 }


### PR DESCRIPTION
Instead of passing the struct around, @jlevison fix references key and value directly, reducing memory footprint by `8%` (tested on `3.9Gb` blocks file).