### PR TITLE
Fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,9 +131,13 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
+      - run: |
+	  sudo apt update
+          # sudo apt install --only-upgrade openssl
+          sudo apt install --only-upgrade ca-certificates
       - checkout
-      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./.circleci/install-go.sh
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./.circleci/install-node.sh #TODO is this really needed?
       - run: ./.circleci/install-docker-compose.sh
       - run: ./docker/test/import-node-staging.sh
@@ -157,8 +161,8 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
-      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./.circleci/install-go.sh
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./.circleci/install-node.sh #TODO is this really needed?
       - run: ./.circleci/install-docker-compose.sh
       - run: ./docker/test/import-gamma-staging.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,9 +154,10 @@ jobs:
 
   gamma_e2e:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202111-01
       docker_layer_caching: true
     steps:
+      - run: sudo apt update ; sudo apt-get install apt-transport-https ca-certificates -y ; sudo update-ca-certificates
       - checkout
       - run: ./.circleci/install-go.sh
       - run: go get -u github.com/orbs-network/go-junit-report
@@ -172,9 +173,9 @@ jobs:
 # TODO re-enable if Ethereum access (with refTime based finality) is restored to test it
 #  ganache_related_tests:
 #    machine:
-#      image: ubuntu-1604:201903-01
+#      image: ubuntu-2004:202111-01
 #    steps:
-#      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
+#      - run: sudo apt update ; sudo apt-get install apt-transport-https ca-certificates -y ; sudo update-ca-certificates
 #      - checkout
 #      - run: go get -u github.com/orbs-network/go-junit-report
 #      - run: ./.circleci/install-go.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,10 @@ version: 2
 jobs:
   tests:
     docker:
-      - image: circleci/golang:1.15
+      - image: circleci/golang:1.12.9
     resource_class: large
     steps:
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
       - run: go get -u github.com/orbs-network/go-junit-report
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,9 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: large
     steps:
-      - run: go get -u github.com/orbs-network/go-junit-report
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run:
           command: ./test.races.sh
           no_output_timeout: 25m
@@ -44,8 +45,9 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: xlarge
     steps:
-      - run: go get -u github.com/orbs-network/go-junit-report
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./test.goroutine-leaks.sh
       - run: ./test.memory-leaks.sh
 
@@ -55,8 +57,9 @@ jobs:
     parallelism: 6
     resource_class: xlarge
     steps:
-      - run: go get -u github.com/orbs-network/go-junit-report
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run:
           command: ./test.flakiness.sh
           no_output_timeout: 25m
@@ -75,8 +78,9 @@ jobs:
     parallelism: 6
     resource_class: xlarge
     steps:
-      - run: go get -u github.com/orbs-network/go-junit-report
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run:
           command: ./.circleci/nightly.sh
           no_output_timeout: 300m
@@ -94,8 +98,9 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
-      - run: go get -u github.com/orbs-network/go-junit-report
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./docker/build/build-docker-node.sh
       - run: ./.circleci/release-node-to-staging.sh
 
@@ -112,8 +117,9 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
-      - run: go get -u github.com/orbs-network/go-junit-report
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./docker/build/build-docker-gamma.sh
       - run: ./.circleci/release-gamma-to-staging.sh
 
@@ -129,8 +135,9 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
-      - run: go get -u github.com/orbs-network/go-junit-report
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./.circleci/install-go.sh
       - run: ./.circleci/install-node.sh #TODO is this really needed?
       - run: ./.circleci/install-docker-compose.sh
@@ -154,8 +161,9 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
-      - run: go get -u github.com/orbs-network/go-junit-report
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./.circleci/install-go.sh
       - run: ./.circleci/install-node.sh #TODO is this really needed?
       - run: ./.circleci/install-docker-compose.sh
@@ -171,8 +179,9 @@ jobs:
 #    machine:
 #      image: ubuntu-1604:201903-01
 #    steps:
-#      - run: go get -u github.com/orbs-network/go-junit-report
+#      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
 #      - checkout
+#      - run: go get -u github.com/orbs-network/go-junit-report
 #      - run: ./.circleci/install-go.sh
 #      - run: ./docker/test/ganache-related-test.sh
 #      - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,10 +131,6 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
-      - run: |
-          sudo apt update
-          sudo apt install --only-upgrade openssl
-          sudo apt install --only-upgrade ca-certificates
       - checkout
       - run: ./.circleci/install-go.sh
       - run: go get -u github.com/orbs-network/go-junit-report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: large
     steps:
