### PR TITLE
disable status update of eth conn 

### DIFF
--- a/bootstrap/node.go
+++ b/bootstrap/node.go
@@ -94,7 +94,8 @@ func NewNode(nodeConfig config.NodeConfig, logger log.Logger) *Node {
 		blockPersistence: blockPersistence,
 	}
 
-	ethereumConnection.ReportConnectionStatus(ctx)
+	// TODO re-enable Ethereum access (with refTime based finality)
+	// ethereumConnection.ReportConnectionStatus(ctx)
 
 	n.Supervise(ethereumConnection)
 	n.Supervise(nodeLogic)


### PR DESCRIPTION
when we don't really use it (after removal of eth endpoint from config and use of default-fake-one)