### PR TITLE
fix vc-stuck metric 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/orbs-network/go-mock v1.1.0
 	github.com/orbs-network/govnr v0.2.0
 	github.com/orbs-network/healthcheck v1.4.0
-	github.com/orbs-network/lean-helix-go v0.6.1
+	github.com/orbs-network/lean-helix-go v0.6.2
 	github.com/orbs-network/membuffers v0.4.0
 	github.com/orbs-network/orbs-client-sdk-go v0.19.0
 	github.com/orbs-network/orbs-contract-sdk v1.8.0

--- a/services/blockstorage/init.go
+++ b/services/blockstorage/init.go
@@ -99,7 +99,7 @@ func NewBlockStorage(
 	}
 	s.Supervise(s.nodeSync)
 	s.Supervise(s.startNotifyNodeSync(ctx))
-	s.updateMetrics(0)
+	s.updateMetrics(time.Now().UnixNano())
 	return s
 }
 


### PR DESCRIPTION
fix to LastCommit.Time metric initial value (now) overridden by 0 
updated the go-mod to lean-helix latest tag v0.6.2