### PR TITLE
Increase block scanner page size type (uint8 is too small)

### DIFF
--- a/bootstrap/inmemory/node.go
+++ b/bootstrap/inmemory/node.go
@@ -59,7 +59,7 @@ func (n *Node) ExtractBlocks() ([]*protocol.BlockPairContainer, error) {
 		return nil, errors.Wrapf(err, "failed reading block height")
 	}
 	var blockPairs []*protocol.BlockPairContainer
-	pageSize := uint8(lastBlock.ResultsBlock.Header.BlockHeight())
+	pageSize := uint64(lastBlock.ResultsBlock.Header.BlockHeight())
 	err = n.blockPersistence.ScanBlocks(1, pageSize, func(first primitives.BlockHeight, page []*protocol.BlockPairContainer) bool {
 		blockPairs = page // TODO should we copy the slice here to make sure both networks are isolated?
 		return false

--- a/services/blockstorage/adapter/filesystem/file_system_persistence.go
+++ b/services/blockstorage/adapter/filesystem/file_system_persistence.go
@@ -263,7 +263,7 @@ func (f *BlockPersistence) WriteNextBlock(blockPair *protocol.BlockPairContainer
 	return true, bh, nil
 }
 
-func (f *BlockPersistence) ScanBlocks(from primitives.BlockHeight, pageSize uint8, cursor adapter.CursorFunc) error {
+func (f *BlockPersistence) ScanBlocks(from primitives.BlockHeight, pageSize uint64, cursor adapter.CursorFunc) error {
 	currentTop := f.bhIndex.topBlockHeight
 	if currentTop < from {
 		return fmt.Errorf("requested unknown block height %d. current height is %d", from, currentTop)
@@ -287,7 +287,7 @@ func (f *BlockPersistence) ScanBlocks(from primitives.BlockHeight, pageSize uint
 	for wantNext && !eof {
 		page := make([]*protocol.BlockPairContainer, 0, pageSize)
 
-		for uint8(len(page)) < pageSize {
+		for uint64(len(page)) < pageSize {
 			aBlock, _, err := f.codec.decode(file)
 			if err != nil {
 				if err == io.EOF || err == io.ErrUnexpectedEOF {

--- a/services/blockstorage/adapter/memory/memory_persistence.go
+++ b/services/blockstorage/adapter/memory/memory_persistence.go
@@ -161,7 +161,7 @@ func (bp *InMemoryBlockPersistence) GetResultsBlock(height primitives.BlockHeigh
 	return blockPair.ResultsBlock, nil
 }
 
-func (bp *InMemoryBlockPersistence) ScanBlocks(from primitives.BlockHeight, pageSize uint8, f adapter.CursorFunc) error {
+func (bp *InMemoryBlockPersistence) ScanBlocks(from primitives.BlockHeight, pageSize uint64, f adapter.CursorFunc) error {
 	bp.blockChain.RLock()
 	defer bp.blockChain.RUnlock()
 

--- a/services/blockstorage/adapter/persistence.go
+++ b/services/blockstorage/adapter/persistence.go
@@ -20,7 +20,7 @@ type CursorFunc func(first primitives.BlockHeight, page []*protocol.BlockPairCon
 type BlockPersistence interface {
 	WriteNextBlock(blockPair *protocol.BlockPairContainer) (bool, primitives.BlockHeight, error)
 
-	ScanBlocks(from primitives.BlockHeight, pageSize uint8, f CursorFunc) error
+	ScanBlocks(from primitives.BlockHeight, pageSize uint64, f CursorFunc) error
 
 	GetLastBlockHeight() (primitives.BlockHeight, error)
 	GetLastBlock() (*protocol.BlockPairContainer, error)

--- a/services/blockstorage/servicesync/service_sync.go
+++ b/services/blockstorage/servicesync/service_sync.go
@@ -26,7 +26,7 @@ type BlockPairCommitter interface {
 
 type blockSource interface {
 	GetBlockTracker() *synchronization.BlockTracker
-	ScanBlocks(from primitives.BlockHeight, pageSize uint8, f adapter.CursorFunc) error
+	ScanBlocks(from primitives.BlockHeight, pageSize uint64, f adapter.CursorFunc) error
 	GetLastBlock() (*protocol.BlockPairContainer, error)
 }
 

--- a/services/blockstorage/servicesync/service_sync_test.go
+++ b/services/blockstorage/servicesync/service_sync_test.go
@@ -121,7 +121,7 @@ func (bsf *blockSourceMock) setLastBlockHeight(height primitives.BlockHeight) {
 }
 
 // TODO V1 - this duplicates logic form inMemoryBlockPersistence. Do we really need a mock object here?
-func (bsf *blockSourceMock) ScanBlocks(from primitives.BlockHeight, pageSize uint8, f adapter.CursorFunc) error {
+func (bsf *blockSourceMock) ScanBlocks(from primitives.BlockHeight, pageSize uint64, f adapter.CursorFunc) error {
 	bsf.Called(from, pageSize, f)
 
 	topBlockHeight := bsf.lastBlock.ResultsBlock.Header.BlockHeight()

--- a/test/acceptance/duplicate_tx_test.go
+++ b/test/acceptance/duplicate_tx_test.go
@@ -106,7 +106,7 @@ func requireTxCommittedOnce(ctx context.Context, t testing.TB, network *Network,
 	// count receipts for txHash in block storage of node 0
 	receiptCount := 0
 	var blocks []*BlockPairContainer
-	err = network.BlockPersistence(0).ScanBlocks(1, uint8(height), func(first primitives.BlockHeight, page []*BlockPairContainer) bool {
+	err = network.BlockPersistence(0).ScanBlocks(1, uint64(height), func(first primitives.BlockHeight, page []*BlockPairContainer) bool {
 		blocks = page
 		return false
 	})
@@ -134,7 +134,7 @@ func TestBlockTrackerAndScanBlocksStayInSync(t *testing.T) {
 		targetBlockHeight := 2
 		err1 := persistence.GetBlockTracker().WaitForBlock(ctx, primitives.BlockHeight(targetBlockHeight))
 
-		err2 := network.BlockPersistence(0).ScanBlocks(1, uint8(targetBlockHeight), func(first primitives.BlockHeight, page []*BlockPairContainer) bool {
+		err2 := network.BlockPersistence(0).ScanBlocks(1, uint64(targetBlockHeight), func(first primitives.BlockHeight, page []*BlockPairContainer) bool {
 			require.Len(t, page, targetBlockHeight)
 			return false
 		})


### PR DESCRIPTION
It's simply difficult to process large batches of blocks if the maximum batch size is 255.

This PR updates the batch size type so I can use block scanner is other projects.