### PR TITLE
Remove IP validation from vc topology

### DIFF
--- a/services/management/adapter/file_provider.go
+++ b/services/management/adapter/file_provider.go
@@ -207,6 +207,8 @@ func parseTopology(currentTopology []topologyNode) ([]*services.GossipPeer, erro
 		hexAddress := item.OrbsAddress
 		if nodeAddress, err := hex.DecodeString(hexAddress); err != nil {
 			return nil, errors.Wrapf(err, "cannot translate topology node address from hex %s", hexAddress)
+		} else if item.Ip == "" {
+			return nil, errors.Errorf("empty ip address for node %s", hexAddress)
 		} else if item.Port < 1024 || item.Port > 65535 {
 			return nil, errors.Errorf("topology node port %d needs to be 1024-65535 range", item.Port)
 		} else {

--- a/services/management/adapter/file_provider_test.go
+++ b/services/management/adapter/file_provider_test.go
@@ -27,7 +27,7 @@ func TestManagementFileProvider_GeneratePath(t *testing.T) {
 		path := fileProvider.generatePath(0)
 		pathWithRef := fileProvider.generatePath(100)
 		require.Equal(t, url, path)
-		require.Equal(t, url + "/100", pathWithRef)
+		require.Equal(t, url+"/100", pathWithRef)
 	})
 }
 
@@ -51,6 +51,14 @@ func TestManagementFileProvider_ReadUrl(t *testing.T) {
 			expectFileProviderToReadCorrectly(t, ctx, fileProvider)
 		})
 	})
+}
+
+func Test_parseTopology(t *testing.T) {
+	_, encodingErr := parseTopology([]topologyNode{{OrbsAddress: "ZZZZZ"}})
+	require.EqualError(t, encodingErr, "cannot translate topology node address from hex ZZZZZ: encoding/hex: invalid byte: U+005A 'Z'")
+
+	_, portErr := parseTopology([]topologyNode{{OrbsAddress: "ffff", Port: 10000000}})
+	require.EqualError(t, portErr, "topology node port 10000000 needs to be 1024-65535 range")
 }
 
 func expectFileProviderToReadCorrectly(t *testing.T, ctx context.Context, fp management.Provider) {

--- a/services/management/adapter/file_provider_test.go
+++ b/services/management/adapter/file_provider_test.go
@@ -57,8 +57,11 @@ func Test_parseTopology(t *testing.T) {
 	_, encodingErr := parseTopology([]topologyNode{{OrbsAddress: "ZZZZZ"}})
 	require.EqualError(t, encodingErr, "cannot translate topology node address from hex ZZZZZ: encoding/hex: invalid byte: U+005A 'Z'")
 
-	_, portErr := parseTopology([]topologyNode{{OrbsAddress: "ffff", Port: 10000000}})
+	_, portErr := parseTopology([]topologyNode{{OrbsAddress: "ffff", Ip: "1.2.3.4", Port: 10000000}})
 	require.EqualError(t, portErr, "topology node port 10000000 needs to be 1024-65535 range")
+
+	_, emptyErr := parseTopology([]topologyNode{{OrbsAddress: "ffff", Ip: "", Port: 2048}})
+	require.EqualError(t, emptyErr, "empty ip address for node ffff")
 }
 
 func expectFileProviderToReadCorrectly(t *testing.T, ctx context.Context, fp management.Provider) {


### PR DESCRIPTION
There were couple of issues:

1. we don't need to validate the IP because the file might use hostnames and it's also valid
2. the error was not thrown in some places because it was `nil`

So I have removed excessive validation and replaced `errors.Wrapf` with `errors.Errorf` where needed.