### PR TITLE
Registry metric double name fix, clean up outgoing cons metrics

### DIFF
--- a/instrumentation/metric/registry.go
+++ b/instrumentation/metric/registry.go
@@ -86,6 +86,10 @@ func (r *inMemoryRegistry) Get(metricName string) metric {
 func (r *inMemoryRegistry) Remove(m metric) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if m == nil {
+		return
+	}
+
 	if mapMetric, isMetricInMap := r.mu.metrics[m.Name()]; isMetricInMap {
 		if mapMetric == m {
 			delete(r.mu.metrics, m.Name())

--- a/services/gossip/adapter/tcp/outgoing_connection.go
+++ b/services/gossip/adapter/tcp/outgoing_connection.go
@@ -52,6 +52,8 @@ func newOutgoingConnection(peer adapter.TransportPeer, parentLogger log.Logger, 
 	queue.networkAddress = networkAddress
 	queue.Disable() // until connection is established
 
+	sendErrors, sendQueueErrors := generateMetrics(peerHexAddress, metricFactory)
+
 	client := &outgoingConnection{
 		logger:          logger,
 		sharedMetrics:   sharedMetrics,
@@ -59,11 +61,26 @@ func newOutgoingConnection(peer adapter.TransportPeer, parentLogger log.Logger, 
 		config:          transportConfig,
 		queue:           queue,
 		peerHexAddress:  peerHexAddress,
-		sendErrors:      metricFactory.NewGauge(fmt.Sprintf("Gossip.OutgoingConnection.SendError.%s.Count", peerHexAddress)),
-		sendQueueErrors: metricFactory.NewGauge(fmt.Sprintf("Gossip.OutgoingConnection.EnqueueErrors.%s.Count", peerHexAddress)),
+		sendErrors:      sendErrors,
+		sendQueueErrors: sendQueueErrors,
 	}
 
 	return client
+}
+
+// This is a round-about way to clean up these metrics that can be left over from previous connection
+func generateMetrics(peerHexAddress string, metricFactory metric.Registry) (*metric.Gauge, *metric.Gauge){
+	sendErrorsName := fmt.Sprintf("Gossip.OutgoingConnection.SendError.%s.Count", peerHexAddress)
+	sendErrorMetric := metricFactory.Get(sendErrorsName)
+	if sendErrorMetric != nil {
+		metricFactory.Remove(sendErrorMetric)
+	}
+	sendQueueErrorsName := fmt.Sprintf("Gossip.OutgoingConnection.EnqueueErrors.%s.Count", peerHexAddress)
+	sendQueueErrorMetric := metricFactory.Get(sendQueueErrorsName)
+	if sendQueueErrorMetric != nil {
+		metricFactory.Remove(sendQueueErrorMetric)
+	}
+	return metricFactory.NewGauge(sendErrorsName),  metricFactory.NewGauge(sendQueueErrorsName)
 }
 
 func (c *outgoingConnection) connect(parent context.Context) {

--- a/services/gossip/adapter/tcp/outgoing_connection.go
+++ b/services/gossip/adapter/tcp/outgoing_connection.go
@@ -72,14 +72,12 @@ func newOutgoingConnection(peer adapter.TransportPeer, parentLogger log.Logger, 
 func generateMetrics(peerHexAddress string, metricFactory metric.Registry) (*metric.Gauge, *metric.Gauge){
 	sendErrorsName := fmt.Sprintf("Gossip.OutgoingConnection.SendError.%s.Count", peerHexAddress)
 	sendErrorMetric := metricFactory.Get(sendErrorsName)
-	if sendErrorMetric != nil {
-		metricFactory.Remove(sendErrorMetric)
-	}
+	metricFactory.Remove(sendErrorMetric)
+
 	sendQueueErrorsName := fmt.Sprintf("Gossip.OutgoingConnection.EnqueueErrors.%s.Count", peerHexAddress)
 	sendQueueErrorMetric := metricFactory.Get(sendQueueErrorsName)
-	if sendQueueErrorMetric != nil {
-		metricFactory.Remove(sendQueueErrorMetric)
-	}
+	metricFactory.Remove(sendQueueErrorMetric)
+
 	return metricFactory.NewGauge(sendErrorsName),  metricFactory.NewGauge(sendQueueErrorsName)
 }
 


### PR DESCRIPTION
registry work with names not pointer (except remove that checks same object), try and remove metric from outgoing_connection.go and queue.go before creating new one to avoid "double register"