### PR TITLE
Release to dockerhub staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
       - checkout
       - run: ./docker/build/build-docker-node.sh
       - run: ./.circleci/release-node-to-ecr.sh
+      - run: ./.circleci/release-node-to-staging.sh
 
   circleci_scripts:
     docker:

--- a/.circleci/release-node-to-staging.sh
+++ b/.circleci/release-node-to-staging.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+docker login -u $DOCKER_HUB_LOGIN -p $DOCKER_HUB_PASSWORD
+
+./docker/build/create-version-file.sh
+export VERSION=$(cat .version)
+
+docker tag orbs:export orbsnetworkstaging/node:$VERSION
+docker push orbsnetworkstaging/node:$VERSION


### PR DESCRIPTION
Releases any node version to `orbsnetworkstaging/node` docker repo.