### PR TITLE
retain 0.5Gb of logs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 multilog_err=1
-multilog_cmd="multilog s16777215 n10 '!tai64nlocal' /opt/orbs/logs"
+multilog_cmd="multilog s16777215 n32 /opt/orbs/logs"
 
 while [[ "${multilog_err}" -ne "0" ]]; do
     sleep 1


### PR DESCRIPTION
- remove redundant log file processor `tai64nlocal`
- increase the maximal logs retention to 0.5Gb