### PR TITLE
Blocks file diagnostic tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,15 @@ require (
 	github.com/c9s/goprocinfo v0.0.0-20190309065803-0b2ad9ac246b
 	github.com/cespare/cp v1.1.1 // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
+	github.com/coreos/etcd v3.3.13+incompatible
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/elastic/gosigar v0.10.4 // indirect
 	github.com/ethereum/go-ethereum v1.9.6
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/google/go-cmp v0.3.1
 	github.com/huin/goupnp v1.0.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,12 +39,15 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/etcd v3.3.13+incompatible h1:8F3hqu9fGYLBifCmRCJsicFqDx/D68Rt3q1JMazcgBQ=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=

--- a/instrumentation/metric/gauge.go
+++ b/instrumentation/metric/gauge.go
@@ -58,6 +58,18 @@ func (g *Gauge) Update(i int64) {
 	atomic.StoreInt64(&g.value, i)
 }
 
+func (g *Gauge) UpdateMax(i int64) {
+	for { // retry indefinitely (?!) if optimistic lock fails
+		old := g.Value()
+		if old >= i {
+			return
+		}
+		if atomic.CompareAndSwapInt64(&g.value, old, i) { // optimistic lock
+			return
+		}
+	}
+}
+
 func (g *Gauge) UpdateUInt32(i int32) {
 	atomic.StoreInt64(&g.value, int64(i))
 }

--- a/instrumentation/metric/histogram.go
+++ b/instrumentation/metric/histogram.go
@@ -14,33 +14,27 @@ import (
 	"time"
 )
 
-type Histogram struct {
+type HistogramTimeDiff struct {
 	namedMetric
 	histo         *hdrhistogram.WindowedHistogram
 	overflowCount int64
 }
 
-func newHistogram(name string, max int64, n int) *Histogram {
-	return &Histogram{
+func newHistogramTimeDiff(name string, max int64, n int) *HistogramTimeDiff {
+	return &HistogramTimeDiff{
 		namedMetric: namedMetric{name: name},
 		histo:       hdrhistogram.NewWindowed(n, 0, max, 1),
 	}
 }
 
-func (h *Histogram) RecordSince(t time.Time) {
+func (h *HistogramTimeDiff) RecordSince(t time.Time) {
 	d := time.Since(t).Nanoseconds()
 	if err := h.histo.Current.RecordValue(int64(d)); err != nil {
 		atomic.AddInt64(&h.overflowCount, 1)
 	}
 }
 
-func (h *Histogram) Record(measurement int64) {
-	if err := h.histo.Current.RecordValue(measurement); err != nil {
-		atomic.AddInt64(&h.overflowCount, 1)
-	}
-}
-
-func (h *Histogram) String() string {
+func (h *HistogramTimeDiff) String() string {
 	var errorRate float64
 	histo := h.histo.Current
 
@@ -63,7 +57,7 @@ func (h *Histogram) String() string {
 		errorRate)
 }
 
-func (h *Histogram) Export() exportedMetric {
+func (h *HistogramTimeDiff) Export() exportedMetric {
 	histo := h.histo.Merge()
 
 	return &histogramExport{
@@ -78,6 +72,67 @@ func (h *Histogram) Export() exportedMetric {
 	}
 }
 
-func (h *Histogram) Rotate() {
+func (h *HistogramTimeDiff) Rotate() {
+	h.histo.Rotate()
+}
+
+type HistogramInt64 struct { // TODO DRY HistogramTimeDiff is similar
+	namedMetric
+	histo         *hdrhistogram.WindowedHistogram
+	overflowCount int64
+}
+
+func newHistogramInt64(name string, max int64, n int) *HistogramInt64 {
+	return &HistogramInt64{
+		namedMetric: namedMetric{name: name},
+		histo:       hdrhistogram.NewWindowed(n, 0, max, 1),
+	}
+}
+
+func (h *HistogramInt64) Record(measurement int64) {
+	if err := h.histo.Current.RecordValue(measurement); err != nil {
+		atomic.AddInt64(&h.overflowCount, 1)
+	}
+}
+
+func (h *HistogramInt64) String() string {
+	var errorRate float64
+	histo := h.histo.Current
+
+	if h.overflowCount > 0 {
+		errorRate = float64(histo.TotalCount()) / float64(h.overflowCount)
+	} else {
+		errorRate = 0
+	}
+
+	return fmt.Sprintf(
+		"metric %s: [min=%d, p50=%d, p95=%d, p99=%d, max=%d, avg=%f, samples=%d, error rate=%f]\n",
+		h.name,
+		histo.Min(),
+		histo.ValueAtQuantile(50),
+		histo.ValueAtQuantile(95),
+		histo.ValueAtQuantile(99),
+		histo.Max(),
+		histo.Mean(),
+		histo.TotalCount(),
+		errorRate)
+}
+
+func (h *HistogramInt64) Export() exportedMetric {
+	histo := h.histo.Merge()
+
+	return &histogramExport{
+		h.name,
+		float64(histo.Min()),
+		float64(histo.ValueAtQuantile(50)),
+		float64(histo.ValueAtQuantile(95)),
+		float64(histo.ValueAtQuantile(99)),
+		float64(histo.Max()),
+		histo.Mean(),
+		histo.TotalCount(),
+	}
+}
+
+func (h *HistogramInt64) Rotate() {
 	h.histo.Rotate()
 }

--- a/instrumentation/metric/histogram_prometheus_test.go
+++ b/instrumentation/metric/histogram_prometheus_test.go
@@ -14,13 +14,13 @@ import (
 	"time"
 )
 
-// This does NOT test correctness of Histogram
+// This does NOT test correctness of NewHistogramInt64
 // (e.g. that calculation of quantiles for given values is correct)
 // It only verifies the accurate conversion of metric values into Prometheus format.
 func Test_PrometheusFormatterForHistogramWithLabels(t *testing.T) {
 	r := NewRegistry().WithVirtualChainId(100000)
 	const SEC = int64(time.Second)
-	histo := r.NewHistogram("Some.Latency", 1000*SEC)
+	histo := r.NewHistogramInt64("Some.Latency", 1000*SEC)
 
 	for i := 0; i < 1000; i++ {
 		histo.Record(int64(i) * SEC)

--- a/services/blockstorage/adapter/filesystem/_main/analyze_blocks.go
+++ b/services/blockstorage/adapter/filesystem/_main/analyze_blocks.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/orbs-network/orbs-network-go/instrumentation/metric"
+	"github.com/orbs-network/orbs-network-go/services/blockstorage/adapter/filesystem"
+	"github.com/orbs-network/orbs-spec/types/go/protocol"
+	"os"
+)
+
+const DefaultMaxBlockSize = 64 * 1024 * 1024
+const MB = 1024 * 1024
+
+var fs = flag.NewFlagSet("", flag.ContinueOnError)
+
+func usage() {
+	fmt.Fprintf(fs.Output(), "\nOrbs Blocks file analysis tool\n\nUsage: %s [options] blocks_file_name\n\nOptions:\n", os.Args[0])
+	fs.PrintDefaults()
+}
+
+func init() {
+	fs.Usage = usage
+}
+
+func main() {
+	maxBlockSizeBytes := fs.Uint64("max-block-size", DefaultMaxBlockSize, "maximum block size in bytes (64MB)")
+	help := fs.Bool("help", false, "print options")
+	fs.Parse(os.Args[1:])
+	filepath := fs.Arg(0)
+
+	if *help {
+		fs.Usage()
+		os.Exit(0)
+	}
+
+	if filepath == "" {
+		fs.Usage()
+		os.Exit(1)
+	}
+	analyze(filepath, *maxBlockSizeBytes)
+}
+
+func analyze(filepath string, maxBlockSizeBytes uint64) {
+	dp, err := filesystem.NewDiagnosticsParser(filepath)
+	if err != nil {
+		fs.Usage()
+		fmt.Printf("\n\nError opening file %s for diagnostics: %e", filepath, err)
+		os.Exit(1)
+	}
+	defer dp.Close()
+
+	fmt.Printf("\n\nBlocks file:  %s\nFile Version: %d\nNetwork Type: %d\nChainId:      %d\n\n", filepath, dp.Header.FileVersion, dp.Header.NetworkType, dp.Header.ChainId)
+
+	scanAllBlocks(maxBlockSizeBytes, dp, filepath)
+}
+
+func scanAllBlocks(maxBlockSizeBytes uint64, dp *filesystem.DiagnosticsParser, filepath string) {
+	registry := metric.NewRegistry()
+	h := registry.NewHistogramInt64("blocksSize", int64(maxBlockSizeBytes))
+
+	totalSize := dp.FileInfo.Size()
+
+	pb := newProgressBar("Scanning Blocks", totalSize, 30)
+
+	err := dp.ScanFile(uint32(maxBlockSizeBytes), func(size int, offset int64, block *protocol.BlockPairContainer) {
+		h.Record(int64(size))
+
+		// TODO collect more interesting stats
+
+		pb.updateProgressBar(offset)
+	})
+
+	if err != nil {
+		fs.Usage()
+		fmt.Printf("\n\nError scanning file %s: %e", filepath, err)
+		os.Exit(1)
+	}
+
+	pb.doneProgressBar()
+
+	bytes, _ := json.MarshalIndent(registry.ExportAll(), "", "  ")
+	fmt.Print("Stats:\n\n", string(bytes))
+}
+
+// Simple progress bar
+
+type progressBar struct {
+	width       int
+	targetValue int64
+	stepValue   int
+	progress    int
+}
+
+func newProgressBar(label string, _totalSize int64, width int) *progressBar {
+
+	fmt.Printf("%s [\033[%dC]\033[%dD", label, width, width+1) // draw the empty progress bar.
+	return &progressBar{
+		targetValue: _totalSize,
+		stepValue:   int(_totalSize) / width,
+		progress:    0,
+	}
+}
+
+func (pb *progressBar) doneProgressBar() {
+	pb.updateProgressBar(pb.targetValue)
+	fmt.Printf("] Done!\n") // complete the progress bar
+}
+
+func (pb *progressBar) updateProgressBar(currentValue int64) {
+	delta := int(currentValue)/pb.stepValue - pb.progress
+	for i := 0; i < delta; i++ {
+		fmt.Print(".")
+		pb.progress++
+	}
+
+}

--- a/services/blockstorage/adapter/filesystem/diagnostics_parser.go
+++ b/services/blockstorage/adapter/filesystem/diagnostics_parser.go
@@ -1,0 +1,84 @@
+package filesystem
+
+import (
+	"bufio"
+	"github.com/orbs-network/orbs-spec/types/go/protocol"
+	"github.com/pkg/errors"
+	"io"
+	"os"
+)
+
+type DiagnosticsParser struct {
+	f                *os.File
+	r                *bufio.Reader
+	Header           blocksFileHeader
+	firstBlockOffset int64
+	FileInfo         os.FileInfo
+}
+
+func NewDiagnosticsParser(filepath string) (*DiagnosticsParser, error) {
+	file, blocksOffset, header, err := openBlocksFileForDiagnostics(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return &DiagnosticsParser{
+		f:                file,
+		r:                bufio.NewReaderSize(file, 1024*1024),
+		Header:           *header,
+		firstBlockOffset: blocksOffset,
+		FileInfo:         info,
+	}, nil
+}
+
+func openBlocksFileForDiagnostics(filename string) (*os.File, int64, *blocksFileHeader, error) {
+
+	file, err := os.OpenFile(filename, os.O_RDONLY, 0600)
+	if err != nil {
+		return nil, 0, nil, errors.Wrapf(err, "failed to open blocks file for reading %s", filename)
+	}
+
+	header := newBlocksFileHeader(0, 0)
+	err = header.read(file)
+	if err != nil {
+		return nil, 0, nil, errors.Wrapf(err, "error reading blocks file Header")
+	}
+
+	offset, err := file.Seek(0, io.SeekCurrent) // read current offset
+	if err != nil {
+		return nil, 0, nil, errors.Wrapf(err, "error reading blocks file Header")
+	}
+
+	return file, offset, header, nil
+}
+
+func (dp *DiagnosticsParser) Close() {
+	defer func() {
+		recover()
+	}()
+
+	dp.f.Close()
+}
+
+func (dp *DiagnosticsParser) ScanFile(maxBlockSizeBytes uint32, f func(size int, offset int64, block *protocol.BlockPairContainer)) error {
+	codec := newCodec(maxBlockSizeBytes)
+
+	offset := dp.firstBlockOffset
+	for {
+		aBlock, blockSize, err := codec.decode(dp.r)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			} else {
+				return err
+			}
+		}
+		f(blockSize, offset, aBlock)
+		offset = offset + int64(blockSize)
+	}
+}

--- a/services/blockstorage/internodesync/factory.go
+++ b/services/blockstorage/internodesync/factory.go
@@ -61,12 +61,12 @@ func NewStateFactoryWithTimers(
 ) *stateFactory {
 
 	f := &stateFactory{
-		config:          config,
-		gossip:          gossip,
-		storage:         storage,
-		conduit:         conduit,
-		logger:          logger,
-		metrics:         newStateMetrics(factory),
+		config:  config,
+		gossip:  gossip,
+		storage: storage,
+		conduit: conduit,
+		logger:  logger,
+		metrics: newStateMetrics(factory),
 	}
 
 	if createCollectTimeoutTimer == nil {
@@ -98,7 +98,6 @@ func (f *stateFactory) getSyncBlocksOrder() gossipmessages.SyncBlocksOrder {
 	}
 }
 
-
 func (f *stateFactory) defaultCreateCollectTimeoutTimer() *synchronization.Timer {
 	return synchronization.NewTimer(f.config.BlockSyncCollectResponseTimeout())
 }
@@ -123,12 +122,12 @@ func (f *stateFactory) CreateIdleState() syncState {
 
 func (f *stateFactory) CreateCollectingAvailabilityResponseState() syncState {
 	return &collectingAvailabilityResponsesState{
-		factory:         f,
-		client:          newBlockSyncGossipClient(f.gossip, f.storage, f.logger, f.config.BlockSyncNumBlocksInBatch, f.config.NodeAddress),
-		createTimer:     f.createCollectTimeoutTimer,
-		logger:          f.logger,
-		conduit:         f.conduit,
-		metrics:         f.metrics.collectingStateMetrics,
+		factory:     f,
+		client:      newBlockSyncGossipClient(f.gossip, f.storage, f.logger, f.config.BlockSyncNumBlocksInBatch, f.config.NodeAddress),
+		createTimer: f.createCollectTimeoutTimer,
+		logger:      f.logger,
+		conduit:     f.conduit,
+		metrics:     f.metrics.collectingStateMetrics,
 	}
 }
 
@@ -155,12 +154,12 @@ func (f *stateFactory) CreateWaitingForChunksState(sourceNodeAddress primitives.
 
 func (f *stateFactory) CreateProcessingBlocksState(message *gossipmessages.BlockSyncResponseMessage) syncState {
 	return &processingBlocksState{
-		blocks:          message,
-		factory:         f,
-		logger:          f.logger,
-		storage:         f.storage,
-		conduit:         f.conduit,
-		metrics:         f.metrics.processingStateMetrics,
+		blocks:  message,
+		factory: f,
+		logger:  f.logger,
+		storage: f.storage,
+		conduit: f.conduit,
+		metrics: f.metrics.processingStateMetrics,
 	}
 }
 
@@ -173,32 +172,32 @@ type stateMetrics struct {
 }
 
 type idleStateMetrics struct {
-	timeSpentInState *metric.Histogram
+	timeSpentInState *metric.HistogramTimeDiff
 	timesReset       *metric.Gauge
 	timesExpired     *metric.Gauge
 }
 
 type collectingStateMetrics struct {
-	timeSpentInState                         *metric.Histogram
+	timeSpentInState                         *metric.HistogramTimeDiff
 	timesSucceededSendingAvailabilityRequest *metric.Gauge
 	timesFailedSendingAvailabilityRequest    *metric.Gauge
 }
 
 type finishedCollectingStateMetrics struct {
-	timeSpentInState               *metric.Histogram
+	timeSpentInState               *metric.HistogramTimeDiff
 	finishedWithNoResponsesCount   *metric.Gauge
 	finishedWithSomeResponsesCount *metric.Gauge
 }
 
 type waitingStateMetrics struct {
-	timeSpentInState *metric.Histogram
+	timeSpentInState *metric.HistogramTimeDiff
 	timesTimeout     *metric.Gauge
 	timesSuccessful  *metric.Gauge
 	timesByzantine   *metric.Gauge
 }
 
 type processingStateMetrics struct {
-	timeSpentInState       *metric.Histogram
+	timeSpentInState       *metric.HistogramTimeDiff
 	blocksRate             *metric.Rate
 	committedBlocks        *metric.Gauge
 	failedCommitBlocks     *metric.Gauge

--- a/services/consensusalgo/benchmarkconsensus/service.go
+++ b/services/consensusalgo/benchmarkconsensus/service.go
@@ -60,10 +60,10 @@ type Service struct {
 }
 
 type metrics struct {
-	consensusRoundTickTime     *metric.Histogram
+	consensusRoundTickTime     *metric.HistogramTimeDiff
 	failedConsensusTicksRate   *metric.Rate
 	timedOutConsensusTicksRate *metric.Rate
-	votingTime                 *metric.Histogram
+	votingTime                 *metric.HistogramTimeDiff
 	lastCommittedTime          *metric.Gauge
 }
 

--- a/services/consensusalgo/leanhelixconsensus/service.go
+++ b/services/consensusalgo/leanhelixconsensus/service.go
@@ -46,8 +46,8 @@ type Service struct {
 }
 
 type metrics struct {
-	timeSinceLastCommitMillis   *metric.Histogram
-	timeSinceLastElectionMillis *metric.Histogram
+	timeSinceLastCommitMillis   *metric.HistogramTimeDiff
+	timeSinceLastElectionMillis *metric.HistogramTimeDiff
 	currentLeaderMemberId       *metric.Text
 	currentElectionCount        *metric.Gauge
 	lastCommittedTime           *metric.Gauge

--- a/services/consensusalgo/leanhelixconsensus/test/harness.go
+++ b/services/consensusalgo/leanhelixconsensus/test/harness.go
@@ -50,8 +50,8 @@ type singleLhcNodeHarness struct {
 }
 
 type metrics struct {
-	timeSinceLastCommitMillis   *metric.Histogram
-	timeSinceLastElectionMillis *metric.Histogram
+	timeSinceLastCommitMillis   *metric.HistogramTimeDiff
+	timeSinceLastElectionMillis *metric.HistogramTimeDiff
 	currentLeaderMemberId       *metric.Text
 	currentElectionCount        *metric.Gauge
 	lastCommittedTime           *metric.Gauge
@@ -108,8 +108,8 @@ func (h *singleLhcNodeHarness) start(parent *with.ConcurrencyHarness, ctx contex
 // NOTICE in the test harness these values always exist so no checking of nil return values
 func (h *singleLhcNodeHarness) getMetrics() *metrics {
 	return &metrics{
-		timeSinceLastCommitMillis:   h.metricRegistry.Get("ConsensusAlgo.LeanHelix.TimeSinceLastCommit.Millis").(*metric.Histogram),
-		timeSinceLastElectionMillis: h.metricRegistry.Get("ConsensusAlgo.LeanHelix.TimeSinceLastElection.Millis").(*metric.Histogram),
+		timeSinceLastCommitMillis:   h.metricRegistry.Get("ConsensusAlgo.LeanHelix.TimeSinceLastCommit.Millis").(*metric.HistogramTimeDiff),
+		timeSinceLastElectionMillis: h.metricRegistry.Get("ConsensusAlgo.LeanHelix.TimeSinceLastElection.Millis").(*metric.HistogramTimeDiff),
 		currentElectionCount:        h.metricRegistry.Get("ConsensusAlgo.LeanHelix.CurrentElection.Number").(*metric.Gauge),
 		currentLeaderMemberId:       h.metricRegistry.Get("ConsensusAlgo.LeanHelix.CurrentLeaderMemberId.Number").(*metric.Text),
 		lastCommittedTime:           h.metricRegistry.Get("ConsensusAlgo.LeanHelix.LastCommitted.TimeNano").(*metric.Gauge),
@@ -146,7 +146,7 @@ func (h *singleLhcNodeHarness) beFirstInCommittee() {
 func (h *singleLhcNodeHarness) expectConsensusContextRequestOrderingCommittee(leaderNodeIndex int) {
 	h.consensusContext.When("RequestOrderingCommittee", mock.Any, mock.Any).Return(&services.RequestCommitteeOutput{
 		NodeAddresses: h.getCommitteeWithNodeIndexAsLeader(leaderNodeIndex),
-		Weights: h.getCommitteeWeights(),
+		Weights:       h.getCommitteeWeights(),
 	}, nil).Times(1)
 }
 

--- a/services/consensuscontext/service.go
+++ b/services/consensuscontext/service.go
@@ -20,9 +20,9 @@ import (
 var LogTag = log.Service("consensus-context")
 
 type metrics struct {
-	createTxBlockTime                         *metric.Histogram
-	createResultsBlockTime                    *metric.Histogram
-	processTransactionsSeInCreateResultsBlock *metric.Histogram
+	createTxBlockTime                         *metric.HistogramTimeDiff
+	createResultsBlockTime                    *metric.HistogramTimeDiff
+	processTransactionsSeInCreateResultsBlock *metric.HistogramTimeDiff
 	transactionsRate                          *metric.Rate
 	committeeSize                             *metric.Gauge
 	committeeMembers                          *metric.Text

--- a/services/crosschainconnector/ethereum/timestampfinder/timestamp_finder.go
+++ b/services/crosschainconnector/ethereum/timestampfinder/timestamp_finder.go
@@ -37,7 +37,7 @@ type finder struct {
 }
 
 type timestampBlockFinderMetrics struct {
-	timeToFindBlock     *metric.Histogram
+	timeToFindBlock     *metric.HistogramTimeDiff
 	stepsRequired       *metric.Rate
 	totalTimesCalled    *metric.Gauge
 	cacheHits           *metric.Gauge

--- a/services/gossip/adapter/tcp/outgoing_connections.go
+++ b/services/gossip/adapter/tcp/outgoing_connections.go
@@ -18,7 +18,7 @@ type outgoingConnectionMetrics struct {
 	sendQueueErrors *metric.Gauge
 	activeCount     *metric.Gauge
 
-	messageSize *metric.Histogram
+	messageSize *metric.HistogramInt64
 }
 
 type outgoingConnections struct {
@@ -52,7 +52,7 @@ func createOutgoingConnectionMetrics(registry metric.Registry) *outgoingConnecti
 		KeepaliveErrors: registry.NewGauge("Gossip.OutgoingConnection.KeepaliveErrors.Count"),
 		sendQueueErrors: registry.NewGauge("Gossip.OutgoingConnection.SendQueueErrors.Count"),
 		activeCount:     registry.NewGauge("Gossip.OutgoingConnection.Active.Count"),
-		messageSize:     registry.NewHistogram("Gossip.OutgoingConnection.MessageSize.Bytes", MAX_PAYLOAD_SIZE_BYTES),
+		messageSize:     registry.NewHistogramInt64("Gossip.OutgoingConnection.MessageSize.Bytes", MAX_PAYLOAD_SIZE_BYTES),
 	}
 }
 

--- a/services/processor/native/adapter/native_compiler.go
+++ b/services/processor/native/adapter/native_compiler.go
@@ -37,11 +37,11 @@ var LogTag = log.String("adapter", "processor-native")
 
 type nativeCompilerMetrics struct {
 	lastWarmUpTimeMs *metric.Gauge
-	totalCompileTime *metric.Histogram
-	writeToDiskTime  *metric.Histogram
-	buildTime        *metric.Histogram
-	loadTime         *metric.Histogram
-	sourceSize       *metric.Histogram
+	totalCompileTime *metric.HistogramTimeDiff
+	writeToDiskTime  *metric.HistogramTimeDiff
+	buildTime        *metric.HistogramTimeDiff
+	loadTime         *metric.HistogramTimeDiff
+	sourceSize       *metric.HistogramInt64
 }
 
 type nativeCompiler struct {
@@ -57,7 +57,7 @@ func createNativeCompilerMetrics(factory metric.Factory) *nativeCompilerMetrics 
 		loadTime:         factory.NewLatency("Processor.Native.Compiler.LoadObject.Time.Millis", 60*time.Minute),
 		lastWarmUpTimeMs: factory.NewGauge("Processor.Native.Compiler.LastWarmUp.Time.Millis"),
 		writeToDiskTime:  factory.NewLatency("Processor.Native.Compiler.WriteToDisk.Time.Millis", 60*time.Minute),
-		sourceSize:       factory.NewHistogram("Processor.Native.Compiler.Source.Size.Bytes", 1024*1024), // megabyte
+		sourceSize:       factory.NewHistogramInt64("Processor.Native.Compiler.Source.Size.Bytes", 1024*1024), // megabyte
 	}
 }
 

--- a/services/processor/native/compiling_repository.go
+++ b/services/processor/native/compiling_repository.go
@@ -61,8 +61,8 @@ type CompilingRepository struct {
 	sanitizer *sanitizer.Sanitizer
 
 	deployedContracts       *metric.Gauge
-	processCallTime         *metric.Histogram
-	contractCompilationTime *metric.Histogram
+	processCallTime         *metric.HistogramTimeDiff
+	contractCompilationTime *metric.HistogramTimeDiff
 	config                  config.NativeProcessorConfig
 }
 

--- a/services/processor/native/service.go
+++ b/services/processor/native/service.go
@@ -47,7 +47,7 @@ type service struct {
 }
 
 type metrics struct {
-	processCallTime *metric.Histogram
+	processCallTime *metric.HistogramTimeDiff
 }
 
 func getMetrics(m metric.Factory) *metrics {

--- a/services/publicapi/service.go
+++ b/services/publicapi/service.go
@@ -34,9 +34,9 @@ type service struct {
 }
 
 type metrics struct {
-	sendTransactionTime                *metric.Histogram
-	getTransactionStatusTime           *metric.Histogram
-	runQueryTime                       *metric.Histogram
+	sendTransactionTime                *metric.HistogramTimeDiff
+	getTransactionStatusTime           *metric.HistogramTimeDiff
+	runQueryTime                       *metric.HistogramTimeDiff
 	totalTransactionsFromClients       *metric.Gauge
 	totalTransactionsErrNilRequest     *metric.Gauge
 	totalTransactionsErrInvalidRequest *metric.Gauge

--- a/services/transactionpool/pending_pool.go
+++ b/services/transactionpool/pending_pool.go
@@ -42,8 +42,8 @@ type pendingPoolMetrics struct {
 	transactionCountGauge    *metric.Gauge
 	poolSizeInBytesGauge     *metric.Gauge
 	transactionRatePerSecond *metric.Rate
-	transactionSpentInQueue  *metric.Histogram
-	transactionServiceTime   *metric.Histogram
+	transactionSpentInQueue  *metric.HistogramTimeDiff
+	transactionServiceTime   *metric.HistogramTimeDiff
 }
 
 func newPendingPoolMetrics(factory metric.Factory) *pendingPoolMetrics {


### PR DESCRIPTION
- depends on #1594 
- add a thin `diagnostics_parser.go` to wrap the codec. The alternative to using this wrapper is to make `Codec` public. Which is better? @noambergIL 
- `analyze_blocks.go` is a command line tool which receives a blocks file, scans all blocks and prints analysis. Currently only a very minimal analysis is done (histogram of block sizes - and one which does not contain all blocks - very basic)

Notice - we can delete the parser class if we make the codec public, the UI tool is easily extendable to answer any question about all blocks in any blocks file.

Tests are missing - need feedback before finalizing
