### PR TITLE
Block sync - retry with smaller chunk sizes 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.6
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/huin/goupnp v1.0.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.1 // indirect

--- a/services/blockstorage/block_sync_server.go
+++ b/services/blockstorage/block_sync_server.go
@@ -110,7 +110,7 @@ func (s *Service) sourceHandleBlockSyncRequest(ctx context.Context, message *gos
 		return errors.Wrap(err, "block sync failed reading from block persistence")
 	}
 
-	var chunkSize = len(blocks)
+	chunkSize := len(blocks)
 	for {
 		lastAvailableBlockHeight := firstAvailableBlockHeight + primitives.BlockHeight(chunkSize) - 1
 		logger.Info("sending blocks to another node via block sync",

--- a/services/blockstorage/block_sync_server.go
+++ b/services/blockstorage/block_sync_server.go
@@ -130,7 +130,7 @@ func (s *Service) sourceHandleBlockSyncRequest(ctx context.Context, message *gos
 				SignedChunkRange: (&gossipmessages.BlockSyncRangeBuilder{
 					BlockType:                blockType,
 					FirstBlockHeight:         firstAvailableBlockHeight,
-					LastBlockHeight:          firstAvailableBlockHeight + primitives.BlockHeight(chunkSize) - 1,
+					LastBlockHeight:          lastAvailableBlockHeight,
 					LastCommittedBlockHeight: lastCommittedBlockHeight,
 				}).Build(),
 				BlockPairs: blocks[:chunkSize],

--- a/services/blockstorage/test/block_sync_server_test.go
+++ b/services/blockstorage/test/block_sync_server_test.go
@@ -227,6 +227,7 @@ func TestSourceRetriesSendingSmallerChunksOnChunkTooBigError(t *testing.T) {
 			require.Len(t, input.Message.BlockPairs, int(expectedChunkSize), "actual batch size does not match the currently expected size")
 			require.Equal(t, firstHeight, input.Message.SignedChunkRange.FirstBlockHeight(), "first block height mismatch")
 			require.Equal(t, firstHeight+primitives.BlockHeight(expectedChunkSize)-1, input.Message.SignedChunkRange.LastBlockHeight(), "last block height mismatch")
+			require.Equal(t, primitives.BlockHeight(lastBlock), input.Message.SignedChunkRange.LastCommittedBlockHeight(), "last committed block height mismatch")
 
 			if expectedChunkSize == 0 {
 				return nil, nil

--- a/services/gossip/topic_block_sync.go
+++ b/services/gossip/topic_block_sync.go
@@ -12,6 +12,7 @@ import (
 	"github.com/orbs-network/orbs-network-go/instrumentation/logfields"
 	"github.com/orbs-network/orbs-network-go/instrumentation/trace"
 	"github.com/orbs-network/orbs-network-go/services/gossip/adapter"
+	"github.com/orbs-network/orbs-network-go/services/gossip/adapter/tcp"
 	"github.com/orbs-network/orbs-network-go/services/gossip/codec"
 	"github.com/orbs-network/orbs-spec/types/go/primitives"
 	"github.com/orbs-network/orbs-spec/types/go/protocol/gossipmessages"
@@ -159,6 +160,10 @@ func (s *Service) receivedBlockSyncRequest(ctx context.Context, header *gossipme
 			s.logger.Info("HandleBlockSyncRequest failed", log.Error(err))
 		}
 	}
+}
+
+func IsChunkTooBigError(err error) bool {
+	return tcp.IsQueueFullError(err)
 }
 
 func (s *Service) SendBlockSyncResponse(ctx context.Context, input *gossiptopics.BlockSyncResponseInput) (*gossiptopics.EmptyOutput, error) {


### PR DESCRIPTION
In case of an error arising form the block chunk being too big, the block-sync server will retry sending the blocks with smaller and smaller chunk sizes (diving by 2 each time).

Fixes #1514