+      - run: go get -u github.com/orbs-network/go-junit-report
       - checkout
-      - run: ./.circleci/retry.sh 5 go get -u github.com/orbs-network/go-junit-report
       - run:
           command: ./test.races.sh
           no_output_timeout: 25m
@@ -43,8 +43,8 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: xlarge
     steps:
+      - run: go get -u github.com/orbs-network/go-junit-report
       - checkout
-      - run: ./.circleci/retry.sh 5 go get -u github.com/orbs-network/go-junit-report
       - run: ./test.goroutine-leaks.sh
       - run: ./test.memory-leaks.sh
 
@@ -54,8 +54,8 @@ jobs:
     parallelism: 6
     resource_class: xlarge
     steps:
+      - run: go get -u github.com/orbs-network/go-junit-report
       - checkout
-      - run: ./.circleci/retry.sh 5 go get -u github.com/orbs-network/go-junit-report
       - run:
           command: ./test.flakiness.sh
           no_output_timeout: 25m
@@ -74,6 +74,7 @@ jobs:
     parallelism: 6
     resource_class: xlarge
     steps:
+      - run: go get -u github.com/orbs-network/go-junit-report
       - checkout
       - run:
           command: ./.circleci/nightly.sh
@@ -92,6 +93,7 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
+      - run: go get -u github.com/orbs-network/go-junit-report
       - checkout
       - run: ./docker/build/build-docker-node.sh
       - run: ./.circleci/release-node-to-staging.sh
@@ -109,6 +111,7 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
+      - run: go get -u github.com/orbs-network/go-junit-report
       - checkout
       - run: ./docker/build/build-docker-gamma.sh
       - run: ./.circleci/release-gamma-to-staging.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: large
     steps:
+      - go get -u github.com/orbs-network/go-junit-report
       - checkout
-      - run: ./.circleci/retry.sh 5 go get -u github.com/orbs-network/go-junit-report
       - run:
           command: ./test.sh
           no_output_timeout: 15m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,10 +128,10 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
+      - run: go get -u github.com/orbs-network/go-junit-report
       - checkout
       - run: ./.circleci/install-go.sh
       - run: ./.circleci/install-node.sh #TODO is this really needed?
-      - run: ./.circleci/retry.sh 5 go get github.com/orbs-network/go-junit-report
       - run: ./.circleci/install-docker-compose.sh
       - run: ./docker/test/import-node-staging.sh
       # Logs here belong to root
@@ -153,10 +153,10 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
+      - run: go get -u github.com/orbs-network/go-junit-report
       - checkout
       - run: ./.circleci/install-go.sh
       - run: ./.circleci/install-node.sh #TODO is this really needed?
-      - run: ./.circleci/retry.sh 5 go get github.com/orbs-network/go-junit-report
       - run: ./.circleci/install-docker-compose.sh
       - run: ./docker/test/import-gamma-staging.sh
       - run: ./docker/test/gamma-e2e.sh
@@ -170,9 +170,9 @@ jobs:
 #    machine:
 #      image: ubuntu-1604:201903-01
 #    steps:
+#      - run: go get -u github.com/orbs-network/go-junit-report
 #      - checkout
 #      - run: ./.circleci/install-go.sh
-#      - run: ./.circleci/retry.sh 5 go get github.com/orbs-network/go-junit-report
 #      - run: ./docker/test/ganache-related-test.sh
 #      - store_artifacts:
 #          path: _out

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,8 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
-      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./docker/build/build-docker-node.sh
       - run: ./.circleci/release-node-to-staging.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,6 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
-      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
       - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./.circleci/install-go.sh
@@ -157,7 +156,6 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
-      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
       - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./.circleci/install-go.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: large
     steps:
-      - go get -u github.com/orbs-network/go-junit-report
+      - run: go get -u github.com/orbs-network/go-junit-report
       - checkout
       - run:
           command: ./test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,6 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
-      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
-      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./docker/build/build-docker-node.sh
       - run: ./.circleci/release-node-to-staging.sh
 
@@ -117,9 +115,7 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
-      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
-      - run: go get -u github.com/orbs-network/go-junit-report
       - run: ./docker/build/build-docker-gamma.sh
       - run: ./.circleci/release-gamma-to-staging.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,9 @@ version: 2
 jobs:
   tests:
     docker:
