### PR TITLE
Fix missing checks in file provider of weights and current ref time

### DIFF
--- a/services/management/adapter/file_provider.go
+++ b/services/management/adapter/file_provider.go
@@ -118,7 +118,7 @@ type committee struct {
 }
 
 type committeeEvent struct {
-	RefTime   uint32
+	RefTime   uint64
 	Committee []committee
 }
 
@@ -130,7 +130,7 @@ type subscription struct {
 }
 
 type subscriptionEvent struct {
-	RefTime uint32
+	RefTime uint64
 	Data    subscription
 }
 
@@ -140,13 +140,13 @@ type protocolVersion struct {
 }
 
 type protocolVersionEvent struct {
-	RefTime uint32
+	RefTime uint64
 	Data    protocolVersion
 }
 
 type vc struct {
 	VirtualChainId        uint64
-	GenesisRefTime        uint32
+	GenesisRefTime        uint64
 	CurrentTopology       []topologyNode
 	CommitteeEvents       []committeeEvent
 	SubscriptionEvents    []subscriptionEvent
@@ -154,7 +154,7 @@ type vc struct {
 }
 
 type mgmt struct {
-	CurrentRefTime   uint32
+	CurrentRefTime   uint64
 	PageStartRefTime uint64
 	PageEndRefTime   uint64
 	VirtualChains    map[string]vc
@@ -169,7 +169,14 @@ func (mp *FileProvider) parseData(contents []byte) (*management.VirtualChainMana
 	vcString := fmt.Sprintf("%d", mp.config.VirtualChainId())
 	vcData, ok := data.VirtualChains[vcString]
 	if !ok {
-		return nil, errors.Errorf("could not find current vc in data")
+		return nil, errors.Errorf("could not find current vc in data (%d)", mp.config.VirtualChainId())
+	}
+
+	if data.CurrentRefTime != 0 {
+		if data.CurrentRefTime < data.PageStartRefTime || data.CurrentRefTime > data.PageEndRefTime {
+			return nil, errors.Errorf("CurrentRefTime %d cannot be smaller than PageStartRefTime %d or bigger than PageEndRefTime %d",
+				data.CurrentRefTime, data.PageStartRefTime, data.PageEndRefTime)
+		}
 	}
 
 	topology, err := parseTopology(vcData.CurrentTopology)
@@ -228,6 +235,8 @@ func parseCommittees(committeeEvents []committeeEvent) ([]management.CommitteeTe
 		for _, member := range event.Committee {
 			if address, err := hex.DecodeString(member.OrbsAddress); err != nil {
 				return nil, errors.Wrapf(err, "cannot decode committee node address hex %s", address)
+			} else if member.Weight == 0 {
+				return nil, errors.Errorf("Weight of node %s is 0 or missing", address)
 			} else {
 				committee = append(committee, primitives.NodeAddress(address))
 				weights = append(weights, primitives.Weight(member.Weight))

--- a/services/management/adapter/file_provider_test.go
+++ b/services/management/adapter/file_provider_test.go
@@ -44,7 +44,7 @@ func TestManagementFileProvider_NoMatchVc(t *testing.T) {
 		"44": { 
 		}
 	}
-}`))
+}`), false)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "could not find current vc in data")
 		})
@@ -64,21 +64,45 @@ func TestManagementFileProvider_BadCurrentInPage(t *testing.T) {
 		"42": { 
 		}
 	}
-}`))
+}`), false)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "cannot be smaller than PageStartRefTime")
+			require.Contains(t, err.Error(), "data: CurrentRefTime (3) ")
 
 			_, err = fileProvider.parseData([]byte(`{
-	"CurrentRefTime": 1, 
-	"PageStartRefTime": 2, 
-	"PageEndRefTime": 4, 
+	"CurrentRefTime": 2, 
+	"PageStartRefTime": 3, 
+	"PageEndRefTime": 2, 
 	"VirtualChains": { 
 		"42": { 
 		}
 	}
-}`))
+}`), false)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "cannot be smaller than PageStartRefTime")
+			require.Contains(t, err.Error(), "data: CurrentRefTime (2) ")
+
+			_, err = fileProvider.parseData([]byte(`{
+	"CurrentRefTime": 4, 
+	"PageStartRefTime": 2, 
+	"PageEndRefTime": 5, 
+	"VirtualChains": { 
+		"42": { 
+		}
+	}
+}`), true)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "historic data : CurrentRefTime (4) ")
+
+			_, err = fileProvider.parseData([]byte(`{
+	"CurrentRefTime": 4, 
+	"PageStartRefTime": 2, 
+	"PageEndRefTime": 1, 
+	"VirtualChains": { 
+		"42": { 
+		}
+	}
+}`), true)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "historic data : CurrentRefTime (4) ")
 		})
 	})
 }


### PR DESCRIPTION
fixes #1582 

Historic response (timestamp given):
start <= end <= current

Latest response (no timestamp given):
start <= end = current


check weights are not 0