### PR TITLE
changes lastCommitTime to initialize with value now - fixes issue of …

### DIFF
--- a/services/blockstorage/init.go
+++ b/services/blockstorage/init.go
@@ -66,7 +66,7 @@ func newMetrics(m metric.Factory) *metrics {
 		inOrderBlockTime:         m.NewGauge("BlockStorage.InOrderBlock.BlockTime.TimeNano"),
 		topBlockHeight:           m.NewGauge("BlockStorage.TopBlock.BlockHeight"),
 		topBlockTime:             m.NewGauge("BlockStorage.TopBlock.BlockTime.TimeNano"),
-		lastCommitTime:           m.NewGauge("BlockStorage.LastCommit.TimeNano"),
+		lastCommitTime:           m.NewGaugeWithValue("BlockStorage.LastCommit.TimeNano", time.Now().UnixNano()),
 	}
 }
 


### PR DESCRIPTION
…observer polling it on node vc boot (prior to sync it holds 0 value ) and accounting it as vc stuck