-      - image: circleci/golang:1.12.9
+      - image: circleci/golang:1.15
     resource_class: large
     steps:
-      - run: go get -u
       - checkout
       - run: go get -u github.com/orbs-network/go-junit-report
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ jobs:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
+      - run: sudo apt update ; sudo apt-get install apt-transport-https ca-certificates -y ; sudo update-ca-certificates
       - checkout
       - run: ./.circleci/install-go.sh
       - run: go get -u github.com/orbs-network/go-junit-report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
 
   node_e2e:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202111-01
       docker_layer_caching: true
     steps:
       - run: sudo apt update ; sudo apt-get install apt-transport-https ca-certificates -y ; sudo update-ca-certificates

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: large
     steps:
-      - run: apt update && apt install ca-certificates libgnutls30 -y
+      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
       - checkout
       - run: go get -u github.com/orbs-network/go-junit-report
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: large
     steps:
+      - run: apt update && apt install ca-certificates libgnutls30 -y
       - checkout
       - run: go get -u github.com/orbs-network/go-junit-report
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,8 +132,8 @@ jobs:
       docker_layer_caching: true
     steps:
       - run: |
-	  sudo apt update
-          # sudo apt install --only-upgrade openssl
+          sudo apt update
+          sudo apt install --only-upgrade openssl
           sudo apt install --only-upgrade ca-certificates
       - checkout
       - run: ./.circleci/install-go.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: large
     steps:
-      - run: go get -u github.com/orbs-network/go-junit-report
       - checkout
+      - run: go get -u github.com/orbs-network/go-junit-report
       - run:
           command: ./test.sh
           no_output_timeout: 15m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: large
     steps:
-      - run: sudo apt update && sudo apt install ca-certificates libgnutls30 -y
+      - run: go get
       - checkout
       - run: go get -u github.com/orbs-network/go-junit-report
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/golang:1.12.9
     resource_class: large
     steps:
-      - run: go get
+      - run: go get -u
       - checkout
       - run: go get -u github.com/orbs-network/go-junit-report
       - run:

--- a/.circleci/nightly.sh
+++ b/.circleci/nightly.sh
@@ -2,6 +2,11 @@
 
 echo "Installing nightly dependencies.."
 ./.circleci/retry.sh 5 go get -u github.com/orbs-network/go-junit-report
+
+echo listing $GOPATH/bin:
+ls -l $GOPATH/bin
+
+echo installing nvm:
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 export NVM_DIR="/home/circleci/.nvm" && . $NVM_DIR/nvm.sh && nvm install v11.2 && nvm use v11.2
 npm install junit-xml-stats -g

--- a/.circleci/nightly.sh
+++ b/.circleci/nightly.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-echo "Installing nightly dependencies.."
-./.circleci/retry.sh 5 go get -u github.com/orbs-network/go-junit-report
-
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 export NVM_DIR="/home/circleci/.nvm" && . $NVM_DIR/nvm.sh && nvm install v11.2 && nvm use v11.2
 npm install junit-xml-stats -g

--- a/.circleci/nightly.sh
+++ b/.circleci/nightly.sh
@@ -3,10 +3,6 @@
 echo "Installing nightly dependencies.."
 ./.circleci/retry.sh 5 go get -u github.com/orbs-network/go-junit-report
 
-echo listing $GOPATH/bin:
-ls -l $GOPATH/bin
-
-echo installing nvm:
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | bash
 export NVM_DIR="/home/circleci/.nvm" && . $NVM_DIR/nvm.sh && nvm install v11.2 && nvm use v11.2
 npm install junit-xml-stats -g

--- a/docker/build/Dockerfile.build
+++ b/docker/build/Dockerfile.build
@@ -2,10 +2,7 @@ FROM golang:1.12.9
 
 WORKDIR /src
 
-RUN apt-get update
-RUN apt-get install --reinstall ca-certificates
-
-#RUN apt update && apt install ca-certificates libgnutls30 -y
+RUN apt update && apt install ca-certificates libgnutls30 -y
 
 RUN apt-get install -y git bash libc6-dev
 

--- a/docker/build/Dockerfile.build
+++ b/docker/build/Dockerfile.build
@@ -2,9 +2,7 @@ FROM golang:1.12.9
 
 WORKDIR /src
 
-# RUN apt update ; apt-get install apt-transport-https ca-certificates -y ; update-ca-certificates
 RUN apt update && apt install ca-certificates libgnutls30 -y
