### PR TITLE
Add daemon tools to ONG to support new production run mode

### DIFF
--- a/docker/build/Dockerfile.export
+++ b/docker/build/Dockerfile.export
@@ -1,6 +1,6 @@
 FROM golang:1.12.9
 
-RUN apt-get install -y git
+RUN apt-get install -y git daemontools
 
 ADD ./_bin/go.mod /src/_tmp/processor-artifacts/go.mod
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/ethereum/go-ethereum v1.9.6
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/huin/goupnp v1.0.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,7 @@ github.com/orbs-network/lean-helix-go v0.3.0 h1:lN46V8I5LV7eZF0sYf8/0BBte8J+i/fl
 github.com/orbs-network/lean-helix-go v0.3.0/go.mod h1:9E/1sZEMZvNLHrP+nif36bio2zKbCkueji4R9e7vJnI=
 github.com/orbs-network/lean-helix-go v0.3.1-0.20200524235631-b7d49dc1d62a h1:CrezkBpRQMda9kbIYzzc6aa/fdWAW7biUriyDQhMSfk=
 github.com/orbs-network/lean-helix-go v0.3.1-0.20200524235631-b7d49dc1d62a/go.mod h1:9E/1sZEMZvNLHrP+nif36bio2zKbCkueji4R9e7vJnI=
+github.com/orbs-network/lean-helix-go v0.3.1/go.mod h1:9E/1sZEMZvNLHrP+nif36bio2zKbCkueji4R9e7vJnI=
 github.com/orbs-network/membuffers v0.3.2/go.mod h1:M5ABv0m0XBGoJbX+7UKVY02hLF4XhS2SlZVEVABMc6M=
 github.com/orbs-network/membuffers v0.3.6 h1:SEfVtDhzi8YHR4qY8ouu8G57sKGsT4vfgdBC5bjG8TE=
 github.com/orbs-network/membuffers v0.3.6/go.mod h1:M5ABv0m0XBGoJbX+7UKVY02hLF4XhS2SlZVEVABMc6M=
@@ -246,6 +247,7 @@ github.com/orbs-network/orbs-spec v0.0.0-20200503073830-babdf6adc845/go.mod h1:D
 github.com/orbs-network/orbs-spec v0.0.0-20200524234311-ad99bb5a54ee h1:xoaJ2lBuvbmqfk1Dl+CgGKC9Gc8AvqYQVaEhZLuta+k=
 github.com/orbs-network/orbs-spec v0.0.0-20200524234311-ad99bb5a54ee/go.mod h1:D4+jHMhQ+mPB4uhqZ2wtzuG8RV2JgltWG1FqAwLIaOw=
 github.com/orbs-network/orbs-spec v0.0.0-20200525092007-a71f2b62f2e5 h1:BpAmtcAIgMf9brHJuzzPVcbagz/XqIrF7hNsEjS7W2k=
+github.com/orbs-network/orbs-spec v0.0.0-20200602223840-61cdeb34eda3/go.mod h1:D4+jHMhQ+mPB4uhqZ2wtzuG8RV2JgltWG1FqAwLIaOw=
 github.com/orbs-network/pbparser v0.2.0/go.mod h1:WSzcxgH5xzywQm0YSASbD7RcdxBXZgqZaDVK8M+8DJ8=
 github.com/orbs-network/pbparser v0.3.0/go.mod h1:WSzcxgH5xzywQm0YSASbD7RcdxBXZgqZaDVK8M+8DJ8=
 github.com/orbs-network/scribe v0.1.0/go.mod h1:FmGcbukz5eolO+mqzxwmuy4RF4UEoLfGJIeEDAoGsBU=


### PR DESCRIPTION
The Docker image of ONG for production use will now include also
the Linux package  `daemontools` which provides the `multilog` binary