### PR TITLE
Fix regression: missing node address metric

### DIFF
--- a/bootstrap/node.go
+++ b/bootstrap/node.go
@@ -41,6 +41,7 @@ func GetMetricRegistry(nodeConfig config.NodeConfig) metric.Registry {
 
 	version := config.GetVersion()
 
+	metricRegistry.NewText("Node.Address", nodeConfig.NodeAddress().String())
 	metricRegistry.NewText("Version.Semantic", version.Semantic)
 	metricRegistry.NewText("Version.Commit", version.Commit)
 


### PR DESCRIPTION
Was mistakenly removed in #1551