-
 
 RUN apt-get install -y git bash libc6-dev
 

--- a/docker/build/Dockerfile.build
+++ b/docker/build/Dockerfile.build
@@ -2,6 +2,8 @@ FROM golang:1.12.9
 
 WORKDIR /src
 
+RUN sudo apt update ; sudo apt-get install apt-transport-https ca-certificates -y ; sudo update-ca-certificates
+
 RUN apt-get install -y git bash libc6-dev
 
 ADD ./go.* /src/

--- a/docker/build/Dockerfile.build
+++ b/docker/build/Dockerfile.build
@@ -2,7 +2,7 @@ FROM golang:1.12.9
 
 WORKDIR /src
 
-RUN apt update ; sudo apt-get install apt-transport-https ca-certificates -y ; sudo update-ca-certificates
+RUN apt-get install apt-transport-https ca-certificates -y ; update-ca-certificates
 
 RUN apt-get install -y git bash libc6-dev
 

--- a/docker/build/Dockerfile.build
+++ b/docker/build/Dockerfile.build
@@ -2,7 +2,10 @@ FROM golang:1.12.9
 
 WORKDIR /src
 
-RUN apt update && apt install ca-certificates libgnutls30 -y
+RUN apt-get update
+RUN apt-get install --reinstall ca-certificates
+
+#RUN apt update && apt install ca-certificates libgnutls30 -y
 
 RUN apt-get install -y git bash libc6-dev
 

--- a/docker/build/Dockerfile.build
+++ b/docker/build/Dockerfile.build
@@ -2,7 +2,7 @@ FROM golang:1.12.9
 
 WORKDIR /src
 
-RUN apt-get install apt-transport-https ca-certificates -y ; update-ca-certificates
+RUN apt update ; apt-get install apt-transport-https ca-certificates -y ; update-ca-certificates
 
 RUN apt-get install -y git bash libc6-dev
 

--- a/docker/build/Dockerfile.build
+++ b/docker/build/Dockerfile.build
@@ -2,7 +2,9 @@ FROM golang:1.12.9
 
 WORKDIR /src
 
-RUN apt update ; apt-get install apt-transport-https ca-certificates -y ; update-ca-certificates
+# RUN apt update ; apt-get install apt-transport-https ca-certificates -y ; update-ca-certificates
+RUN apt update && apt install ca-certificates libgnutls30 -y
+
 
 RUN apt-get install -y git bash libc6-dev
 

--- a/docker/build/Dockerfile.build
+++ b/docker/build/Dockerfile.build
@@ -2,7 +2,7 @@ FROM golang:1.12.9
 
 WORKDIR /src
 
-RUN sudo apt update ; sudo apt-get install apt-transport-https ca-certificates -y ; sudo update-ca-certificates
+RUN apt update ; sudo apt-get install apt-transport-https ca-certificates -y ; sudo update-ca-certificates
 
 RUN apt-get install -y git bash libc6-dev
 

--- a/docker/build/Dockerfile.export
+++ b/docker/build/Dockerfile.export
@@ -1,5 +1,7 @@
 FROM golang:1.12.9
 
+RUN apt update && apt install ca-certificates libgnutls30 -y
+
 RUN apt-get update && apt-get install -y git daemontools
 
 ADD ./_bin/go.mod /src/_tmp/processor-artifacts/go.mod

--- a/docker/build/Dockerfile.gamma
+++ b/docker/build/Dockerfile.gamma
@@ -1,5 +1,7 @@
 FROM golang:1.12.9
 
+RUN apt update && apt install ca-certificates libgnutls30 -y
+
 RUN apt-get install -y bash git
 
 ADD ./_bin/go.mod /src/_tmp/processor-artifacts/go.mod


### PR DESCRIPTION
For a while nightly builds are failing in CI.

Address failure to compile and build due to expiration of the LetsEncrypt root certificate used by GitHub.

- Root CA authority certificate used by Github has expired recently. In all docker base images the only known cert is now expired. now installing new certificates in every dockerfile. copied solution from [here](https://stackoverflow.com/questions/69420529/app-engine-deploy-failing-with-fatal-unable-to-access-https-gopkg-in-yaml-v)

- E2E tests involving compilation outside of docker image/docker build required upgrading circleci base image to ubuntu 20 and  then upgrading 
   
Please squash when merging