### PR TITLE
updated the go-mod to include orbs-spec latest version and lean-helix v0.6.1 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,11 +29,11 @@ require (
 	github.com/orbs-network/go-mock v1.1.0
 	github.com/orbs-network/govnr v0.2.0
 	github.com/orbs-network/healthcheck v1.4.0
-	github.com/orbs-network/lean-helix-go v0.5.1-0.20201011065550-9473b7e1df05
+	github.com/orbs-network/lean-helix-go v0.6.1
 	github.com/orbs-network/membuffers v0.4.0
 	github.com/orbs-network/orbs-client-sdk-go v0.19.0
 	github.com/orbs-network/orbs-contract-sdk v1.8.0
-	github.com/orbs-network/orbs-spec v0.0.0-20201013064336-2e9a104f3993
+	github.com/orbs-network/orbs-spec v0.0.0-20201111202205-46827c8fe793
 	github.com/orbs-network/scribe v0.2.3
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/services/blockstorage/init.go
+++ b/services/blockstorage/init.go
@@ -66,7 +66,7 @@ func newMetrics(m metric.Factory) *metrics {
 		inOrderBlockTime:         m.NewGauge("BlockStorage.InOrderBlock.BlockTime.TimeNano"),
 		topBlockHeight:           m.NewGauge("BlockStorage.TopBlock.BlockHeight"),
 		topBlockTime:             m.NewGauge("BlockStorage.TopBlock.BlockTime.TimeNano"),
-		lastCommitTime:           m.NewGauge("BlockStorage.LastCommit.TimeNano"),
+		lastCommitTime:           m.NewGaugeWithValue("BlockStorage.LastCommit.TimeNano", time.Now().UnixNano()),
 	}
 }
 

--- a/services/consensusalgo/leanhelixconsensus/block_provider.go
+++ b/services/consensusalgo/leanhelixconsensus/block_provider.go
@@ -191,15 +191,15 @@ func (p *blockProvider) GenerateGenesisBlockProposal(ctx context.Context) (lh.Bl
 }
 
 func (s *Service) verifyChainTip(ctx context.Context, blockPair *protocol.BlockPairContainer, prevBlockPair *protocol.BlockPairContainer) error {
-	if err := s.blockProvider.validateBlockCommittee(ctx, blockPair, prevBlockPair); err != nil {
-		s.logger.Info("HandleBlockConsensus()::verifyChainTip - Failed to validate block committee", log.Error(err))
+	if err := s.blockProvider.ValidateBlockReferenceTime(ctx, blockPair, prevBlockPair); err != nil {
+		s.logger.Info("HandleBlockConsensus()::verifyChainTip - Failed to validate block reference time", log.Error(err))
 		return s.validateBlockConsensus(ctx, blockPair, nil, true) // prevBlock nil => use current ref time (committee)
 	}
 	return nil
 }
 
-func (p *blockProvider) validateBlockCommittee(ctx context.Context, blockPair *protocol.BlockPairContainer, prevBlockPair *protocol.BlockPairContainer) error {
-	_, err := p.consensusContext.ValidateBlockCommittee(ctx, &services.ValidateBlockCommitteeInput{
+func (p *blockProvider) ValidateBlockReferenceTime(ctx context.Context, blockPair *protocol.BlockPairContainer, prevBlockPair *protocol.BlockPairContainer) error {
+	_, err := p.consensusContext.ValidateBlockReferenceTime(ctx, &services.ValidateBlockReferenceTimeInput{
 		BlockHeight:            getBlockHeight(blockPair),
 		PrevBlockReferenceTime: getBlockReferenceTime(prevBlockPair),
 	})

--- a/services/consensuscontext/committee.go
+++ b/services/consensuscontext/committee.go
@@ -103,18 +103,18 @@ func (s *service) RequestBlockProofValidationCommittee(ctx context.Context, inpu
 	return res, nil
 }
 
-func (s *service) ValidateBlockCommittee(ctx context.Context, input *services.ValidateBlockCommitteeInput) (*services.ValidateBlockCommitteeOutput, error) {
+func (s *service) ValidateBlockReferenceTime(ctx context.Context, input *services.ValidateBlockReferenceTimeInput) (*services.ValidateBlockReferenceTimeOutput, error) {
 	// refTime might be adjusted to genesis if block height is 1
 	adjustedPrevBlockReferenceTime, err := s.adjustPrevReference(ctx, input.BlockHeight, input.PrevBlockReferenceTime)
 	if err != nil {
-		return nil, errors.Wrap(err, "ValidateBlockCommittee")
+		return nil, errors.Wrap(err, "ValidateBlockReferenceTime")
 	}
 
 	now := time.Duration(time.Now().Unix()) * time.Second
 	if (time.Duration(adjustedPrevBlockReferenceTime)*time.Second)+s.config.ManagementConsensusGraceTimeout() < now { // prevRefTime-committee is too old
-		return nil, errors.New("ValidateBlockCommittee: block committee (:=prevBlock.RefTime) is outdated")
+		return nil, errors.New("ValidateBlockReferenceTime: block reference time is outdated ( used on :=prevBlock.RefTime for current consensus round committee grace time ) ")
 	}
 
-	return &services.ValidateBlockCommitteeOutput{}, nil
+	return &services.ValidateBlockReferenceTimeOutput{}, nil
 
 }


### PR DESCRIPTION
includes renaming consensusContext.ValidateBlockCommittee -> ValidateBlockReferenceTime  + lean-helix latest version (includes soft validation and reduce incoming msgs logging) + includes metric fix for vc stuck