### PR TITLE
[Bug report] Failed test for GetBlock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.6
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/huin/goupnp v1.0.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.1 // indirect

--- a/test/e2e/get_block_test.go
+++ b/test/e2e/get_block_test.go
@@ -1,0 +1,20 @@
+package e2e
+
+import (
+	"github.com/orbs-network/orbs-client-sdk-go/codec"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func (h *Harness) GetBlock(blockHeight uint64) (*codec.GetBlockResponse, error) {
+	return h.client.GetBlock(blockHeight)
+}
+
+func TestGetBlock(t *testing.T) {
+	h := NewAppHarness()
+	h.WaitUntilTransactionPoolIsReady(t)
+
+	blockResponse, err := h.GetBlock(1)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, blockResponse.BlockHeight)
+}


### PR DESCRIPTION
Desired behavior: `client.GetBlock()` either returns a block, or an error.

Current behavior: `client.GetBlock()` panics.

