### PR TITLE
new reputation calculation with a weighted non-repeated draw

### DIFF
--- a/services/processor/native/repository/Committee/committee.go
+++ b/services/processor/native/repository/Committee/committee.go
@@ -7,14 +7,14 @@
 package committee_systemcontract
 
 import (
-	"bytes"
 	"encoding/binary"
 	"github.com/orbs-network/orbs-contract-sdk/go/sdk/v1/env"
 	"github.com/orbs-network/orbs-network-go/crypto/hash"
-	"math"
-	"sort"
 )
 
+/**
+ * This function is meant ot be used via the callsystemcontract func ... it will not give same result when used with RunQuery
+ */
 func getOrderedCommittee() []byte {
 	return getOrderedCommitteeForAddresses(_getElectedValidators())
 }
@@ -38,44 +38,50 @@ func _generateSeed() []byte {
 	return seedBytes
 }
 
-func _orderList(addrs [][]byte, seed []byte) [][]byte {
-	addrsToSort := addrsAndScores{addrs, make([]float64, len(addrs))}
-	for i, addr := range addrs {
-		addrsToSort.scores[i] = _calculateScoreWithReputation(addr, seed)
+func _orderList(addresses [][]byte, seed []byte) [][]byte {
+	committeeSize := len(addresses)
+	accumulatedWeights := make([]int, committeeSize)
+	totalWeight := 0
+	for i, address := range addresses {
+		weight := _absoluteWeight(address)
+		totalWeight += weight
+		accumulatedWeights[i] = totalWeight
 	}
-	sort.Sort(addrsToSort)
-	return addrsToSort.addresses
+
+	orderedCommitteeAddresses := make([][]byte, 0, committeeSize)
+	random := seed
+
+	for j := 0; j < committeeSize; j++ {
+		random = _nextRandom(random)
+		curr := _getRandomWeight(random, totalWeight)
+
+		for i := 0; i < committeeSize; i++ {
+			if curr > accumulatedWeights[i] || accumulatedWeights[i] == 0 {
+				continue
+			}
+			orderedCommitteeAddresses = append(orderedCommitteeAddresses, addresses[i])
+			currWeight := _absoluteWeight(addresses[i])
+			totalWeight -= currWeight
+			accumulatedWeights[i] = 0
+			for k := i + 1;k < committeeSize;k++ {
+				if accumulatedWeights[k] != 0 {
+					accumulatedWeights[k] -= currWeight
+				}
+			}
+			break
+		}
+	}
+	return orderedCommitteeAddresses
 }
 
-func _calculateScoreWithReputation(addr []byte, seed []byte) float64 {
-	rep := getReputation(addr)
-	return float64(_calculateScore(addr, seed)) / _reputationAsFactor(rep)
+func _absoluteWeight(address []byte) int {
+	return 1 << (_getMaxReputation() - getReputation(address))
 }
 
-func _calculateScore(addr []byte, seed []byte) uint32 {
-	random := hash.CalcSha256(addr, seed)
-	return binary.LittleEndian.Uint32(random[hash.SHA256_HASH_SIZE_BYTES-4:])
+func _nextRandom(random []byte) []byte {
+	return hash.CalcSha256(random)
 }
 
-func _reputationAsFactor(reputation uint32) float64 {
-	return math.Pow(2, float64(reputation))
-}
-
-type addrsAndScores struct {
-	addresses [][]byte
-	scores    []float64
-}
-
-func (s addrsAndScores) Len() int {
-	return len(s.addresses)
-}
-
-func (s addrsAndScores) Swap(i, j int) {
-	s.addresses[i], s.addresses[j] = s.addresses[j], s.addresses[i]
-	s.scores[i], s.scores[j] = s.scores[j], s.scores[i]
-}
-
-// descending order
-func (s addrsAndScores) Less(i, j int) bool {
-	return s.scores[i] > s.scores[j] || (s.scores[i] == s.scores[j] && bytes.Compare(s.addresses[i], s.addresses[j]) > 0)
+func _getRandomWeight(random []byte, maxWeight int) int {
+	return int(binary.LittleEndian.Uint32(random[hash.SHA256_HASH_SIZE_BYTES-4:]) % uint32(maxWeight)) + 1
 }

--- a/services/processor/native/repository/Committee/committee_test.go
+++ b/services/processor/native/repository/Committee/committee_test.go
@@ -7,142 +7,158 @@
 package committee_systemcontract
 
 import (
-	"encoding/binary"
+	"bytes"
 	"github.com/orbs-network/orbs-contract-sdk/go/sdk/v1/state"
 	. "github.com/orbs-network/orbs-contract-sdk/go/testing/unit"
-	"github.com/orbs-network/orbs-network-go/crypto/hash"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
-func appendAndOrder(newAddr []byte, addrs [][]byte) [][]byte {
-	return appendAndOrderWithSeed(newAddr, addrs, []byte{})
-}
-
-func appendAndOrderWithSeed(newAddr []byte, addrs [][]byte, seed []byte) [][]byte {
-	currScore := _calculateScoreWithReputation(newAddr, seed)
-	addrs = append(addrs, newAddr)
-	for i := len(addrs) - 1; i > 0; i-- {
-		if currScore > _calculateScoreWithReputation(addrs[i-1], seed) {
-			addrs[i], addrs[i-1] = addrs[i-1], addrs[i]
-		} else {
-			break
+func TestOrbsCommitteeContract_check_random(t *testing.T) {
+	totalWeight := 1280
+	random := []byte{0x02, 0x1, 0x2, 0x3, 0x5, 0x5, 0x6, 0x4}
+	maxRuns := 1000000
+	res := make([]int, totalWeight+1)
+	for i := 0; i < maxRuns; i++ {
+		random = _nextRandom(random)
+		ind := _getRandomWeight(random, totalWeight)
+		res[ind] += 1
+	}
+	expected := maxRuns / totalWeight
+	expectedOver := expected * 98 / 100
+	expectedUnder := expected * 102 / 100
+	tooFar := 0
+	for i := 1; i <= totalWeight; i++ {
+		if res[i] < expectedOver || res[i] > expectedUnder {
+			tooFar++
 		}
 	}
-	return addrs
+	require.LessOrEqual(t, float64(tooFar)/float64(maxRuns), 0.001, "misses of+-2 percent should be under 0.1 percent")
 }
 
-func TestOrbsCommitteeContract_getOrderedCommittee_withoutReputation(t *testing.T) {
-	addrs := makeNodeAddressArray(10)
-	blockHeight := 155
+func TestOrbsCommitteeContract_check_OrderWithDiffSeedAndRep(t *testing.T) {
+	committeeSize := 5
+	addressArray := makeNodeAddressArray(committeeSize)
+
+	InServiceScope(nil, nil, func(m Mockery) {
+		_init()
+		ordered := _orderList(addressArray, []byte{7})
+		orderedDiffSeed := _orderList(addressArray, []byte{8})
+		require.NotEqual(t, ordered, orderedDiffSeed)
+		require.ElementsMatch(t, ordered, orderedDiffSeed, "must actually be same list in diff order")
+		orderedSameSeed := _orderList(addressArray, []byte{7})
+		require.EqualValues(t, ordered, orderedSameSeed)
+		state.WriteUint32(_formatMisses(addressArray[0]), ReputationBottomCap)
+		orderedSameSeedDiffProb := _orderList(addressArray, []byte{7})
+		require.NotEqual(t, ordered, orderedSameSeedDiffProb)
+		require.ElementsMatch(t, ordered, orderedSameSeedDiffProb, "must actually be same list in diff order")
+	})
+}
+
+func TestOrbsCommitteeContract_orderList_AllRepIs0(t *testing.T) {
+	max := 10000
+	committeeSize := 20
+	addresses := makeNodeAddressArray(committeeSize)
+	checkAddress := addresses[0]
+	var foundAtPos0, foundAtPosMid, foundAtPosLast int
+
+	InServiceScope(nil, nil, func(m Mockery) {
+		_init()
+		// no setup
+
+		// run
+		midLocation := committeeSize / 2
+		endLocation := committeeSize - 1
+		for i := 1 ; i <= max ; i++ {
+			m.MockEnvBlockHeight(i) // to generate random seed
+			outputArr := _orderList(addresses, _generateSeed())
+			if bytes.Equal(outputArr[0], checkAddress) {
+				foundAtPos0++
+			} else if bytes.Equal(outputArr[midLocation], checkAddress){
+				foundAtPosMid++
+			} else if bytes.Equal(outputArr[endLocation], checkAddress){
+				foundAtPosLast++
+			}
+		}
+
+		// assert
+		expected := max / committeeSize // equal chance
+		requireCountToBeInRange(t, foundAtPos0, expected)
+		requireCountToBeInRange(t, foundAtPosMid, expected)
+		requireCountToBeInRange(t, foundAtPosLast, expected)
+	})
+}
+
+func TestOrbsCommitteeContract_orderList_OneRepIsWorst(t *testing.T) {
+	max := 100000
+	committeeSize := 4 // to allow a good spread in a small amount of runs we need a small committee size.
+	addresses := makeNodeAddressArray(committeeSize)
+	badAddress := addresses[0]
+	goodAddress := addresses[1]
+	foundBadAddressInFirstPosition := 0
+	foundGoodAddressInFirstPosition := 0
 
 	InServiceScope(nil, nil, func(m Mockery) {
 		_init()
 
 		// prepare
-		m.MockEnvBlockHeight(blockHeight)
-
-		// add each to the correct place
-		expectedOrder := make([][]byte, 0, len(addrs))
-		for _, addr := range addrs {
-			expectedOrder = appendAndOrderWithSeed(addr, expectedOrder, _generateSeed())
-		}
+		state.WriteUint32(_formatMisses(badAddress), ReputationBottomCap)
 
 		// run
-		ordered := _getOrderedCommitteeArray(addrs)
+		for i := 1 ; i <= max ; i++ {
+			m.MockEnvBlockHeight(i) // to generate random seed
+			outputArr := _orderList(addresses, _generateSeed())
+			if bytes.Equal(outputArr[0], badAddress) {
+				foundBadAddressInFirstPosition++
+			}
+			if bytes.Equal(outputArr[0], goodAddress) {
+				foundGoodAddressInFirstPosition++
+			}
+		}
 
-		//assert
-		require.EqualValues(t, expectedOrder, ordered)
+		// assert
+		requireCountToBeInRange(t, foundGoodAddressInFirstPosition, (max * 64) / ((committeeSize-1) * 64 + 1))
+		requireCountToBeInRange(t, foundBadAddressInFirstPosition, max / ((committeeSize-1) * 64 + 1))
 	})
 }
 
-func TestOrbsCommitteeContract_getOrderedCommittee_SimpleReputation(t *testing.T) {
-	addrs := makeNodeAddressArray(3)
-	blockHeight := 155
+func TestOrbsCommitteeContract_orderList_QuarterAreALittleBad(t *testing.T) {
+	max := 10000
+	committeeSize := 20
+	addresses := makeNodeAddressArray(committeeSize)
+	badAddress := addresses[0]
+	goodAddress := addresses[5]
+	foundBadAddressInFirstPosition := 0
+	foundGoodAddressInFirstPosition := 0
 
 	InServiceScope(nil, nil, func(m Mockery) {
 		_init()
 
 		// prepare
-		m.MockEnvBlockHeight(blockHeight)
-		state.WriteUint32(_formatMisses(addrs[0]), 10)
-
-		// sort with simplified calculation
-		expectedOrder := make([][]byte, 0, len(addrs))
-		for _, addr := range addrs {
-			expectedOrder = appendAndOrderWithSeed(addr, expectedOrder, _generateSeed())
-		}
+		state.WriteUint32(_formatMisses(addresses[0]), ToleranceLevel+2)
+		state.WriteUint32(_formatMisses(addresses[1]), ToleranceLevel+2)
+		state.WriteUint32(_formatMisses(addresses[2]), ToleranceLevel+2)
+		state.WriteUint32(_formatMisses(addresses[3]), ToleranceLevel+2)
+		state.WriteUint32(_formatMisses(addresses[4]), ToleranceLevel+2)
 
 		// run
-		ordered := _getOrderedCommitteeArray(addrs)
-
-		//assert
-		require.EqualValues(t, expectedOrder, ordered)
-	})
-}
-
-func TestOrbsCommitteeContract_orderList_noReputation_noSeed(t *testing.T) {
-	addrs := makeNodeAddressArray(10)
-
-	InServiceScope(nil, nil, func(m Mockery) {
-		_init()
-
-		// Prepare do calculation in similar way
-		expectedOrder := make([][]byte, 0, len(addrs))
-		for _, addr := range addrs {
-			expectedOrder = appendAndOrder(addr, expectedOrder)
+		for i := 1 ; i <= max ; i++ {
+			m.MockEnvBlockHeight(i) // to generate random seed
+			outputArr := _orderList(addresses, _generateSeed())
+			if bytes.Equal(outputArr[0], badAddress) {
+				foundBadAddressInFirstPosition++
+			}
+			if bytes.Equal(outputArr[0], goodAddress) {
+				foundGoodAddressInFirstPosition++
+			}
 		}
 
-		// run with empty seed
-		ordered := _orderList(addrs, []byte{})
-
-		//assert
-		require.EqualValues(t, expectedOrder, ordered)
+		// assert
+		requireCountToBeInRange(t, foundGoodAddressInFirstPosition, (max * 64) / ((committeeSize-5) * 64 + 5 * 16))
+		requireCountToBeInRange(t, foundBadAddressInFirstPosition, (max * 16) / ((committeeSize-5) * 64 + 5 * 16))
 	})
 }
 
-func TestOrbsCommitteeContract_calculateScoreWithReputation(t *testing.T) {
-	addr := makeNodeAddress(25)
-	blockHeight := 777744444
-
-	InServiceScope(nil, nil, func(m Mockery) {
-		_init()
-
-		// Prepare
-		m.MockEnvBlockHeight(blockHeight)
-		scoreWithOutRep := _calculateScore(addr, _generateSeed())
-
-		// rep below cap
-		state.WriteUint32(_formatMisses(addr), 2)
-		score := _calculateScoreWithReputation(addr, _generateSeed())
-		require.EqualValues(t, scoreWithOutRep, score)
-
-		// rep with factor (2^5)
-		state.WriteUint32(_formatMisses(addr), 5)
-		score = _calculateScoreWithReputation(addr, _generateSeed())
-		require.EqualValues(t, float64(scoreWithOutRep)/float64(32), score)
-
-		// rep with factor (2^10) miss is above cap
-		state.WriteUint32(_formatMisses(addr), 11)
-		score = _calculateScoreWithReputation(addr, _generateSeed())
-		require.EqualValues(t, float64(scoreWithOutRep)/float64(1024), score)
-	})
-}
-
-func TestOrbsCommitteeContract_calculateScore(t *testing.T) {
-	addr := []byte{0xa1, 0x33}
-	var emptySeed = []byte{}
-	nonEmptySeed := []byte{0x44}
-	nonEmptySeedOneBitDiff := []byte{0x43}
-
-	scoreWithEmpty := _calculateScore(addr, emptySeed)
-	scoreWithNonEmpty := _calculateScore(addr, nonEmptySeed)
-	scoreWithNonEmptyOneBitDiff := _calculateScore(addr, nonEmptySeedOneBitDiff)
-
-	shaOfAddrWithNoSeed := hash.CalcSha256(addr)
-	expectedScoreWithEmpty := binary.LittleEndian.Uint32(shaOfAddrWithNoSeed[hash.SHA256_HASH_SIZE_BYTES-4:])
-
-	require.Equal(t, expectedScoreWithEmpty, scoreWithEmpty, "for score with empty seed doesn't match expected")
-	require.NotEqual(t, scoreWithNonEmpty, scoreWithEmpty, "for score with and without seed must not match")
-	require.NotEqual(t, scoreWithNonEmpty, scoreWithNonEmptyOneBitDiff, "score is diff even with one bit difference in seed")
+func requireCountToBeInRange(t testing.TB, actual, expected int) {
+	require.InDelta(t, expected, actual, 0.05 * float64(expected), "expect (%d) to be five precent delta to (%d)", actual, expected)
 }

--- a/services/processor/native/repository/Committee/index.go
+++ b/services/processor/native/repository/Committee/index.go
@@ -20,7 +20,7 @@ const METHOD_GET_ORDERED_COMMITTEE = "getOrderedCommittee" // used with election
 const METHOD_GET_ORDERED_COMMITTEE_FOR_ADDRESSES = "getOrderedCommitteeForAddresses" // used before election or for testing
 const METHOD_UPDATE_MISSES = "updateMisses"
 
-var PUBLIC = sdk.Export(getOrderedCommittee, getOrderedCommitteeForAddresses, getReputation, getAllCommitteeReputations, getMisses, getAllCommitteeMisses, updateMisses)
+var PUBLIC = sdk.Export(getOrderedCommittee, getNextOrderedCommittee, getOrderedCommitteeForAddresses, getReputation, getAllCommitteeReputations, getMisses, getAllCommitteeMisses, updateMisses)
 var SYSTEM = sdk.Export(_init)
 var EVENTS = sdk.Export(CommitteeMemberMissed, CommitteeMemberClosedBlock)
 

--- a/services/processor/native/repository/Committee/reputation.go
+++ b/services/processor/native/repository/Committee/reputation.go
@@ -13,8 +13,8 @@ import (
 	"github.com/orbs-network/orbs-contract-sdk/go/sdk/v1/state"
 )
 
-const ToleranceLevel = uint32(4)
-const ReputationBottomCap = uint32(10)
+const ToleranceLevel = uint32(2)
+const ReputationBottomCap = uint32(8)
 
 func _formatMisses(addr []byte) []byte {
 	return []byte(fmt.Sprintf("Address_%s_Misses", hex.EncodeToString(addr)))
@@ -31,13 +31,17 @@ func _addMiss(addr []byte) {
 
 func getReputation(addr []byte) uint32 {
 	currMiss := getMisses(addr)
-	if currMiss < ToleranceLevel {
+	if currMiss <= ToleranceLevel {
 		return 0
 	}
 	if currMiss < ReputationBottomCap {
-		return currMiss
+		return currMiss - ToleranceLevel
 	}
-	return ReputationBottomCap
+	return _getMaxReputation()
+}
+
+func _getMaxReputation() uint32 {
+	return ReputationBottomCap - ToleranceLevel
 }
 
 func _clearMiss(addr []byte) {
@@ -46,7 +50,7 @@ func _clearMiss(addr []byte) {
 
 // Function for external monitoring of reputation via absolute number of misses
 func getAllCommitteeMisses() (committeeAddresses [][20]byte, committeeMisses []uint32) {
-	addressesArray := _getOrderedCommitteeForAddresses(_getElectedValidators())
+	addressesArray := _split(_getElectedValidators())
 	committeeAddresses = make([][20]byte, len(addressesArray))
 	committeeMisses = make([]uint32, len(addressesArray))
 	for i, address := range addressesArray {
@@ -58,7 +62,7 @@ func getAllCommitteeMisses() (committeeAddresses [][20]byte, committeeMisses []u
 
 // Function for external monitoring of reputation
 func getAllCommitteeReputations() (committeeAddresses [][20]byte, committeeReputations []uint32) {
-	addressesArray := _getOrderedCommitteeForAddresses(_getElectedValidators())
+	addressesArray := _split(_getElectedValidators())
 	committeeAddresses = make([][20]byte, len(addressesArray))
 	committeeReputations = make([]uint32, len(addressesArray))
 	for i, address := range addressesArray {

--- a/services/processor/native/repository/Committee/reputation_test.go
+++ b/services/processor/native/repository/Committee/reputation_test.go
@@ -59,18 +59,18 @@ func TestOrbsCommitteeContract_getReputation(t *testing.T) {
 		_init()
 
 		// Prepare
-		moreThanRepCap := int(ReputationBottomCap) + 2
+		moreThanRepCap := int(ReputationBottomCap) + 3
 
 		// assert
 		for i := 0; i < moreThanRepCap; i++ {
 			rep := getReputation(addr)
 			miss := getMisses(addr)
-			if i < int(ToleranceLevel) {
+			if i <= int(ToleranceLevel) {
 				require.EqualValues(t, 0, rep, "upto tolerance should be 0")
 			} else if i < int(ReputationBottomCap) {
-				require.EqualValues(t, miss, rep, "upto cap should be miss")
+				require.EqualValues(t, miss-ToleranceLevel, rep, "upto cap should be miss")
 			} else {
-				require.EqualValues(t, ReputationBottomCap, rep, "cannot go over cap of reputation")
+				require.EqualValues(t, ReputationBottomCap-ToleranceLevel, rep, "cannot go over cap of reputation")
 			}
 			_addMiss(addr)
 		}


### PR DESCRIPTION
New algo to calculate reputation :
1) rep is now 0-6, (instead of 4-10) and rep 1 indicates a slash of half your chance to be leader.
2) algo is based on weighted draw
3) getAllX doesn't represent a committee order anymore.
4) input is assumed in consensus order so that the genesis has to first sort its config node addresses